### PR TITLE
Added JWT config to the serverless common yml

### DIFF
--- a/poc/random_quote/serverless.yml
+++ b/poc/random_quote/serverless.yml
@@ -31,7 +31,6 @@ provider:
       - name: quotes-backend
         url: api/quotes
     cors: ${file(../serverless.common.yml):cors}
-    jwtValidate: ${file(../serverless.common.yml):jwtValidate}
 
 plugins: # look for additional plugins in the community plugins repo: https://github.com/serverless/plugins
   - serverless-azure-functions

--- a/poc/random_quote/serverless.yml
+++ b/poc/random_quote/serverless.yml
@@ -31,6 +31,7 @@ provider:
       - name: quotes-backend
         url: api/quotes
     cors: ${file(../serverless.common.yml):cors}
+    jwtValidate: ${file(../serverless.common.yml):jwtValidate}
 
 plugins: # look for additional plugins in the community plugins repo: https://github.com/serverless/plugins
   - serverless-azure-functions

--- a/poc/serverless.common.yml
+++ b/poc/serverless.common.yml
@@ -15,6 +15,16 @@ cors:
   exposeHeaders:
     - '*'
 
+jwtValidate:
+  headerName: authorization
+  scheme: bearer
+  failedStatusCode: 401
+  failedErrorMessage: "Unauthorized. Access token is missing or invalid."
+  openId:
+    metadataUrl: "https://atatb2c.b2clogin.com/atatb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1_atat_mct_sign_in"
+  issuers:
+    - "https://atatb2c.b2clogin.com/49050e1f-32c0-4930-a8bb-65f57947c62e/v2.0/"
+
 ###########################
 ###########################
 ###########################


### PR DESCRIPTION
Added the jwtValidate to the serverless.common.yml which can be used later on when we need to have full integration with the api.

AT-6134