### PR TITLE
add .nvmrc and specify node 14

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/fermium

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/fermium
+v14


### PR DESCRIPTION
Allows `nvm install` and `nvm use` without params

- same version as `atat-web-ui` repo
- [AWS Lambda supports Node.js 14](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)