### PR TITLE
Update Wizard spec to:

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -348,7 +348,7 @@ paths:
     get:
       tags:
         - taskOrder
-      description: Gets a Task Order PDF
+      description: Gets File Metadata for a Task Order
       operationId: getTaskOrder
       parameters:
         - name: taskOrderId
@@ -361,10 +361,9 @@ paths:
         '200':
           description: Successful operation
           content:
-            application/pdf:
+            application/json:
               schema:
-                type: string
-                format: binary
+                $ref: '#/components/schemas/FileMetadata'
         '404':
           description: Task Order with the given ID does not exist
     delete:
@@ -384,6 +383,29 @@ paths:
           description: Successful operation
         '404':
           description: Task Order with the given number does not exist
+  '/taskOrderFiles/{taskOrderId}/download':
+    get:
+      tags:
+        - taskOrder
+      description: Gets a Task Order PDF
+      operationId: downloadTaskOrder
+      parameters:
+        - name: taskOrderId
+          in: path
+          description: Task Order ID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: Task Order with the given ID does not exist or has not completed virus scanning
 components:
   parameters:
     offsetParam:
@@ -455,19 +477,26 @@ components:
             error_map:
               type: object
               description: 'Maps form input IDs to validation error messages so that clients can display in-line errors'
+    FileMetadataSummary:
+      type: object
+      description: Metadata describing an uploaded file
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+          description: name of file when originally uploaded
     FileMetadata:
       type: object
       description: Metadata describing an uploaded file
       allOf:
         - $ref: '#/components/schemas/BaseObject'
+        - $ref: '#/components/schemas/FileMetadataSummary'
         - type: object
           properties:
             size:
               type: number
               description: file size in bytes
-            name:
-              type: string
-              description: name of file when originally uploaded
             status:
               type: string
               description: status of uploaded file scans and review
@@ -519,7 +548,7 @@ components:
             type: string
           task_order_file:
             allOf:
-              - $ref: '#/components/schemas/FileMetadata'
+              - $ref: '#/components/schemas/FileMetadataSummary'
             description: Metadata associated with file which was previously uploaded by POST /taskOrderFiles
           csp:
             type: string


### PR DESCRIPTION
1) modify the /taskOrderFile routes to provide one GET for the binary file and another GET for the file metadata
2) simplify the data that the UI needs to supply in the task_order_file property of the Funding Step

Ticket: AT-6409