### PR TITLE
Implement 'GET /portfolioDrafts'

### DIFF
--- a/packages/provisioning/serverless.yml
+++ b/packages/provisioning/serverless.yml
@@ -46,6 +46,22 @@ package:
     - '!**/*.test.js'
 
 functions:
+  get:
+    handler: src/handlers/portfolioDrafts/get.handler
+    apim:
+      api: portfolio-drafts-api
+      backend: portfolio-drafts-backend
+      operations:
+        - method: get
+          urlTemplate: /
+          displayName: GetPortfolioDrafts
+    events:
+      - http: true
+        x-azure-settings:
+          route: portfolioDrafts
+          methods:
+            - GET
+          authLevel: anonymous
   post:
     handler: src/handlers/portfolioDrafts/post.handler
     apim:

--- a/packages/provisioning/serverless.yml
+++ b/packages/provisioning/serverless.yml
@@ -46,7 +46,7 @@ package:
     - '!**/*.test.js'
 
 functions:
-  get:
+  getPortfolioDrafts:
     handler: src/handlers/portfolioDrafts/get.handler
     apim:
       api: portfolio-drafts-api
@@ -54,7 +54,7 @@ functions:
       operations:
         - method: get
           urlTemplate: /
-          displayName: GetPortfolioDrafts
+          displayName: getPortfolioDrafts
     events:
       - http: true
         x-azure-settings:

--- a/packages/provisioning/src/handlers/portfolioDrafts/get.ts
+++ b/packages/provisioning/src/handlers/portfolioDrafts/get.ts
@@ -1,0 +1,18 @@
+import { Context } from '@azure/functions'
+import { CosmosClient } from '@azure/cosmos'
+
+export async function handler (context: Context): Promise<void> {
+  const connectionString = process.env['COSMOS-CONNECTION-STRING']
+  context.log('Connecting to ' + connectionString)
+  const client = new CosmosClient(connectionString)
+
+  // TODO: create these in terraform & fail fast
+  const { database } = await client.databases.createIfNotExists({ id: 'atat' })
+  const { container } = await database.containers.createIfNotExists({ id: 'portfolios' })
+
+  // TODO: add a modicum of error handling
+  const results = await container.items.readAll().fetchAll()
+  context.res = {
+    body: results
+  }
+}


### PR DESCRIPTION
Adds the capability to retrieve a collection of portfolio drafts.
Implements `GET /portfolioDrafts`
Replaces #27

Ticket: AT-6362