### PR TITLE
Implement 'createPorfolioStep' function

### DIFF
--- a/applications/portfolioDrafts/models/PortfolioStep.ts
+++ b/applications/portfolioDrafts/models/PortfolioStep.ts
@@ -1,4 +1,3 @@
-import { AttributeValue } from "@aws-sdk/client-dynamodb";
 export interface PortfolioStep {
   name: string;
   description: string;

--- a/applications/portfolioDrafts/models/PortfolioStep.ts
+++ b/applications/portfolioDrafts/models/PortfolioStep.ts
@@ -1,3 +1,4 @@
+import { AttributeValue } from "@aws-sdk/client-dynamodb";
 export interface PortfolioStep {
   name: string;
   description: string;

--- a/applications/portfolioDrafts/portfolio/createPortfolioStep.ts
+++ b/applications/portfolioDrafts/portfolio/createPortfolioStep.ts
@@ -8,7 +8,7 @@ import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode }
 const TABLE_NAME = process.env.ATAT_TABLE_NAME;
 
 /**
- * Handles requests from the API Gateway.
+ * Submits the Portfolio Step of the Portfolio Draft Wizard
  *
  * @param event - The POST request from API Gateway
  */

--- a/applications/portfolioDrafts/portfolio/createPortfolioStep.ts
+++ b/applications/portfolioDrafts/portfolio/createPortfolioStep.ts
@@ -6,8 +6,6 @@ import { PortfolioStepResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCod
 import { ErrorCodes } from "../models/Error";
 
 const TABLE_NAME = process.env.ATAT_TABLE_NAME;
-const InvalidBody = { code: "INVALID_INPUT", message: "HTTP request body must not be empty" };
-const DatabaseError = { code: "OTHER", message: "Internal database error" };
 
 /**
  * Handles requests from the API Gateway.
@@ -50,12 +48,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     await client.send(command);
   } catch (err) {
     console.log("Database error: " + err);
-    // return { statusCode: 500, body: JSON.stringify(DatabaseError) };
     return new ErrorResponse(
       { code: ErrorCodes.OTHER, message: "Database error" },
       ErrorStatusCode.INTERNAL_SERVER_ERROR
     );
   }
-  // return { statusCode: 201, body: JSON.stringify(pf) };
   return new PortfolioStepResponse(portfolioStep, SuccessStatusCode.CREATED);
 };

--- a/applications/portfolioDrafts/portfolio/post.ts
+++ b/applications/portfolioDrafts/portfolio/post.ts
@@ -17,21 +17,33 @@ const CLIENT = dynamodbClient;
  * @param event - The POST request from API Gateway
  */
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  if (!event.body) {
+    return { statusCode: 400, body: "" };
+  }
   /*
     if (event.body && !JSON.parse(event.body)) {
     return { statusCode: 400, body: "Request body must be empty" };
   }
 */
-  const portfolioId = event.pathParameters?.portfolioId;
+  const portfolioId = event.pathParameters?.portfolioDraftId;
+  /*
   if (!portfolioId) {
     return { statusCode: 400, body: "invalid request, you are missing the path parameter id:" };
   }
-  let requestJSON = "";
-  // requestJSON = JSON.parse(event.body);
+  */
+
+  const requestBody = JSON.parse(event.body);
+  const pf: PortfolioStep = {
+    name: requestBody.name,
+    description: requestBody.description,
+    dod_components: requestBody.dod_components,
+    portfolio_managers: requestBody,
+  };
+
   const now = new Date().toISOString();
 
   const pf: PortfolioStep = {
-    name: "bob",
+    name: requestBody.name,
     description: "bob's app",
     dod_components: ["air_force", "army", "marine_corps", "navy", "space_force"],
     portfolio_managers: ["joe.manager@example.com", "jane.manager@example.com"],
@@ -49,6 +61,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     Key: {
       portfolioId,
     },
+    UpdateExpression: "set portfolioStep = portfolioStep",
     ExpressionAttributeValues: {
       portfolioStep: pf,
     },

--- a/applications/portfolioDrafts/portfolio/post.ts
+++ b/applications/portfolioDrafts/portfolio/post.ts
@@ -20,50 +20,35 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   if (!event.body) {
     return { statusCode: 400, body: "" };
   }
-  /*
-    if (event.body && !JSON.parse(event.body)) {
-    return { statusCode: 400, body: "Request body must be empty" };
-  }
-*/
+
   const portfolioId = event.pathParameters?.portfolioDraftId;
-  /*
+
   if (!portfolioId) {
     return { statusCode: 400, body: "invalid request, you are missing the path parameter id:" };
   }
-  */
 
   const requestBody = JSON.parse(event.body);
   const pf: PortfolioStep = {
     name: requestBody.name,
     description: requestBody.description,
     dod_components: requestBody.dod_components,
-    portfolio_managers: requestBody,
+    portfolio_managers: requestBody.portfolio_managers,
   };
 
   const now = new Date().toISOString();
 
-  const pf: PortfolioStep = {
-    name: requestBody.name,
-    description: "bob's app",
-    dod_components: ["air_force", "army", "marine_corps", "navy", "space_force"],
-    portfolio_managers: ["joe.manager@example.com", "jane.manager@example.com"],
-  };
-
   console.log(pf);
-
-  const putCommand = new PutCommand({
-    TableName: TABLE_NAME,
-    Item: pf,
-  });
-
   const updateCommand = new UpdateCommand({
     TableName: TABLE_NAME,
     Key: {
-      portfolioId,
+      id: portfolioId,
     },
-    UpdateExpression: "set portfolioStep = portfolioStep",
+    UpdateExpression: "set #portfolioVariable = :x",
+    ExpressionAttributeNames: {
+      "#portfolioVariable": "portfolioStep",
+    },
     ExpressionAttributeValues: {
-      portfolioStep: pf,
+      ":x": pf,
     },
   });
 

--- a/applications/portfolioDrafts/portfolio/post.ts
+++ b/applications/portfolioDrafts/portfolio/post.ts
@@ -27,7 +27,6 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     portfolio_managers: requestBody.portfolio_managers,
   };
 
-  console.log(pf);
   const command = new UpdateCommand({
     TableName: TABLE_NAME,
     Key: {

--- a/applications/portfolioDrafts/portfolio/post.ts
+++ b/applications/portfolioDrafts/portfolio/post.ts
@@ -28,7 +28,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   };
 
   console.log(pf);
-  const updateCommand = new UpdateCommand({
+  const command = new UpdateCommand({
     TableName: TABLE_NAME,
     Key: {
       id: portfolioId,
@@ -43,7 +43,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   });
 
   try {
-    await client.send(updateCommand);
+    await client.send(command);
   } catch (err) {
     console.log(err);
     return { statusCode: 500, body: JSON.stringify(DatabaseError) };

--- a/applications/portfolioDrafts/portfolio/post.ts
+++ b/applications/portfolioDrafts/portfolio/post.ts
@@ -4,7 +4,7 @@ import { PortfolioStep } from ".././models/PortfolioStep";
 import { dynamodbClient as client } from ".././utils/dynamodb";
 
 const TABLE_NAME = process.env.ATAT_TABLE_NAME;
-const InvalidBody = { code: "INVALID_INPUT", message: "A valid request body must be specified" };
+const InvalidBody = { code: "INVALID_INPUT", message: "HTTP request body must not be empty" };
 const DatabaseError = { code: "OTHER", message: "Internal database error" };
 
 /**

--- a/applications/portfolioDrafts/portfolio/post.ts
+++ b/applications/portfolioDrafts/portfolio/post.ts
@@ -1,0 +1,44 @@
+import { PutCommand } from "@aws-sdk/lib-dynamodb";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { v4 as uuid } from "uuid";
+import { PortfolioSummary } from ".././models/PortfolioSummary";
+import { ProvisioningStatus } from ".././models/ProvisioningStatus";
+import { dynamodbClient } from ".././utils/dynamodb";
+
+const TABLE_NAME = process.env.ATAT_TABLE_NAME;
+// const PRIMARY_KEY = process.env.PRIMARY_KEY || "";
+// TODO: Just use "dynamoDbClient"
+const CLIENT = dynamodbClient;
+
+/**
+ * Handles requests from the API Gateway.
+ *
+ * @param event - The POST request from API Gateway
+ */
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  if (event.body && !JSON.parse(event.body)) {
+    return { statusCode: 400, body: "Request body must be empty" };
+  }
+  const now = new Date().toISOString();
+  const pf: PortfolioSummary = {
+    id: uuid(),
+    created_at: now,
+    updated_at: now,
+    status: ProvisioningStatus.NotStarted,
+  };
+
+  console.log(pf);
+
+  const putCommand = new PutCommand({
+    TableName: TABLE_NAME,
+    Item: pf,
+  });
+
+  try {
+    await CLIENT.send(putCommand);
+  } catch (err) {
+    console.log(err);
+    return { statusCode: 500, body: "database error" };
+  }
+  return { statusCode: 201, body: JSON.stringify(pf) };
+};

--- a/applications/portfolioDrafts/portfolio/post.ts
+++ b/applications/portfolioDrafts/portfolio/post.ts
@@ -1,14 +1,9 @@
-import { PutCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { v4 as uuid } from "uuid";
-import { PortfolioSummary } from ".././models/PortfolioSummary";
-import { ProvisioningStatus } from ".././models/ProvisioningStatus";
 import { PortfolioStep } from ".././models/PortfolioStep";
 import { dynamodbClient } from ".././utils/dynamodb";
 
 const TABLE_NAME = process.env.ATAT_TABLE_NAME;
-// const PRIMARY_KEY = process.env.PRIMARY_KEY || "";
-// TODO: Just use "dynamoDbClient"
 const CLIENT = dynamodbClient;
 
 /**
@@ -34,8 +29,6 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     dod_components: requestBody.dod_components,
     portfolio_managers: requestBody.portfolio_managers,
   };
-
-  const now = new Date().toISOString();
 
   console.log(pf);
   const updateCommand = new UpdateCommand({

--- a/applications/portfolioDrafts/portfolio/post.ts
+++ b/applications/portfolioDrafts/portfolio/post.ts
@@ -49,7 +49,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     await CLIENT.send(updateCommand);
   } catch (err) {
     console.log(err);
-    return { statusCode: 500, body: "database error" };
+    return { statusCode: 500, body: "Database error" };
   }
   return { statusCode: 201, body: JSON.stringify(pf) };
 };

--- a/applications/portfolioDrafts/utils/response.ts
+++ b/applications/portfolioDrafts/utils/response.ts
@@ -1,5 +1,6 @@
 import { APIGatewayProxyResult } from "aws-lambda";
 import { BaseDocument } from "../models/BaseDocument";
+import { PortfolioStep } from "../models/PortfolioStep";
 import { Error } from "../models/Error";
 
 type Headers = { [header: string]: string | number | boolean } | undefined;
@@ -114,6 +115,25 @@ export class DocumentResponse extends SuccessResponse {
    */
   constructor(
     response: BaseDocument,
+    statusCode: SuccessStatusCode = SuccessStatusCode.OK,
+    headers?: Headers,
+    multiValueHeaders?: MultiValueHeaders
+  ) {
+    super(JSON.stringify(response), statusCode, headers, multiValueHeaders);
+  }
+}
+
+export class PortfolioStepResponse extends SuccessResponse {
+  /**
+   * Create a document response for an API request.
+   *
+   * @param response - The instance of the model to include in the response
+   * @param statusCode - The HTTP success status code for the response
+   * @param headers - HTTP response headers
+   * @param multiValueHeaders - HTTP response headers, allowing multiple values for a header
+   */
+  constructor(
+    response: PortfolioStep,
     statusCode: SuccessStatusCode = SuccessStatusCode.OK,
     headers?: Headers,
     multiValueHeaders?: MultiValueHeaders

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -76,10 +76,8 @@ export class AtatWebApiStack extends cdk.Stack {
     // We definitely want to improve the ergonomics of this and doing so is a high priority; however, following
     // these examples and steps should be a good start to allow progress while that work is happening.
     const portfolioDrafts = restApi.root.addResource("portfolioDrafts");
-
-    const portfolioId = portfolioDrafts.addResource("{portfolioId}");
-
-    const portfolio = portfolioId.addResource("portfolio");
+    const portfolioDraftId = portfolioDrafts.addResource("{portfolioDraftId}");
+    const portfolio = portfolioDraftId.addResource("portfolio");
 
     const getPortfolioDraftsFn = new lambdaNodejs.NodejsFunction(this, "PortfolioDraftsGetFunction", {
       entry: "applications/portfolioDrafts/index.ts",

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -108,7 +108,6 @@ export class AtatWebApiStack extends cdk.Stack {
     // operationId: getPortfolioDraft
     // operationId: deletePortfolioDraft
     // operationId: getPortfolioStep
-    // operationId: createPortfolioStep
     // operationId: getFundingStep
     // operationId: createFundingStep
     // operationId: getApplicationStep

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -77,6 +77,10 @@ export class AtatWebApiStack extends cdk.Stack {
     // these examples and steps should be a good start to allow progress while that work is happening.
     const portfolioDrafts = restApi.root.addResource("portfolioDrafts");
 
+    const portfolioId = portfolioDrafts.addResource("{portfolioId}");
+
+    const portfolio = portfolioId.addResource("portfolio");
+
     const getPortfolioDraftsFn = new lambdaNodejs.NodejsFunction(this, "PortfolioDraftsGetFunction", {
       entry: "applications/portfolioDrafts/index.ts",
       ...sharedFunctionProps,
@@ -92,6 +96,18 @@ export class AtatWebApiStack extends cdk.Stack {
     });
     portfolioDrafts.addMethod("POST", new apigw.LambdaIntegration(createPortfolioDraftFn));
     table.grantReadWriteData(createPortfolioDraftFn);
+
+    // createPortfolioStep
+    const createPortfolioStepFn = new lambdaNodejs.NodejsFunction(this, "CreatePortfolioSteptFunction", {
+      entry: "applications/portfolioDrafts/portfolio/post.ts",
+      ...sharedFunctionProps,
+    });
+    portfolio.addMethod("POST", new apigw.LambdaIntegration(createPortfolioStepFn));
+
+    // Allow the POST function to read and write (since that will be necessary to add the
+    // new quotes)
+
+    table.grantReadWriteData(createPortfolioStepFn);
 
     // -- operationIds from API spec ---
     // operationId: getPortfolioDrafts

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -87,7 +87,7 @@ export class AtatWebApiStack extends cdk.Stack {
     // Prevent the GET function from being able to write to DynamoDB (it doesn't need to)
     table.grantReadData(getPortfolioDraftsFn);
 
-    // operationId: createPortfolioDraft
+    // createPortfolioDraft
     const createPortfolioDraftFn = new lambdaNodejs.NodejsFunction(this, "createPortfolioDraft", {
       entry: "applications/portfolioDrafts/createPortfolioDraft.ts",
       ...sharedFunctionProps,

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -87,16 +87,6 @@ export class AtatWebApiStack extends cdk.Stack {
     // Prevent the GET function from being able to write to DynamoDB (it doesn't need to)
     table.grantReadData(getPortfolioDraftsFn);
 
-<<<<<<< HEAD
-=======
-    // operationId: createPortfolioStep
-    const createPortfolioStepFn = new lambdaNodejs.NodejsFunction(this, "CreatePortfolioSteptFunction", {
-      entry: "applications/portfolioDrafts/portfolio/post.ts",
-      ...sharedFunctionProps,
-    });
-    portfolio.addMethod("POST", new apigw.LambdaIntegration(createPortfolioStepFn));
-    table.grantReadWriteData(createPortfolioStepFn);
->>>>>>> Add comment to match existing format in atat-web-api-stack.ts, response to PR review
     // operationId: createPortfolioDraft
     const createPortfolioDraftFn = new lambdaNodejs.NodejsFunction(this, "createPortfolioDraft", {
       entry: "applications/portfolioDrafts/createPortfolioDraft.ts",
@@ -106,8 +96,8 @@ export class AtatWebApiStack extends cdk.Stack {
     table.grantReadWriteData(createPortfolioDraftFn);
 
     // createPortfolioStep
-    const createPortfolioStepFn = new lambdaNodejs.NodejsFunction(this, "CreatePortfolioSteptFunction", {
-      entry: "applications/portfolioDrafts/portfolio/post.ts",
+    const createPortfolioStepFn = new lambdaNodejs.NodejsFunction(this, "CreatePortfolioStepFunction", {
+      entry: "applications/portfolioDrafts/portfolio/createPortfolioStep.ts",
       ...sharedFunctionProps,
     });
     portfolio.addMethod("POST", new apigw.LambdaIntegration(createPortfolioStepFn));

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -87,6 +87,16 @@ export class AtatWebApiStack extends cdk.Stack {
     // Prevent the GET function from being able to write to DynamoDB (it doesn't need to)
     table.grantReadData(getPortfolioDraftsFn);
 
+<<<<<<< HEAD
+=======
+    // operationId: createPortfolioStep
+    const createPortfolioStepFn = new lambdaNodejs.NodejsFunction(this, "CreatePortfolioSteptFunction", {
+      entry: "applications/portfolioDrafts/portfolio/post.ts",
+      ...sharedFunctionProps,
+    });
+    portfolio.addMethod("POST", new apigw.LambdaIntegration(createPortfolioStepFn));
+    table.grantReadWriteData(createPortfolioStepFn);
+>>>>>>> Add comment to match existing format in atat-web-api-stack.ts, response to PR review
     // operationId: createPortfolioDraft
     const createPortfolioDraftFn = new lambdaNodejs.NodejsFunction(this, "createPortfolioDraft", {
       entry: "applications/portfolioDrafts/createPortfolioDraft.ts",

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -101,10 +101,6 @@ export class AtatWebApiStack extends cdk.Stack {
       ...sharedFunctionProps,
     });
     portfolio.addMethod("POST", new apigw.LambdaIntegration(createPortfolioStepFn));
-
-    // Allow the POST function to read and write (since that will be necessary to add the
-    // new quotes)
-
     table.grantReadWriteData(createPortfolioStepFn);
 
     // -- operationIds from API spec ---


### PR DESCRIPTION
Implements `createPortfolioStep` function for AWS.
Inserts `portfolio_step` and all child elements into an existing Portfolio Draft item in DynamoDB.

- Includes resource creation for `portfolioDraftId` and `portfolio` routes.
- Includes creation of and grants ReadWrite to `createPortfolioStepFn`

This functionality was completed previously in #25 for Azure.

Ticket: AT-6368