### PR TITLE
Create an interface for responses and errors

### DIFF
--- a/applications/portfolioDrafts/createPortfolioDraft.ts
+++ b/applications/portfolioDrafts/createPortfolioDraft.ts
@@ -1,9 +1,11 @@
 import { PutCommand } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { v4 as uuid } from "uuid";
+import { ErrorCodes } from "./models/Error";
 import { PortfolioSummary } from "./models/PortfolioSummary";
 import { ProvisioningStatus } from "./models/ProvisioningStatus";
 import { dynamodbClient as client } from "./utils/dynamodb";
+import { ErrorResponse, SuccessResponse } from "./utils/response";
 
 const TABLE_NAME = process.env.ATAT_TABLE_NAME;
 // const PRIMARY_KEY = process.env.PRIMARY_KEY || "";
@@ -15,7 +17,7 @@ const TABLE_NAME = process.env.ATAT_TABLE_NAME;
  */
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   if (event.body && !JSON.parse(event.body)) {
-    return { statusCode: 400, body: "Request body must be empty" };
+    return new ErrorResponse({ code: ErrorCodes.INVALID_INPUT, message: "Request body must be empty" }, 400);
   }
 
   const now = new Date().toISOString();
@@ -36,9 +38,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   try {
     const data = await client.send(command);
     console.log("success. created item: " + JSON.stringify(data));
-    return { statusCode: 201, body: JSON.stringify(data) };
+    return new SuccessResponse(document, 201);
   } catch (err) {
     console.log("database error: " + err);
-    return { statusCode: 500, body: "database error" };
+    return new ErrorResponse({ code: ErrorCodes.OTHER, message: "Database error" }, 500);
   }
 };

--- a/applications/portfolioDrafts/createPortfolioDraft.ts
+++ b/applications/portfolioDrafts/createPortfolioDraft.ts
@@ -5,7 +5,7 @@ import { ErrorCodes } from "./models/Error";
 import { PortfolioSummary } from "./models/PortfolioSummary";
 import { ProvisioningStatus } from "./models/ProvisioningStatus";
 import { dynamodbClient as client } from "./utils/dynamodb";
-import { ErrorResponse, SuccessResponse } from "./utils/response";
+import { ErrorResponse, ErrorStatusCode, SuccessResponse, SuccessStatusCode } from "./utils/response";
 
 const TABLE_NAME = process.env.ATAT_TABLE_NAME;
 // const PRIMARY_KEY = process.env.PRIMARY_KEY || "";
@@ -17,7 +17,10 @@ const TABLE_NAME = process.env.ATAT_TABLE_NAME;
  */
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   if (event.body && !JSON.parse(event.body)) {
-    return new ErrorResponse({ code: ErrorCodes.INVALID_INPUT, message: "Request body must be empty" }, 400);
+    return new ErrorResponse(
+      { code: ErrorCodes.INVALID_INPUT, message: "Request body must be empty" },
+      ErrorStatusCode.BAD_REQUEST
+    );
   }
 
   const now = new Date().toISOString();
@@ -38,9 +41,12 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   try {
     const data = await client.send(command);
     console.log("success. created item: " + JSON.stringify(data));
-    return new SuccessResponse(document, 201);
+    return new SuccessResponse(document, SuccessStatusCode.CREATED);
   } catch (err) {
     console.log("database error: " + err);
-    return new ErrorResponse({ code: ErrorCodes.OTHER, message: "Database error" }, 500);
+    return new ErrorResponse(
+      { code: ErrorCodes.OTHER, message: "Database error" },
+      ErrorStatusCode.INTERNAL_SERVER_ERROR
+    );
   }
 };

--- a/applications/portfolioDrafts/createPortfolioDraft.ts
+++ b/applications/portfolioDrafts/createPortfolioDraft.ts
@@ -5,7 +5,7 @@ import { ErrorCodes } from "./models/Error";
 import { PortfolioSummary } from "./models/PortfolioSummary";
 import { ProvisioningStatus } from "./models/ProvisioningStatus";
 import { dynamodbClient as client } from "./utils/dynamodb";
-import { ErrorResponse, ErrorStatusCode, SuccessResponse, SuccessStatusCode } from "./utils/response";
+import { DocumentResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "./utils/response";
 
 const TABLE_NAME = process.env.ATAT_TABLE_NAME;
 // const PRIMARY_KEY = process.env.PRIMARY_KEY || "";
@@ -41,7 +41,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   try {
     const data = await client.send(command);
     console.log("success. created item: " + JSON.stringify(data));
-    return new SuccessResponse(document, SuccessStatusCode.CREATED);
+    return new DocumentResponse(document, SuccessStatusCode.CREATED);
   } catch (err) {
     console.log("database error: " + err);
     return new ErrorResponse(

--- a/applications/portfolioDrafts/models/Error.ts
+++ b/applications/portfolioDrafts/models/Error.ts
@@ -1,0 +1,13 @@
+export enum ErrorCodes {
+  INVALID_INPUT = "INVALID_INPUT",
+  OTHER = "OTHER",
+}
+
+export interface Error {
+  code: string;
+  message: string;
+}
+
+export interface ValidationError extends Error {
+  errorMap: Record<string, any>;
+}

--- a/applications/portfolioDrafts/utils/response.ts
+++ b/applications/portfolioDrafts/utils/response.ts
@@ -87,7 +87,7 @@ abstract class SuccessResponse extends Response {
     headers?: Headers,
     multiValueHeaders?: MultiValueHeaders
   ) {
-    super(JSON.stringify(response), statusCode, headers, multiValueHeaders, false);
+    super(response, statusCode, headers, multiValueHeaders, false);
   }
 }
 

--- a/applications/portfolioDrafts/utils/response.ts
+++ b/applications/portfolioDrafts/utils/response.ts
@@ -45,12 +45,30 @@ abstract class Response implements APIGatewayProxyResult {
   }
 }
 
-export class SuccessResponse extends Response {
+abstract class SuccessResponse extends Response {
+  constructor(
+    response: string,
+    statusCode: SuccessStatusCode = SuccessStatusCode.OK,
+    headers?: Headers,
+    multiValueHeaders?: MultiValueHeaders,
+    isBase64Encoded?: boolean
+  ) {
+    super(JSON.stringify(response), statusCode, headers, multiValueHeaders, isBase64Encoded);
+  }
+}
+
+export class NoContentResponse extends SuccessResponse {
+  constructor(headers?: Headers, multiValueHeaders?: MultiValueHeaders, isBase64Encoded?: boolean) {
+    super("", SuccessStatusCode.NO_CONTENT, headers, multiValueHeaders, isBase64Encoded);
+  }
+}
+
+export class DocumentResponse extends SuccessResponse {
   constructor(
     response: BaseDocument,
     statusCode: SuccessStatusCode = SuccessStatusCode.OK,
-    headers: Headers = undefined,
-    multiValueHeaders: MultiValueHeaders = undefined,
+    headers?: Headers,
+    multiValueHeaders?: MultiValueHeaders,
     isBase64Encoded?: boolean
   ) {
     super(JSON.stringify(response), statusCode, headers, multiValueHeaders, isBase64Encoded);
@@ -61,8 +79,8 @@ export class ErrorResponse extends Response {
   constructor(
     error: Error,
     statusCode: ErrorStatusCode,
-    headers: Headers = undefined,
-    multiValueHeaders: MultiValueHeaders = undefined,
+    headers?: Headers,
+    multiValueHeaders?: MultiValueHeaders,
     isBase64Encoded?: boolean
   ) {
     super(JSON.stringify(error), statusCode, headers, multiValueHeaders, isBase64Encoded);

--- a/applications/portfolioDrafts/utils/response.ts
+++ b/applications/portfolioDrafts/utils/response.ts
@@ -1,0 +1,50 @@
+import { APIGatewayProxyResult } from "aws-lambda";
+import { BaseDocument } from "../models/BaseDocument";
+import { Error } from "../models/Error";
+
+type Headers = { [header: string]: string | number | boolean } | undefined;
+type MultiValueHeaders = { [header: string]: (string | number | boolean)[] } | undefined;
+
+export class SuccessResponse implements APIGatewayProxyResult {
+  statusCode: number;
+  headers?: Headers;
+  multiValueHeaders?: MultiValueHeaders;
+  body: string;
+  isBase64Encoded: boolean;
+
+  constructor(
+    response: BaseDocument,
+    statusCode = 200,
+    headers: Headers = {},
+    multiValueHeaders: MultiValueHeaders = {},
+    isBase64Encoded = false
+  ) {
+    this.body = JSON.stringify(response);
+    this.statusCode = statusCode;
+    this.headers = headers;
+    this.multiValueHeaders = multiValueHeaders;
+    this.isBase64Encoded = isBase64Encoded;
+  }
+}
+
+export class ErrorResponse implements APIGatewayProxyResult {
+  statusCode: number;
+  headers?: Headers;
+  multiValueHeaders?: MultiValueHeaders;
+  body: string;
+  isBase64Encoded: boolean;
+
+  constructor(
+    response: Error,
+    statusCode: number,
+    headers: Headers = {},
+    multiValueHeaders: MultiValueHeaders = {},
+    isBase64Encoded = false
+  ) {
+    this.body = JSON.stringify(response);
+    this.statusCode = statusCode;
+    this.headers = headers;
+    this.multiValueHeaders = multiValueHeaders;
+    this.isBase64Encoded = isBase64Encoded;
+  }
+}

--- a/applications/portfolioDrafts/utils/response.ts
+++ b/applications/portfolioDrafts/utils/response.ts
@@ -5,6 +5,24 @@ import { Error } from "../models/Error";
 type Headers = { [header: string]: string | number | boolean } | undefined;
 type MultiValueHeaders = { [header: string]: (string | number | boolean)[] } | undefined;
 
+export enum SuccessStatusCode {
+  OK = 200,
+  CREATED = 201,
+  ACCEPTED = 202,
+  NO_CONTENT = 204,
+}
+
+export enum ErrorStatusCode {
+  BAD_REQUEST = 400,
+  UNAUTHORIZED = 401,
+  FORBIDDEN = 403,
+  NOT_FOUND = 404,
+  METHOD_NOT_ALLOWED = 405,
+  NOT_ACCEPTABLE = 406,
+  INTERNAL_SERVER_ERROR = 500,
+  NOT_IMPLEMENTED = 501,
+}
+
 abstract class Response implements APIGatewayProxyResult {
   statusCode: number;
   body: string;
@@ -14,7 +32,7 @@ abstract class Response implements APIGatewayProxyResult {
 
   constructor(
     body: string,
-    statusCode: number,
+    statusCode: SuccessStatusCode | ErrorStatusCode,
     headers?: Headers,
     multiValueHeaders?: MultiValueHeaders,
     isBase64Encoded?: boolean
@@ -30,7 +48,7 @@ abstract class Response implements APIGatewayProxyResult {
 export class SuccessResponse extends Response {
   constructor(
     response: BaseDocument,
-    statusCode = 200,
+    statusCode: SuccessStatusCode = SuccessStatusCode.OK,
     headers: Headers = undefined,
     multiValueHeaders: MultiValueHeaders = undefined,
     isBase64Encoded?: boolean
@@ -42,7 +60,7 @@ export class SuccessResponse extends Response {
 export class ErrorResponse extends Response {
   constructor(
     error: Error,
-    statusCode: number,
+    statusCode: ErrorStatusCode,
     headers: Headers = undefined,
     multiValueHeaders: MultiValueHeaders = undefined,
     isBase64Encoded?: boolean

--- a/applications/portfolioDrafts/utils/response.ts
+++ b/applications/portfolioDrafts/utils/response.ts
@@ -5,21 +5,21 @@ import { Error } from "../models/Error";
 type Headers = { [header: string]: string | number | boolean } | undefined;
 type MultiValueHeaders = { [header: string]: (string | number | boolean)[] } | undefined;
 
-export class SuccessResponse implements APIGatewayProxyResult {
+abstract class Response implements APIGatewayProxyResult {
   statusCode: number;
+  body: string;
   headers?: Headers;
   multiValueHeaders?: MultiValueHeaders;
-  body: string;
-  isBase64Encoded: boolean;
+  isBase64Encoded?: boolean | undefined;
 
   constructor(
-    response: BaseDocument,
-    statusCode = 200,
-    headers: Headers = {},
-    multiValueHeaders: MultiValueHeaders = {},
-    isBase64Encoded = false
+    body: string,
+    statusCode: number,
+    headers?: Headers,
+    multiValueHeaders?: MultiValueHeaders,
+    isBase64Encoded?: boolean
   ) {
-    this.body = JSON.stringify(response);
+    this.body = body;
     this.statusCode = statusCode;
     this.headers = headers;
     this.multiValueHeaders = multiValueHeaders;
@@ -27,24 +27,26 @@ export class SuccessResponse implements APIGatewayProxyResult {
   }
 }
 
-export class ErrorResponse implements APIGatewayProxyResult {
-  statusCode: number;
-  headers?: Headers;
-  multiValueHeaders?: MultiValueHeaders;
-  body: string;
-  isBase64Encoded: boolean;
-
+export class SuccessResponse extends Response {
   constructor(
-    response: Error,
-    statusCode: number,
-    headers: Headers = {},
-    multiValueHeaders: MultiValueHeaders = {},
-    isBase64Encoded = false
+    response: BaseDocument,
+    statusCode = 200,
+    headers: Headers = undefined,
+    multiValueHeaders: MultiValueHeaders = undefined,
+    isBase64Encoded?: boolean
   ) {
-    this.body = JSON.stringify(response);
-    this.statusCode = statusCode;
-    this.headers = headers;
-    this.multiValueHeaders = multiValueHeaders;
-    this.isBase64Encoded = isBase64Encoded;
+    super(JSON.stringify(response), statusCode, headers, multiValueHeaders, isBase64Encoded);
+  }
+}
+
+export class ErrorResponse extends Response {
+  constructor(
+    error: Error,
+    statusCode: number,
+    headers: Headers = undefined,
+    multiValueHeaders: MultiValueHeaders = undefined,
+    isBase64Encoded?: boolean
+  ) {
+    super(JSON.stringify(error), statusCode, headers, multiValueHeaders, isBase64Encoded);
   }
 }


### PR DESCRIPTION
This adds type safety around our response objects. It ensures that we provide a proper Error object that matches the API specification when returning an error response or that we provide a subclass of `BaseDocument` when returning a success response. Utilizing an `enum` for the status codes also adds type safety to ensure that we don't return a 200 when we return an error body. The less-safe abstract parent `Response` class is not exported. Possibly missing is a 30x `RedirectResponse` class but that is not currently defined in our API.

I believe that all error codes current defined in the specification and application are represented in these classes, enums, and interfaces.