### PR TITLE
Rename three wizard step properties in PortfolioDraft schema in API

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -557,9 +557,9 @@ components:
         - $ref: '#/components/schemas/PortfolioDraftSummary'
       type: object
       properties:
-        portfolio:
+        portfolio_step:
           $ref: '#/components/schemas/PortfolioStep'
-        funding:
+        funding_step:
           $ref: '#/components/schemas/FundingStep'
-        application:
+        application_step:
           $ref: '#/components/schemas/ApplicationStep'


### PR DESCRIPTION
Under PortfolioDraft:

- `porfolio` -> `portfolio_step`
- `funding` -> `funding_step`
- `application` -> `application_step`