### PR TITLE
First cut of POST /taskOrderFiles

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,7 @@
     ],
     "ignorePatterns": ["**/*.js", "coverage/**"],
     "rules": {
-      "no-console": "off"
+      "no-console": "warn"
     },
     "overrides": [
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,7 @@
     ],
     "ignorePatterns": ["**/*.js", "coverage/**"],
     "rules": {
-      "no-console": "warn"
+      "no-console": "off"
     },
     "overrides": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ tags-private.json
 
 # Editor configuration files
 .vscode/
+.idea
+
+# OSX
+.DS_Store

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -156,7 +156,7 @@ export class AtatWebApiStack extends cdk.Stack {
   }
 }
 
-const addCreateTaskOrderFiles = (scope: cdk.Stack, resource: apigw.Resource) => {
+function addCreateTaskOrderFiles(scope: cdk.Stack, resource: apigw.Resource) {
   const bucket = new s3.Bucket(scope, "PendingBucket", {
     publicReadAccess: false,
     removalPolicy: cdk.RemovalPolicy.RETAIN,
@@ -175,4 +175,4 @@ const addCreateTaskOrderFiles = (scope: cdk.Stack, resource: apigw.Resource) => 
   });
   resource.addMethod("POST", new apigw.LambdaIntegration(fn));
   bucket.grantPut(fn);
-};
+}

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -1,11 +1,10 @@
 import * as apigw from "@aws-cdk/aws-apigateway";
-import {ContentHandling} from "@aws-cdk/aws-apigateway";
-import {UserPool} from "@aws-cdk/aws-cognito";
+import { UserPool } from "@aws-cdk/aws-cognito";
 import * as dynamodb from "@aws-cdk/aws-dynamodb";
 import * as s3 from "@aws-cdk/aws-s3";
 import * as lambdaNodejs from "@aws-cdk/aws-lambda-nodejs";
 import * as cdk from "@aws-cdk/core";
-import {Duration} from "@aws-cdk/core";
+import { Duration } from "@aws-cdk/core";
 
 // This is a suboptimal solution to finding the relative directory to the
 // package root. This is necessary because it is possible for this file to be
@@ -56,11 +55,6 @@ export class AtatWebApiStack extends cdk.Stack {
     // stage for everything being dev is good enough for a proof of concept
     const restApi = new apigw.RestApi(this, "AtatWebApi", {
       binaryMediaTypes: ["multipart/form-data"],
-      deployOptions: {
-        loggingLevel: apigw.MethodLoggingLevel.INFO,
-        tracingEnabled: true,
-        dataTraceEnabled: true
-      },
       endpointConfiguration: {
         types: [apigw.EndpointType.REGIONAL],
       },
@@ -157,28 +151,28 @@ export class AtatWebApiStack extends cdk.Stack {
     // TODO: getApplicationStep
     // TODO: createApplicationStep
     // TODO: submitPortfolioDraft
-    addCreateTaskOrderFiles(this, taskOrderFiles, sharedFunctionProps);
+    addCreateTaskOrderFiles(this, taskOrderFiles);
     // TODO: deleteTaskOrder
   }
 }
 
-function addCreateTaskOrderFiles(scope: cdk.Stack,
-                                 resource: apigw.Resource) {
+const addCreateTaskOrderFiles = (scope: cdk.Stack, resource: apigw.Resource) => {
   const bucket = new s3.Bucket(scope, "PendingBucket", {
     publicReadAccess: false,
     removalPolicy: cdk.RemovalPolicy.RETAIN,
-    autoDeleteObjects: false
+    autoDeleteObjects: false,
   });
   const fn = new lambdaNodejs.NodejsFunction(scope, "CreateTaskOrderFileFunction", {
     entry: packageRoot() + "/api/taskOrderFiles/createTaskOrderFile.ts",
     timeout: Duration.seconds(300),
     environment: {
-      PENDING_BUCKET: bucket.bucketName
+      PENDING_BUCKET: bucket.bucketName,
     },
     bundling: {
       externalModules: ["aws-sdk"],
     },
-  })
+    memorySize: 256,
+  });
   resource.addMethod("POST", new apigw.LambdaIntegration(fn));
   bucket.grantPut(fn);
-}
+};

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -42,6 +42,7 @@
     "@aws-cdk/aws-kms": "1.118.0",
     "@aws-cdk/aws-lambda": "1.118.0",
     "@aws-cdk/aws-lambda-nodejs": "1.118.0",
+    "@aws-cdk/aws-s3": "1.118.0",
     "@aws-cdk/core": "1.118.0",
     "eslint": "^7.31.0",
     "source-map-support": "^0.5.16",

--- a/packages/api/models/Error.ts
+++ b/packages/api/models/Error.ts
@@ -9,5 +9,5 @@ export interface Error {
 }
 
 export interface ValidationError extends Error {
-  errorMap: Record<string, any>;
+  errorMap: Record<string, never>;
 }

--- a/packages/api/models/Error.ts
+++ b/packages/api/models/Error.ts
@@ -9,5 +9,5 @@ export interface Error {
 }
 
 export interface ValidationError extends Error {
-  errorMap: Record<string, never>;
+  errorMap: Record<string, unknown>;
 }

--- a/packages/api/models/FileMetadata.ts
+++ b/packages/api/models/FileMetadata.ts
@@ -1,13 +1,13 @@
 import { BaseDocument } from "./BaseDocument";
 
-export interface FileMetadata extends BaseDocument {
-    name: string;
-    size: number;
-    status: FileScanStatus;
+export const enum FileScanStatus {
+  PENDING = "pending",
+  ACCEPTED = "accepted",
+  REJECTED = "rejected",
 }
 
-export const enum FileScanStatus {
-    Pending = "pending",
-    Accepted = "accepted",
-    Rejected = "rejected"
+export interface FileMetadata extends BaseDocument {
+  name: string;
+  size: number;
+  status: FileScanStatus;
 }

--- a/packages/api/models/FileMetadata.ts
+++ b/packages/api/models/FileMetadata.ts
@@ -1,6 +1,6 @@
 import { BaseDocument } from "./BaseDocument";
 
-export const enum FileScanStatus {
+export enum FileScanStatus {
   PENDING = "pending",
   ACCEPTED = "accepted",
   REJECTED = "rejected",

--- a/packages/api/models/FileMetadata.ts
+++ b/packages/api/models/FileMetadata.ts
@@ -11,23 +11,3 @@ export const enum FileScanStatus {
     Accepted = "accepted",
     Rejected = "rejected"
 }
-
-export class S3FileMetadata implements FileMetadata {
-
-    id: string;
-    name: string;
-    size: number;
-    status: FileScanStatus;
-    created_at: string;
-    updated_at: string;
-
-    constructor(id: string, name: string, size: number, status: FileScanStatus, created_at: string, updated_at: string) {
-        this.id = id;
-        this.name = name;
-        this.size = size;
-        this.status = status;
-        this.created_at = created_at;
-        this.updated_at = updated_at;
-    }
-
-}

--- a/packages/api/models/FileMetadata.ts
+++ b/packages/api/models/FileMetadata.ts
@@ -1,0 +1,33 @@
+import { BaseDocument } from "./BaseDocument";
+
+export interface FileMetadata extends BaseDocument {
+    name: string;
+    size: number;
+    status: FileScanStatus;
+}
+
+export const enum FileScanStatus {
+    Pending = "pending",
+    Accepted = "accepted",
+    Rejected = "rejected"
+}
+
+export class S3FileMetadata implements FileMetadata {
+
+    id: string;
+    name: string;
+    size: number;
+    status: FileScanStatus;
+    created_at: string;
+    updated_at: string;
+
+    constructor(id: string, name: string, size: number, status: FileScanStatus, created_at: string, updated_at: string) {
+        this.id = id;
+        this.name = name;
+        this.size = size;
+        this.status = status;
+        this.created_at = created_at;
+        this.updated_at = updated_at;
+    }
+
+}

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -4,6 +4,21 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@aws-crypto/crc32": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.1.0.tgz",
+			"integrity": "sha512-ifvfaaJVvT+JUTi3zSkX4wtuGGVJrAcjN7ftg+JiE/frNBP3zNwo4xipzWBsMLZfNuzMZuaesEYyqkZcs5tzCQ==",
+			"requires": {
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
 		"@aws-crypto/ie11-detection": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
@@ -81,6 +96,23 @@
 				"tslib": "^2.3.0"
 			}
 		},
+		"@aws-sdk/chunked-blob-reader": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.23.0.tgz",
+			"integrity": "sha512-gmJhCuXrKOOumppviE4K30NvsIQIqqxbGDNptrJrMYBO0qXCbK8/BypZ/hS/oT3loDzlSIxG2z5GDL/va9lbFw==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/chunked-blob-reader-native": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.23.0.tgz",
+			"integrity": "sha512-Ya5f8Ntv0EyZw+AHkpV6n6qqHzpCDNlkX50uj/dwFCMmPiHFWsWMvd0Qu04Y7miycJINEatRrJ5V8r/uVvZIDg==",
+			"requires": {
+				"@aws-sdk/util-base64-browser": "3.23.0",
+				"tslib": "^2.3.0"
+			}
+		},
 		"@aws-sdk/client-dynamodb": {
 			"version": "3.26.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.26.0.tgz",
@@ -120,6 +152,60 @@
 				"@aws-sdk/util-waiter": "3.25.0",
 				"tslib": "^2.3.0",
 				"uuid": "^8.3.2"
+			}
+		},
+		"@aws-sdk/client-s3": {
+			"version": "3.26.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.26.0.tgz",
+			"integrity": "sha512-9iHbpMat5erkvhuRJeJ8ASeosNJytlb6v352GTUZFnI9g5zRlT3v1powj+W2UnyXoS73hatXKPvMwDWTvDAIfg==",
+			"requires": {
+				"@aws-crypto/sha256-browser": "^1.0.0",
+				"@aws-crypto/sha256-js": "^1.0.0",
+				"@aws-sdk/client-sts": "3.26.0",
+				"@aws-sdk/config-resolver": "3.25.0",
+				"@aws-sdk/credential-provider-node": "3.26.0",
+				"@aws-sdk/eventstream-serde-browser": "3.25.0",
+				"@aws-sdk/eventstream-serde-config-resolver": "3.25.0",
+				"@aws-sdk/eventstream-serde-node": "3.25.0",
+				"@aws-sdk/fetch-http-handler": "3.25.0",
+				"@aws-sdk/hash-blob-browser": "3.25.0",
+				"@aws-sdk/hash-node": "3.25.0",
+				"@aws-sdk/hash-stream-node": "3.25.0",
+				"@aws-sdk/invalid-dependency": "3.25.0",
+				"@aws-sdk/md5-js": "3.25.0",
+				"@aws-sdk/middleware-apply-body-checksum": "3.25.0",
+				"@aws-sdk/middleware-bucket-endpoint": "3.25.0",
+				"@aws-sdk/middleware-content-length": "3.25.0",
+				"@aws-sdk/middleware-expect-continue": "3.25.0",
+				"@aws-sdk/middleware-host-header": "3.25.0",
+				"@aws-sdk/middleware-location-constraint": "3.25.0",
+				"@aws-sdk/middleware-logger": "3.25.0",
+				"@aws-sdk/middleware-retry": "3.25.0",
+				"@aws-sdk/middleware-sdk-s3": "3.25.0",
+				"@aws-sdk/middleware-serde": "3.25.0",
+				"@aws-sdk/middleware-signing": "3.25.0",
+				"@aws-sdk/middleware-ssec": "3.25.0",
+				"@aws-sdk/middleware-stack": "3.25.0",
+				"@aws-sdk/middleware-user-agent": "3.25.0",
+				"@aws-sdk/node-config-provider": "3.25.0",
+				"@aws-sdk/node-http-handler": "3.25.0",
+				"@aws-sdk/protocol-http": "3.25.0",
+				"@aws-sdk/smithy-client": "3.25.0",
+				"@aws-sdk/types": "3.25.0",
+				"@aws-sdk/url-parser": "3.25.0",
+				"@aws-sdk/util-base64-browser": "3.23.0",
+				"@aws-sdk/util-base64-node": "3.23.0",
+				"@aws-sdk/util-body-length-browser": "3.23.0",
+				"@aws-sdk/util-body-length-node": "3.23.0",
+				"@aws-sdk/util-user-agent-browser": "3.25.0",
+				"@aws-sdk/util-user-agent-node": "3.25.0",
+				"@aws-sdk/util-utf8-browser": "3.23.0",
+				"@aws-sdk/util-utf8-node": "3.23.0",
+				"@aws-sdk/util-waiter": "3.25.0",
+				"@aws-sdk/xml-builder": "3.23.0",
+				"entities": "2.2.0",
+				"fast-xml-parser": "3.19.0",
+				"tslib": "^2.3.0"
 			}
 		},
 		"@aws-sdk/client-sso": {
@@ -307,6 +393,58 @@
 				"tslib": "^2.3.0"
 			}
 		},
+		"@aws-sdk/eventstream-marshaller": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.25.0.tgz",
+			"integrity": "sha512-gUZIIxupgCIGyspiIV6bEplSRWnhAR9MkyrCJbHhbs4GjWIYlFqp7W0+Y7HY1tIeeXCUf0O8KE3paUMszKPXtg==",
+			"requires": {
+				"@aws-crypto/crc32": "^1.0.0",
+				"@aws-sdk/types": "3.25.0",
+				"@aws-sdk/util-hex-encoding": "3.23.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/eventstream-serde-browser": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.25.0.tgz",
+			"integrity": "sha512-QJF08OIZiufoBPPoVcRwBPvZIpKMSZpISZfpCHcY1GaTpMIzz35N7Nkd10JGpfzpUO9oFcgcmm2q3XHo1XJyyw==",
+			"requires": {
+				"@aws-sdk/eventstream-marshaller": "3.25.0",
+				"@aws-sdk/eventstream-serde-universal": "3.25.0",
+				"@aws-sdk/types": "3.25.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/eventstream-serde-config-resolver": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.25.0.tgz",
+			"integrity": "sha512-Fb4VS3waKNzc6pK6tQBmWM+JmCNQJYNG/QBfb8y4AoJOZ+I7yX0Qgo90drh8IiUcIKDeprUFjSi/cGIa/KHIsg==",
+			"requires": {
+				"@aws-sdk/types": "3.25.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/eventstream-serde-node": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.25.0.tgz",
+			"integrity": "sha512-gPs+6w0zXf+p0PuOxxmpAlCvP/7E7+8oAar8Ys27exnLXNgqJJK1k5hMBSrfR9GLVti3EhJ1M9x5Seg1SN0/SA==",
+			"requires": {
+				"@aws-sdk/eventstream-marshaller": "3.25.0",
+				"@aws-sdk/eventstream-serde-universal": "3.25.0",
+				"@aws-sdk/types": "3.25.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/eventstream-serde-universal": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.25.0.tgz",
+			"integrity": "sha512-NgsQk5dXg7NlRDEKGRUdiAx7WESQGD1jEhXitklL3/PHRZ7Y9BJugEFlBvKpU7tiHZBcomTbl/gE2o6i2op/jA==",
+			"requires": {
+				"@aws-sdk/eventstream-marshaller": "3.25.0",
+				"@aws-sdk/types": "3.25.0",
+				"tslib": "^2.3.0"
+			}
+		},
 		"@aws-sdk/fetch-http-handler": {
 			"version": "3.25.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.25.0.tgz",
@@ -319,6 +457,17 @@
 				"tslib": "^2.3.0"
 			}
 		},
+		"@aws-sdk/hash-blob-browser": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.25.0.tgz",
+			"integrity": "sha512-dsvV/nkW8v9wIotd3xJn3TQ8AxVLl56H82WkGkHcfw61csRxj3eSUNv0apUBopCcQPK8OK4l2nHAg08r0+LWXg==",
+			"requires": {
+				"@aws-sdk/chunked-blob-reader": "3.23.0",
+				"@aws-sdk/chunked-blob-reader-native": "3.23.0",
+				"@aws-sdk/types": "3.25.0",
+				"tslib": "^2.3.0"
+			}
+		},
 		"@aws-sdk/hash-node": {
 			"version": "3.25.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.25.0.tgz",
@@ -326,6 +475,15 @@
 			"requires": {
 				"@aws-sdk/types": "3.25.0",
 				"@aws-sdk/util-buffer-from": "3.23.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/hash-stream-node": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.25.0.tgz",
+			"integrity": "sha512-pzScUO9pPEEHQ5YQk1sl1bPlU2tt0OCblxUwboZJ9mRgNnWwkMWxe7Mec5IfyMWVUcbIznUHn7qRYEvJQ9JXmw==",
+			"requires": {
+				"@aws-sdk/types": "3.25.0",
 				"tslib": "^2.3.0"
 			}
 		},
@@ -354,6 +512,39 @@
 				"tslib": "^2.3.0"
 			}
 		},
+		"@aws-sdk/md5-js": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.25.0.tgz",
+			"integrity": "sha512-97MtL1VF3JCkyJJnwi8LcXpqItnH1VtgoqtVqmaASYp5GXnlsnA1WDnB0754ufPHlssS1aBj/gkLzMZ0Htw/Rg==",
+			"requires": {
+				"@aws-sdk/types": "3.25.0",
+				"@aws-sdk/util-utf8-browser": "3.23.0",
+				"@aws-sdk/util-utf8-node": "3.23.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-apply-body-checksum": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.25.0.tgz",
+			"integrity": "sha512-162qFG7eap4vDKuKrpXWQYE4tbIETNrpTQX6jrPgqostOy1O0Nc5Bn1COIoOMgeMVnkOAZV7qV1J/XAYGz32Yw==",
+			"requires": {
+				"@aws-sdk/is-array-buffer": "3.23.0",
+				"@aws-sdk/protocol-http": "3.25.0",
+				"@aws-sdk/types": "3.25.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-bucket-endpoint": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.25.0.tgz",
+			"integrity": "sha512-r/6ECFiw/TNjzhAuZzUx3M/1mAtezHTp3e8twB4dDbRRQqABrEZ/dynXi1VxrT2kKW0ZgZNXqEer/NfPOtWB8g==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.25.0",
+				"@aws-sdk/types": "3.25.0",
+				"@aws-sdk/util-arn-parser": "3.23.0",
+				"tslib": "^2.3.0"
+			}
+		},
 		"@aws-sdk/middleware-content-length": {
 			"version": "3.25.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.25.0.tgz",
@@ -376,12 +567,42 @@
 				"tslib": "^2.3.0"
 			}
 		},
+		"@aws-sdk/middleware-expect-continue": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.25.0.tgz",
+			"integrity": "sha512-o3euv8NIO0zlHML81krtfs4TrF5gZwoxBYtY+6tRHXlgutsHe1yfg1wrhWnJNbJg1QhPwXxbMNfYX7MM83D8Ng==",
+			"requires": {
+				"@aws-sdk/middleware-header-default": "3.25.0",
+				"@aws-sdk/protocol-http": "3.25.0",
+				"@aws-sdk/types": "3.25.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-header-default": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.25.0.tgz",
+			"integrity": "sha512-xkFfZcctPL0VTxmEKITf6/MSDv/8rY+8uA9OMt/YZqfbg0RfeqR2+R1xlDNDxeHeK/v+g5gTNIYTQLM8L2unNA==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.25.0",
+				"@aws-sdk/types": "3.25.0",
+				"tslib": "^2.3.0"
+			}
+		},
 		"@aws-sdk/middleware-host-header": {
 			"version": "3.25.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.25.0.tgz",
 			"integrity": "sha512-xKD/CfsUS3ul2VaQ3IgIUXgA7jU2/Guo/DUhYKrLZTOxm0nuvsIFw0RqSCtRBCLptE5Qi+unkc1LcFDbfqrRbg==",
 			"requires": {
 				"@aws-sdk/protocol-http": "3.25.0",
+				"@aws-sdk/types": "3.25.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-location-constraint": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.25.0.tgz",
+			"integrity": "sha512-diwmJ+MRQrq3H9VH+8CNAT4dImf2j3CLewlMrUEY+HsJN9xl2mtU6GQaluQg60iw6FjurLUKKGTTZCul4PGkIQ==",
+			"requires": {
 				"@aws-sdk/types": "3.25.0",
 				"tslib": "^2.3.0"
 			}
@@ -405,6 +626,17 @@
 				"@aws-sdk/types": "3.25.0",
 				"tslib": "^2.3.0",
 				"uuid": "^8.3.2"
+			}
+		},
+		"@aws-sdk/middleware-sdk-s3": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.25.0.tgz",
+			"integrity": "sha512-Y1P6JnpAdj7p5Q43aSLSuYBCc3hKpZ/mrqFSGN8VFXl7Tzo7tYfjpd9SVRxNGJK7O7tDAUsPNmuGqBrdA2tj8w==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.25.0",
+				"@aws-sdk/types": "3.25.0",
+				"@aws-sdk/util-arn-parser": "3.23.0",
+				"tslib": "^2.3.0"
 			}
 		},
 		"@aws-sdk/middleware-sdk-sts": {
@@ -437,6 +669,15 @@
 				"@aws-sdk/property-provider": "3.25.0",
 				"@aws-sdk/protocol-http": "3.25.0",
 				"@aws-sdk/signature-v4": "3.25.0",
+				"@aws-sdk/types": "3.25.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-ssec": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.25.0.tgz",
+			"integrity": "sha512-bnrHb8oddW+vDexbNzZtpfshshKru+skcmq3dyXlL8LB/NlJsMiQJE8xoGbq5odTLiflIgaDBt527m5q58i+fg==",
+			"requires": {
 				"@aws-sdk/types": "3.25.0",
 				"tslib": "^2.3.0"
 			}
@@ -569,6 +810,14 @@
 				"tslib": "^2.3.0"
 			}
 		},
+		"@aws-sdk/util-arn-parser": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.23.0.tgz",
+			"integrity": "sha512-J3+/wnC21kbb3UAHo7x31aCZxzIa7GBijt6Q7nad/j2aF38EZtE3SI0aZpD8250Vi+9zsZ4672QDUeSZ5BR5kg==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
 		"@aws-sdk/util-base64-browser": {
 			"version": "3.23.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.23.0.tgz",
@@ -696,6 +945,14 @@
 			"requires": {
 				"@aws-sdk/abort-controller": "3.25.0",
 				"@aws-sdk/types": "3.25.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/xml-builder": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.23.0.tgz",
+			"integrity": "sha512-5LEGdhQIJtGTwg4dIYyNtpz5QvPcQoxsqJygmj+VB8KLd+mWorH1IOpiL74z0infeK9N+ZFUUPKIzPJa9xLPqw==",
+			"requires": {
 				"tslib": "^2.3.0"
 			}
 		},
@@ -1864,6 +2121,14 @@
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true
 		},
+		"busboy": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+			"integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+			"requires": {
+				"dicer": "0.3.0"
+			}
+		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2108,6 +2373,14 @@
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
+		},
+		"dicer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+			"integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+			"requires": {
+				"streamsearch": "0.1.2"
+			}
 		},
 		"diff": {
 			"version": "5.0.0",
@@ -3491,6 +3764,14 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"lambda-multipart-parser": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lambda-multipart-parser/-/lambda-multipart-parser-1.0.1.tgz",
+			"integrity": "sha512-5FKqZAoJuAXJXIAQvr/60vpB/Cf0+tds/V6896ZwpoAldHL7+INviVhbGzQIjmmtgw9oaig13q6kHwlnFT/NqA==",
+			"requires": {
+				"busboy": "^0.3.0"
+			}
+		},
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4145,6 +4426,11 @@
 					"dev": true
 				}
 			}
+		},
+		"streamsearch": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+			"integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
 		},
 		"string-length": {
 			"version": "4.0.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,9 +9,11 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.25.0",
+    "@aws-sdk/client-s3": "^3.25.0",
     "@aws-sdk/lib-dynamodb": "^3.25.0",
     "@aws-sdk/util-dynamodb": "^3.25.0",
     "@types/aws-lambda": "^8.10.81",
+    "lambda-multipart-parser": "^1.0.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/api/taskOrderFiles/createTaskOrderFile.ts
+++ b/packages/api/taskOrderFiles/createTaskOrderFile.ts
@@ -1,0 +1,66 @@
+import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
+import {v4 as uuid} from "uuid";
+import {ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode} from "../utils/response";
+import {PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
+import {FileMetadata, FileScanStatus} from "../models/FileMetadata";
+import * as parser from "lambda-multipart-parser"
+import {ErrorCodes} from "../models/Error";
+
+const bucketName = process.env.PENDING_BUCKET;
+
+/**
+ * Creates a new Task Order File
+ *
+ * @param event - The POST request from API Gateway
+ */
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const key = uuid();
+    const client = new S3Client({});
+
+    try {
+        const result = await parser.parse(event);
+        if (result.files.length != 1) {
+            return new ErrorResponse(
+                { code: ErrorCodes.INVALID_INPUT, message: "Expected exactly one file." },
+                ErrorStatusCode.BAD_REQUEST
+            );
+        }
+        else {
+            let file = result.files[0];
+            if (file.contentType != 'application/pdf') {
+                return new ErrorResponse(
+                    { code: ErrorCodes.INVALID_INPUT, message: "Expected a PDF file" },
+                    ErrorStatusCode.BAD_REQUEST
+                );
+            }
+            else {
+                const command = new PutObjectCommand({
+                    Bucket: bucketName,
+                    Key: key,
+                    Body: file.content,
+                    ContentType: file.contentType
+                });
+                const response = await client.send(command);
+                console.log(response);
+                const now = new Date().toISOString();
+                const metadata: FileMetadata = {
+                    id: key,
+                    created_at: now,
+                    updated_at: now,
+                    status: FileScanStatus.Pending,
+                    size: file.content.length,
+                    name: file.filename
+                };
+                return new ApiSuccessResponse<FileMetadata>(metadata, SuccessStatusCode.CREATED);
+            }
+        }
+
+    } catch (err) {
+        console.log("Unexpected error: " + err);
+        return new ErrorResponse(
+            { code: ErrorCodes.OTHER, message: "Unexpected error" },
+            ErrorStatusCode.INTERNAL_SERVER_ERROR
+        );
+    }
+
+};

--- a/packages/api/taskOrderFiles/createTaskOrderFile.ts
+++ b/packages/api/taskOrderFiles/createTaskOrderFile.ts
@@ -1,10 +1,10 @@
-import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
-import {v4 as uuid} from "uuid";
-import {ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode} from "../utils/response";
-import {PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
-import {FileMetadata, FileScanStatus} from "../models/FileMetadata";
-import * as parser from "lambda-multipart-parser"
-import {ErrorCodes} from "../models/Error";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { v4 as uuid } from "uuid";
+import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../utils/response";
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { FileMetadata, FileScanStatus } from "../models/FileMetadata";
+import * as parser from "lambda-multipart-parser";
+import { ErrorCodes } from "../models/Error";
 
 const bucketName = process.env.PENDING_BUCKET;
 
@@ -14,53 +14,51 @@ const bucketName = process.env.PENDING_BUCKET;
  * @param event - The POST request from API Gateway
  */
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    const key = uuid();
-    const client = new S3Client({});
-
-    try {
-        const result = await parser.parse(event);
-        if (result.files.length != 1) {
-            return new ErrorResponse(
-                { code: ErrorCodes.INVALID_INPUT, message: "Expected exactly one file." },
-                ErrorStatusCode.BAD_REQUEST
-            );
-        }
-        else {
-            let file = result.files[0];
-            if (file.contentType != 'application/pdf') {
-                return new ErrorResponse(
-                    { code: ErrorCodes.INVALID_INPUT, message: "Expected a PDF file" },
-                    ErrorStatusCode.BAD_REQUEST
-                );
-            }
-            else {
-                const command = new PutObjectCommand({
-                    Bucket: bucketName,
-                    Key: key,
-                    Body: file.content,
-                    ContentType: file.contentType
-                });
-                const response = await client.send(command);
-                console.log(response);
-                const now = new Date().toISOString();
-                const metadata: FileMetadata = {
-                    id: key,
-                    created_at: now,
-                    updated_at: now,
-                    status: FileScanStatus.Pending,
-                    size: file.content.length,
-                    name: file.filename
-                };
-                return new ApiSuccessResponse<FileMetadata>(metadata, SuccessStatusCode.CREATED);
-            }
-        }
-
-    } catch (err) {
+  const result = await parser.parse(event);
+  if (result.files.length !== 1) {
+    return new ErrorResponse(
+      { code: ErrorCodes.INVALID_INPUT, message: "Expected exactly one file." },
+      ErrorStatusCode.BAD_REQUEST
+    );
+  } else {
+    const file = result.files[0];
+    if (file.contentType !== "application/pdf") {
+      return new ErrorResponse(
+        { code: ErrorCodes.INVALID_INPUT, message: "Expected a PDF file" },
+        ErrorStatusCode.BAD_REQUEST
+      );
+    } else {
+      try {
+        return await uploadFile(file);
+      } catch (err) {
         console.log("Unexpected error: " + err);
         return new ErrorResponse(
-            { code: ErrorCodes.OTHER, message: "Unexpected error" },
-            ErrorStatusCode.INTERNAL_SERVER_ERROR
+          { code: ErrorCodes.OTHER, message: "Unexpected error" },
+          ErrorStatusCode.INTERNAL_SERVER_ERROR
         );
+      }
     }
+  }
+};
 
+const uploadFile = async (file: parser.MultipartFile) => {
+  const client = new S3Client({});
+  const key = uuid();
+  const command = new PutObjectCommand({
+    Bucket: bucketName,
+    Key: key,
+    Body: file.content,
+    ContentType: file.contentType,
+  });
+  await client.send(command);
+  const now = new Date().toISOString();
+  const metadata: FileMetadata = {
+    id: key,
+    created_at: now,
+    updated_at: now,
+    status: FileScanStatus.PENDING,
+    size: file.content.length,
+    name: file.filename,
+  };
+  return new ApiSuccessResponse<FileMetadata>(metadata, SuccessStatusCode.CREATED);
 };


### PR DESCRIPTION
Implementation will take a file (with Content-Type: multipart/form) and save it off to the Pending S3 Bucket. A few notes:

1) There's a hard limit per request of 10MB because we have to go through API Gateway,. This should be OK given that our average PDF size is 100KB and max is 2MB.
2) We have raised the timeout from the default of 3s to 300s to accommodate very slow connections. No need to prematurely kill our lambdas here.

Ticket: AT-6417