### PR TITLE
Refactor resource names

### DIFF
--- a/poc/shared_infrastructure/main.tf
+++ b/poc/shared_infrastructure/main.tf
@@ -29,7 +29,7 @@ resource "azurerm_resource_group" "rg" {
 }
 
 resource "azurerm_storage_account" "sa" {
-  name                     = var.storage_account_name
+  name                     = "${var.environment}-storage"
   resource_group_name      = azurerm_resource_group.rg.name
   location                 = azurerm_resource_group.rg.location
   account_tier             = "Standard"
@@ -82,7 +82,7 @@ module "keyvault" {
 }
 
 resource "azurerm_cosmosdb_account" "da" {
-  name                      = var.cosmosdb_account_name
+  name                     = "${var.environment}-database"
   resource_group_name       = azurerm_resource_group.rg.name
   location                  = azurerm_resource_group.rg.location
   offer_type                = "Standard"
@@ -102,7 +102,7 @@ resource "azurerm_cosmosdb_account" "da" {
 }
 
 resource "azurerm_cosmosdb_sql_database" "db" {
-  name                = var.cosmosdb_database_name
+  name                = "atat"
   resource_group_name = azurerm_cosmosdb_account.da.resource_group_name
   account_name        = azurerm_cosmosdb_account.da.name
   throughput          = 400
@@ -141,7 +141,7 @@ resource "azurerm_cosmosdb_sql_container" "portfolios" {
 }
 
 resource "azurerm_servicebus_namespace" "service_bus" {
-  name                = "${var.environment}-service-bus"
+  name                = "${var.environment}-servicebus"
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
   sku                 = "Standard"

--- a/poc/shared_infrastructure/terraform.tfvars.template
+++ b/poc/shared_infrastructure/terraform.tfvars.template
@@ -2,7 +2,6 @@
 # Common Variables #
 ####################
 resource_group_name  = ""
-storage_account_name = ""
 location             = "eastus"  # Virginia
 failover_location    = "westcentralus"  # Wyoming
 environment          = ""
@@ -33,9 +32,3 @@ kv-customkeys = {
     keysize = "2048"
   }
 }
-
-############
-# Database #
-############
-cosmosdb_account_name = ""
-cosmosdb_database_name = ""

--- a/poc/shared_infrastructure/variables-network.tf
+++ b/poc/shared_infrastructure/variables-network.tf
@@ -21,29 +21,6 @@ variable "location" {
   description = "Define the region the in which resource group will be created"
 }
 
-###################################
-# Azure Storage Account variables #
-###################################
-
-variable "storage_account_name" {
-  type        = string
-  description = "Name of the storage account"
-}
-
-#####################################
-# Azure Cosmos DB Account variables #
-#####################################
-
-variable "cosmosdb_account_name" {
-  type        = string
-  description = "Name of the Cosmos DB account"
-}
-
-variable "cosmosdb_database_name" {
-  type        = string
-  description = "Name of the Cosmos DB database"
-}
-
 variable "failover_location" {
   type        = string
   description = "Define the failover Azure region; Should be geographically separate from the primary location"


### PR DESCRIPTION
Refactor resource names for consistency and treat them similarly.  Eliminates unnecessary tfvars.
- `<environment>-keyvault`
- `<environment>-storage`
- `<environment>-database`
- `<environment>-servicebus`