### PR TITLE
Update Wizard spec for Funding Step

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -439,6 +439,13 @@ components:
             name:
               type: string
               description: name of file when originally uploaded
+            status:
+              type: string
+              description: virus scanning status of uploaded file
+              enum:
+                - "pending"
+                - "clean"
+                - "dirty"
     PortfolioStep:
       type: object
       required:
@@ -481,33 +488,36 @@ components:
         properties:
           task_order_number:
             type: string
-          task_order_file_id:
-            type: string
-            description: ID of the file associated with this task order (previously uploaded by POST /taskOrderFiles)
+          task_order_file:
+            allOf:
+              - $ref: '#/components/schemas/FileMetadata'
+            description: Metadata associated with file which was previously uploaded by POST /taskOrderFiles
           csp:
             type: string
             enum:
               - "aws"
               - "azure"
-          clin:
-            type: object
-            properties:
-              clin_number:
-                type: string
-              idiq_clin:
-                type: string
-              total_clin_value:
-                type: "integer"
-              obligated_funds:
-                type: "integer"
-              pop_start_date:
-                type: string
-                format: date
-                example: '2021-07-01'
-              pop_end_date:
-                type: string
-                format: date
-                example: '2022-07-01'
+          clins:
+            type: array
+            items:
+              type: object
+              properties:
+                clin_number:
+                  type: string
+                idiq_clin:
+                  type: string
+                total_clin_value:
+                  type: "integer"
+                obligated_funds:
+                  type: "integer"
+                pop_start_date:
+                  type: string
+                  format: date
+                  example: '2021-07-01'
+                pop_end_date:
+                  type: string
+                  format: date
+                  example: '2022-07-01'
     ApplicationStep:
       description: Represents the Application Step of the Portfolio Draft Wizard
       type: array

--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -441,11 +441,11 @@ components:
               description: name of file when originally uploaded
             status:
               type: string
-              description: virus scanning status of uploaded file
+              description: status of uploaded file scans and review
               enum:
                 - "pending"
-                - "clean"
-                - "dirty"
+                - "accepted"
+                - "rejected"
     PortfolioStep:
       type: object
       required:


### PR DESCRIPTION
Fixing a few issues in the Funding Step of the spec:
1) Added support for multiple CLINs per Task Order
2) Changed `funding_step.task_order_file_id` to contain the entire `FileMetadata` object and renamed it to `task_order_file` accordingly
3) Addded `funding_step.task_order_file.status` field to indicate file scanning status for uploaded task orders

Ticket: AT-6409