### PR TITLE
Add JSON linting support

### DIFF
--- a/poc/random_quote/.eslintrc.json
+++ b/poc/random_quote/.eslintrc.json
@@ -7,7 +7,8 @@
   },
   "extends": [
     "standard",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended",
+    "plugin:json/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/poc/random_quote/.eslintrc.json
+++ b/poc/random_quote/.eslintrc.json
@@ -18,7 +18,7 @@
   "plugins": [
     "@typescript-eslint"
   ],
-  "ignorePatterns": ["**/*.js"],
+  "ignorePatterns": ["**/*.js", "coverage/**"],
   "rules": {
     "no-console": "warn"
   },

--- a/poc/random_quote/package-lock.json
+++ b/poc/random_quote/package-lock.json
@@ -17,6 +17,7 @@
         "eslint": "^7.30.0",
         "eslint-config-standard": "^16.0.3",
         "eslint-plugin-import": "^2.23.4",
+        "eslint-plugin-json": "^3.0.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^5.1.0",
         "fork-ts-checker-webpack-plugin": "^6.2.12",
@@ -5387,6 +5388,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/eslint-plugin-json": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-3.0.0.tgz",
+      "integrity": "sha512-7qoY5pbzBLEttJWy4/cDtULK3EKglgIwfXk5Yqp3StJaQ4Bu4Jmp0n2fJN5vBe/hLGaECupq3edn1j/k7O0bFA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "vscode-json-languageservice": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/eslint-plugin-node": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
@@ -8152,6 +8166,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -12665,6 +12685,46 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.6.tgz",
+      "integrity": "sha512-DIKb3tcfRtb3tIE6g9SLOl5E9tNSt6kljH08Wa5RwFlVshtXGrDDzttchze4CYy9pJpE9mBtCbRHmLvY1Z1ZXA==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+      "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==",
+      "dev": true
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
+      "dev": true
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
+      "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==",
+      "dev": true
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
+      "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==",
+      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -18183,6 +18243,16 @@
         }
       }
     },
+    "eslint-plugin-json": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-3.0.0.tgz",
+      "integrity": "sha512-7qoY5pbzBLEttJWy4/cDtULK3EKglgIwfXk5Yqp3StJaQ4Bu4Jmp0n2fJN5vBe/hLGaECupq3edn1j/k7O0bFA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "vscode-json-languageservice": "^4.0.2"
+      }
+    },
     "eslint-plugin-node": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
@@ -20198,6 +20268,12 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -23820,6 +23896,43 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true,
       "optional": true
+    },
+    "vscode-json-languageservice": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.6.tgz",
+      "integrity": "sha512-DIKb3tcfRtb3tIE6g9SLOl5E9tNSt6kljH08Wa5RwFlVshtXGrDDzttchze4CYy9pJpE9mBtCbRHmLvY1Z1ZXA==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      }
+    },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+      "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==",
+      "dev": true
+    },
+    "vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
+      "dev": true
+    },
+    "vscode-nls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
+      "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==",
+      "dev": true
+    },
+    "vscode-uri": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
+      "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/poc/random_quote/package.json
+++ b/poc/random_quote/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "test": "jest --verbose --no-watchman",
     "start": "func host start",
-    "lint": "eslint --ext .js,.ts .",
-    "lint:fix": "eslint --ext .js,.ts --fix ."
+    "lint": "eslint --ext .js,.ts,.json .",
+    "lint:fix": "eslint --ext .js,.ts,.json --fix ."
   },
   "keywords": [
     "azure",
@@ -22,6 +22,7 @@
     "eslint": "^7.30.0",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-json": "^3.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "fork-ts-checker-webpack-plugin": "^6.2.12",


### PR DESCRIPTION
This should resolve scenarios where we are seeing linter differences
between local and the CI pipeline (because the CI pipeline is correctly
linting JSON files whereas the npm setup is not).

Eventually we need to converge on having a shared .eslintrc.json file
for all of our functions (as much as possible) and possibly using a tool
like lerna to manage the various projects that we have in the repo;
however, for now here are the steps to follow to get _other_ projects in
sync with this PoC app config:

1. Install the `eslint-plugin-json` package as a dev dependency
```
npm install --save-dev eslint-plugin-json
```

2. Add `"plugin:json/recommended"` to the `extends` section of
`.eslintrc.json`

3. Update `package.json` to have `,.json` in the `lint` and `lint:fix`
commands.