### PR TITLE
Integrate Cosmos DB

### DIFF
--- a/poc/shared_infrastructure/main.tf
+++ b/poc/shared_infrastructure/main.tf
@@ -80,3 +80,62 @@ module "keyvault" {
   secrets    = var.kv-secrets
   customkeys = var.kv-customkeys
 }
+
+resource "azurerm_cosmosdb_account" "da" {
+  name                      = var.cosmosdb_account_name
+  resource_group_name       = azurerm_resource_group.rg.name
+  location                  = azurerm_resource_group.rg.location
+  offer_type                = "Standard"
+  kind                      = "GlobalDocumentDB"
+  enable_automatic_failover = true
+  consistency_policy {
+    consistency_level = "Session"
+  }
+  geo_location {
+    location          = var.failover_location
+    failover_priority = 1
+  }
+  geo_location {
+    location          = azurerm_resource_group.rg.location
+    failover_priority = 0
+  }
+}
+
+resource "azurerm_cosmosdb_sql_database" "db" {
+  name                = var.cosmosdb_database_name
+  resource_group_name = data.azurerm_cosmosdb_account.da.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.da.name
+  throughput          = 400
+}
+
+resource "azurerm_cosmosdb_sql_container" "users" {
+  name                  = "users"
+  resource_group_name   = azurerm_cosmosdb_account.da.resource_group_name
+  account_name          = azurerm_cosmosdb_account.da.name
+  database_name         = azurerm_cosmosdb_sql_database.db.name
+  partition_key_path    = "/user_id"
+  partition_key_version = 1
+  throughput            = 400
+  indexing_policy {
+    indexing_mode = "Consistent"
+    included_path {
+      path = "/*"
+    }
+  }
+}
+
+resource "azurerm_cosmosdb_sql_container" "portfolios" {
+  name                  = "portfolios"
+  resource_group_name   = azurerm_cosmosdb_account.da.resource_group_name
+  account_name          = azurerm_cosmosdb_account.da.name
+  database_name         = azurerm_cosmosdb_sql_database.db.name
+  partition_key_path    = "/portfolio_id"
+  partition_key_version = 1
+  throughput            = 400
+  indexing_policy {
+    indexing_mode = "Consistent"
+    included_path {
+      path = "/*"
+    }
+  }
+}

--- a/poc/shared_infrastructure/main.tf
+++ b/poc/shared_infrastructure/main.tf
@@ -103,8 +103,8 @@ resource "azurerm_cosmosdb_account" "da" {
 
 resource "azurerm_cosmosdb_sql_database" "db" {
   name                = var.cosmosdb_database_name
-  resource_group_name = data.azurerm_cosmosdb_account.da.resource_group_name
-  account_name        = data.azurerm_cosmosdb_account.da.name
+  resource_group_name = azurerm_cosmosdb_account.da.resource_group_name
+  account_name        = azurerm_cosmosdb_account.da.name
   throughput          = 400
 }
 

--- a/poc/shared_infrastructure/variables-network.tf
+++ b/poc/shared_infrastructure/variables-network.tf
@@ -30,3 +30,21 @@ variable "storage_account_name" {
   description = "Name of the storage account"
 }
 
+#####################################
+# Azure Cosmos DB Account variables #
+#####################################
+
+variable "cosmosdb_account_name" {
+  type        = string
+  description = "Name of the Cosmos DB account"
+}
+
+variable "cosmosdb_database_name" {
+  type        = string
+  description = "Name of the Cosmos DB database"
+}
+
+variable "failover_location" {
+  type        = string
+  description = "Define the failover Azure region; Should be geographically separate from the primary location"
+}


### PR DESCRIPTION
Replaces #9 since #6 was merged to `develop`.

Added these to the terraform configuration:

- resource of type `azurerm_cosmosdb_account`
- resource of type `azurerm_cosmosdb_sql_database` likely named _atat_
- resource of type `azurerm_cosmosdb_sql_container` named _users_
- resource of type `azurerm_cosmosdb_sql_container` named _portfolios_

Expects the following variables to be provided:

- `cosmosdb_account_name`
- `cosmosdb_database_name`
- `failover_location`

Ticket: AT-6315