### PR TITLE
Improve README organization and content update

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,18 +131,24 @@ Serverless: -> get: [GET] atat-sls-poc-js-eus-dev-atat-js-fallback-jts.azurewebs
 Serverless: -> post: [POST] atat-sls-poc-js-eus-dev-atat-js-fallback-jts.azurewebsites.net/api/post
 ```
 
-#### Manual Post-deployment Step
-NOTE: The Function App created by Serverless Framework needs access to the Key Vault created by Terraform. 
-Unfortunately this creates the need for a third step in our process. It must be performed manually, but will be 
-automated in the future.
 
-* Log into the Azure Portal
-* Navigate to the Key Vault created by your Terraform earlier
-* Using the Access Policies screens, provide the Function App created by Serverless Framework with access to the 
-Key Vault such that it can read secrets
-* Navigate to your Function App and select Configuration
-* Look under Application Settings for COSMOS-CONNECTION-STRING and ensure that the Source column has a green check mark
-before `Key vault Reference`
+#### Grant Function App access to read Key Vault secrets
+The newly created Function App needs permission to access the Key Vault in the shared infrastructure such that it can read secrets in that vault. This step must be performed manually, but will be automated in the future.
+1. Log in to Azure Portal
+2. Navigate to the Key Vault in the shared infrastructure
+3. Select _Access policies_ under the _Settings_ heading in the resource menu on the left
+4. Click _Add Access Policy_
+5. On the _Add access policy_ screen, select _Get_ from the _Secret permissions_ drop-down
+6. On the same screen, select a principal by supplying the name of the Function App
+7. Click Add.  This will close the _Add access policy_ screen.
+8. **Click Save**
+
+Now verify that the Function App can access the required secret.
+
+1. Navigate to the newly created Function App
+2. Select _Configuration_ under the _Settings_ heading in the resource menu on the left
+3. Under _Application settings_ look for `COSMOS-CONNECTION-STRING` and **ensure that the _Source_ column contains a green check mark** before _Key vault Reference_
+4. Click on _Refresh_ in the commands bar at the top if necessary
 
 #### Remove
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ These software packages are required.
 | Azure CLI | n/a | Follow steps at [Install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) at microsoft.com |
 | Terraform | n/a | Follow steps at [Install Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/azure-get-started) at hashicorp.com |
 
-### Deploy Shared Infrastructure
+### Deploy Shared Infrastructure with Terraform
 ---
-This monorepo currently contains a single Application (ATAT Portfolio Drafts API), but may eventually contain multiple Applications which all share some common infrastructure pieces. The following instructions describe their deployment:
+This monorepo currently contains a single Application (ATAT Portfolio Drafts API), but may eventually contain multiple Applications which all share some common infrastructure pieces. The following instructions describe their deployment.
+
 [Terraform](https://www.terraform.io/) will be used to deploy shared infrastructure in Microsoft Azure.
 Examples of such shared resources:
 * Key Vault

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following steps describe the process for installing and deploying the ATAT P
   ```
 * Azure CLI\
   Follow steps at [Install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) at microsoft.com
----
+
 ### Deploying
 #### Install npm dependencies
 ```
@@ -35,7 +35,7 @@ cd ./poc/random_quote
 npm ci
 ```
 
----
+
 
 #### Login to Azure and set subscription
 ```
@@ -102,7 +102,7 @@ terraform destroy
 
 Follow steps at [Creating a Service Principal](https://www.serverless.com/framework/docs/providers/azure/guide/quick-start#creating-a-service-principal) at serverless.com
 
----
+
 
 
 #### Deploy app (and repeat as needed iteratively)
@@ -153,7 +153,7 @@ sls remove --stage <your-stage-name> --region 'East US'
 
 This should delete and remove all provisioned resources created by the deploy command.
 
----
+
 
 ### Running tests
 
@@ -161,7 +161,7 @@ This should delete and remove all provisioned resources created by the deploy co
 npm test
 ```
 
----
+
 ### Lint
 
 To run the lint scripts to format and validate the typescript files, use the command:
@@ -196,7 +196,7 @@ the following settings should be auto applied. If not, you can create it by addi
 }
 ```
 
----
+
 
 ### Troubleshooting
 #### Deploying Hanging

--- a/README.md
+++ b/README.md
@@ -28,14 +28,11 @@ Examples of such shared resources:
 * Cosmos DB Account and Database 
 * Azure Service Bus
 
-The following is a list of `main.tf` files and their locations which can be used with Terraform to deploy Shared Infrastructure:
-* `./provisioning/shared_infrastructure/main.tf`
-
 #### Prerequisites
-1. Navigate to a directory containing a `main.tf` file.
-2. Prepare a file `terraform.tfvars` from file `terraform.tfvars.template` in the same directory (if available)
-3. Ensure you are logged in to Azure with `az login`
-4. Set your desired subscription with `az account set -s <subscription-id>`.  You can view the selected subscription with `az account show` 
+1. Navigate with `cd ./provisioning/shared_infrastructure`.  This directory contains a `main.tf` file which can be used with Terraform to deploy shared infrastructure.
+3. Prepare a file `terraform.tfvars` from file `terraform.tfvars.template` in the same directory (if available)
+4. Ensure you are logged in to Azure with `az login`
+5. Set your desired subscription with `az account set -s <subscription-id>`.  You can view the selected subscription with `az account show` 
 
 #### Terraform Steps
 
@@ -88,14 +85,11 @@ terraform destroy
 ---
 [Serverless Framework](https://www.serverless.com/) will be used to deploy Azure Function Apps.
 
-The following is a list of `serverless.yml` files and their locations which can be used with Serverless Framework to deploy Function Apps:
-* `./provisioning/serverless.yml`
-
 #### Prerequisites
-1. Navigate to a directory containing a `serverless.yml` file.
-2. This directory also contains a `package.json` file. Install JavaScript dependencies with `npm ci`
-3. Ensure you are logged in to Azure with `az login`
-4. Set your desired subscription with `az account set -s <subscription-id>`.  You can view the selected subscription with `az account show`
+1. Navigate with `cd ./provisioning`.  This directory contains a `serverless.yml` file which can be used with Serverless Framework to deploy Function Apps.
+3. This directory also contains a `package.json` file. Install JavaScript dependencies with `npm ci`
+4. Ensure you are logged in to Azure with `az login`
+5. Set your desired subscription with `az account set -s <subscription-id>`.  You can view the selected subscription with `az account show`
 
 #### Create a Service Principal
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To destroy the deployed shared infrastructure run:
 terraform destroy
 ```
 
-### Deploy Azure Function Apps
+### Deploy ATAT Portolio Drafts API with Serverless Framework
 ---
 [Serverless Framework](https://www.serverless.com/) will be used to deploy Azure Function Apps.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ These software packages are required.
 
 ### Deploy Shared Infrastructure
 ---
+This monorepo currently contains a single Application (ATAT Portfolio Drafts API), but may eventually contain multiple Applications which all share some common infrastructure pieces. The following instructions describe their deployment:
 [Terraform](https://www.terraform.io/) will be used to deploy shared infrastructure in Microsoft Azure.
 Examples of such shared resources:
 * Key Vault

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These software packages are required.
 
 | Package | Command | Notes |
 | ----------- | ----------- |----------- |
-| Node Version Manager | `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash` | Then restart your shell. Details available in the [nvm README](https://github.com/nvm-sh/nvm#installing-and-updating). |
+| Node Version Manager | `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh \| bash` | Then restart your shell. Details available in the [nvm README](https://github.com/nvm-sh/nvm#installing-and-updating). |
 | Node.js | `nvm install` | Node.js version is specified in file `./.nvmrc` |
 | Serverless Framework | `npm install -g serverless` | n/a |
 | TypeScript | `npm install -g typescript` | n/a |

--- a/README.md
+++ b/README.md
@@ -25,11 +25,10 @@ Examples of such shared resources:
 * Key Vault
 * Storage Account
 * Cosmos DB Account and Database 
-* Enterprise Service Bus
+* Azure Service Bus
 
 The following is a list of `main.tf` files and their locations which can be used with Terraform to deploy Shared Infrastructure:
 * `./provisioning/shared_infrastructure/main.tf`
-* `./poc/shared_infrastructure/main.tf`
 
 #### Prerequisites
 1. Navigate to a directory containing a `main.tf` file.
@@ -85,7 +84,6 @@ terraform destroy
 
 The following is a list of `serverless.yml` files and their locations which can be used with Serverless Framework to deploy Function Apps:
 * `./provisioning/serverless.yml`
-* `./poc/random_quote/serverless.yml`
 
 #### Prerequisites
 1. Navigate to a directory containing a `serverless.yml` file.

--- a/README.md
+++ b/README.md
@@ -47,9 +47,14 @@ terraform init -backend-config=resource_group_name=$AZURE_STORAGE_RESOURCE_GROUP
 
 ##### Select a workspace
 
-Select the desired workspace.
 Terraform state is stored by default in a file named _terraform.tfstate_.  In this case it is stored remotely inside the storage container on Azure.
 
+Optionally, create a new terraform workspace.
+```
+terraform workspace new <your-workspace-name>
+```
+
+Select the desired workspace.
 ```
 terraform workspace select <your-workspace-name>
 ```

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ sls remove --stage <your-stage-name> --region 'East US'
 
 #### Running unit tests
 
-Execute all [Jest](TODO) tests.
+Execute all [Jest](https://jestjs.io/) tests.
 ```
 npm test
 ```


### PR DESCRIPTION
Major re-organization under these headers:

- Install Prerequisites
- Deploy Shared Infrastructure
- Deploy Azure Function Apps
- Support Information

Made _Deploy..._ sections generic to include `./poc` and newer `./provisioning`