### PR TITLE
Allow isolated deployments by supplying 'TicketId' context variable to CDK

### DIFF
--- a/infrastructure/bin/atat-web-api.ts
+++ b/infrastructure/bin/atat-web-api.ts
@@ -9,8 +9,10 @@ const accountId = app.node.tryGetContext("account");
 const region = app.node.tryGetContext("region");
 // Ugly hack to quickly isolate deployments for developers.  To be improved/removed later.
 const ticketId = app.node.tryGetContext("TicketId") || "";
-if (ticketId === "") {
-  console.warn("Hello Developer. You must provide a context variable named 'TicketId'.");
+if (!ticketId) {
+  console.warn(
+    "Hello Developer. You must provide a context variable named 'TicketId' to isolate your deployment from others."
+  );
   console.warn("  For example...");
   console.warn('  $ cdk deploy -c "TicketId=AT1234"');
 }

--- a/infrastructure/bin/atat-web-api.ts
+++ b/infrastructure/bin/atat-web-api.ts
@@ -7,7 +7,9 @@ import { getTags } from "../lib/load-tags";
 const app = new cdk.App();
 const accountId = app.node.tryGetContext("account");
 const region = app.node.tryGetContext("region");
-const stack = new AtatWebApiStack(app, "AtatWebApiStack", {
+// Ugly hack to quickly isolate deployments for developers.  To be improved/removed later.
+const ticketId = app.node.tryGetContext("TicketId") || "";
+const stack = new AtatWebApiStack(app, ticketId + "AtatWebApiStack", {
   env: { account: accountId, region },
 });
 

--- a/infrastructure/bin/atat-web-api.ts
+++ b/infrastructure/bin/atat-web-api.ts
@@ -9,6 +9,11 @@ const accountId = app.node.tryGetContext("account");
 const region = app.node.tryGetContext("region");
 // Ugly hack to quickly isolate deployments for developers.  To be improved/removed later.
 const ticketId = app.node.tryGetContext("TicketId") || "";
+if (ticketId === "") {
+  console.warn("Hello Developer. You must provide a context variable named 'TicketId'.");
+  console.warn("  For example...");
+  console.warn('  $ cdk deploy -c "TicketId=AT1234"');
+}
 const stack = new AtatWebApiStack(app, ticketId + "AtatWebApiStack", {
   env: { account: accountId, region },
 });

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -25,9 +25,11 @@ export class AtatWebApiStack extends cdk.Stack {
         userPassword: true,
       },
     });
+    // Ugly hack to quickly isolate deployments for developers.  To be improved/removed later.
+    const ticketId = this.node.tryGetContext("TicketId").toLowerCase() || "";
     const userPoolDomain = userPool.addDomain("api-app-domain", {
       cognitoDomain: {
-        domainPrefix: "atatapi",
+        domainPrefix: ticketId + "atatapi",
       },
     });
     const poolDomainOutput = new cdk.CfnOutput(this, "UserPoolDomain", {

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -26,7 +26,7 @@ export class AtatWebApiStack extends cdk.Stack {
       },
     });
     // Ugly hack to quickly isolate deployments for developers.  To be improved/removed later.
-    const ticketId = this.node.tryGetContext("TicketId").toLowerCase() || "";
+    const ticketId = (this.node.tryGetContext("TicketId") || "").toLowerCase();
     const userPoolDomain = userPool.addDomain("api-app-domain", {
       cognitoDomain: {
         domainPrefix: ticketId + "atatapi",


### PR DESCRIPTION
This will quickly allow deployments to be isolated for developers.

During cdk deploy/diff/destroy a context variable named `TicketId` must be provided.

For example:
`cdk deploy -c "TicketId=AT1234"`

If the context variable is not supplied a warning is displayed.

> Hello Developer. You must provide a context variable named 'TicketId' to isolate your deployment from others.
>   For example...
>   $ cdk deploy -c "TicketId=AT1234"