### PR TITLE
Add reusable instances of ErrorResponse for use across functions

### DIFF
--- a/packages/api/portfolioDrafts/funding/createFundingStep.ts
+++ b/packages/api/portfolioDrafts/funding/createFundingStep.ts
@@ -1,20 +1,18 @@
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { ErrorCodes } from "../../models/Error";
 import { FundingStep } from "../../models/FundingStep";
 import { dynamodbClient as client } from "../../utils/dynamodb";
-import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
+import {
+  ApiSuccessResponse,
+  SuccessStatusCode,
+  DATABASE_ERROR,
+  NO_SUCH_PORTFOLIO_DRAFT,
+  REQUEST_BODY_EMPTY,
+  REQUEST_BODY_INVALID,
+} from "../../utils/response";
 import { isFundingStep, isValidJson } from "../../utils/validation";
 
 const TABLE_NAME = process.env.ATAT_TABLE_NAME;
-const NO_SUCH_PORTFOLIO_DRAFT = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "Portfolio Draft with the given ID does not exist" },
-  ErrorStatusCode.NOT_FOUND
-);
-const REQUEST_BODY_INVALID = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "A valid FundingStep object must be provided" },
-  ErrorStatusCode.BAD_REQUEST
-);
 
 /**
  * Submits the Funding Step of the Portfolio Draft Wizard
@@ -23,10 +21,7 @@ const REQUEST_BODY_INVALID = new ErrorResponse(
  */
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   if (!event.body) {
-    return new ErrorResponse(
-      { code: ErrorCodes.INVALID_INPUT, message: "Request body must not be empty" },
-      ErrorStatusCode.BAD_REQUEST
-    );
+    return REQUEST_BODY_EMPTY;
   }
 
   const portfolioDraftId = event.pathParameters?.portfolioDraftId;
@@ -69,10 +64,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       return NO_SUCH_PORTFOLIO_DRAFT;
     }
     console.error("Database error: " + error);
-    return new ErrorResponse(
-      { code: ErrorCodes.OTHER, message: "Database error" },
-      ErrorStatusCode.INTERNAL_SERVER_ERROR
-    );
+    return DATABASE_ERROR;
   }
   return new ApiSuccessResponse<FundingStep>(fundingStep, SuccessStatusCode.CREATED);
 };

--- a/packages/api/portfolioDrafts/funding/createFundingStep.ts
+++ b/packages/api/portfolioDrafts/funding/createFundingStep.ts
@@ -2,14 +2,8 @@ import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { FundingStep } from "../../models/FundingStep";
 import { dynamodbClient as client } from "../../utils/dynamodb";
-import {
-  ApiSuccessResponse,
-  SuccessStatusCode,
-  DATABASE_ERROR,
-  NO_SUCH_PORTFOLIO_DRAFT,
-  REQUEST_BODY_EMPTY,
-  REQUEST_BODY_INVALID,
-} from "../../utils/response";
+import { DATABASE_ERROR, NO_SUCH_PORTFOLIO_DRAFT, REQUEST_BODY_EMPTY, REQUEST_BODY_INVALID } from "../../utils/errors";
+import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
 import { isFundingStep, isValidJson } from "../../utils/validation";
 
 const TABLE_NAME = process.env.ATAT_TABLE_NAME;

--- a/packages/api/utils/errors.ts
+++ b/packages/api/utils/errors.ts
@@ -1,0 +1,83 @@
+import { ErrorCodes } from "../models/Error";
+import { ErrorStatusCode, ErrorResponse } from "./response";
+
+/**
+ * To be used when a database error occurs.  Hides error/implementation details.
+ */
+export const DATABASE_ERROR = new ErrorResponse(
+  { code: ErrorCodes.OTHER, message: "Database error" },
+  ErrorStatusCode.INTERNAL_SERVER_ERROR
+);
+
+/**
+ * To be used when a request body is required but was not provided
+ */
+export const REQUEST_BODY_EMPTY = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Request body must not be empty" },
+  ErrorStatusCode.BAD_REQUEST
+);
+
+/**
+ * To be used when a request body exists but is invalid
+ * Could be invalid because:
+ *  - request body is not of the expected Content-Type (for example, application/json, or application/pdf)
+ *  - is not valid JSON / PDF
+ *  - when JSON, is not of the expected type (for example, doesn't look like PortfolioStep/FundingStep/ApplicationStep)
+ */
+export const REQUEST_BODY_INVALID = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "A valid request body must be provided" },
+  ErrorStatusCode.BAD_REQUEST
+);
+
+/**
+ * To be used when a request parameter exists but is invalid
+ * Could be invalid because:
+ *  - has the wrong form (for example, uuid or date expected but won't parse)
+ *  - is out of range (for example, integer not in the accepted range)
+ */
+export const QUERY_PARAM_INVALID = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Invalid request parameter" },
+  ErrorStatusCode.BAD_REQUEST
+);
+
+/**
+ * To be used when an expected path variable exists but is invalid
+ * Could be invalid because:
+ *  - has the wrong form (for example, uuid expected but won't parse)
+ */
+export const PATH_VARIABLE_INVALID = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Invalid path variable" },
+  ErrorStatusCode.BAD_REQUEST
+);
+
+/**
+ * To be used when the specified Portfolio Draft is not found
+ */
+export const NO_SUCH_PORTFOLIO_DRAFT = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Portfolio Draft with the given ID does not exist" },
+  ErrorStatusCode.NOT_FOUND
+);
+
+/**
+ * To be used when a Portfolio Step is not found for a specified Portfolio Draft
+ */
+export const NO_SUCH_PORTFOLIO_STEP = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Portfolio Step not found for this Portfolio Draft" },
+  ErrorStatusCode.NOT_FOUND
+);
+
+/**
+ * To be used when a Funding Step is not found for a specified Portfolio Draft
+ */
+export const NO_SUCH_FUNDING_STEP = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Funding Step not found for this Portfolio Draft" },
+  ErrorStatusCode.NOT_FOUND
+);
+
+/**
+ * To be used when a Application Step is not found for a specified Portfolio Draft
+ */
+export const NO_SUCH_APPLICATION_STEP = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Application Step not found for this Portfolio Draft" },
+  ErrorStatusCode.NOT_FOUND
+);

--- a/packages/api/utils/response.ts
+++ b/packages/api/utils/response.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyResult } from "aws-lambda";
-import { Error, ErrorCodes } from "../models/Error";
+import { Error } from "../models/Error";
 
 type Headers = { [header: string]: string | number | boolean } | undefined;
 type MultiValueHeaders = { [header: string]: (string | number | boolean)[] } | undefined;
@@ -137,84 +137,3 @@ export class ErrorResponse extends Response {
     super(JSON.stringify(error), statusCode, headers, multiValueHeaders, false);
   }
 }
-
-/**
- * To be used when a database error occurs.  Hides error/implementation details.
- */
-export const DATABASE_ERROR = new ErrorResponse(
-  { code: ErrorCodes.OTHER, message: "Database error" },
-  ErrorStatusCode.INTERNAL_SERVER_ERROR
-);
-
-/**
- * To be used when a request body is required but was not provided
- */
-export const REQUEST_BODY_EMPTY = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "Request body must not be empty" },
-  ErrorStatusCode.BAD_REQUEST
-);
-
-/**
- * To be used when a request body exists but is invalid
- * Could be invalid because:
- *  - request body is not of the expected Content-Type (for example, application/json, or application/pdf)
- *  - is not valid JSON / PDF
- *  - when JSON, is not of the expected type (for example, doesn't look like PortfolioStep/FundingStep/ApplicationStep)
- */
-export const REQUEST_BODY_INVALID = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "A valid request body must be provided" },
-  ErrorStatusCode.BAD_REQUEST
-);
-
-/**
- * To be used when a request parameter exists but is invalid
- * Could be invalid because:
- *  - has the wrong form (for example, uuid or date expected but won't parse)
- *  - is out of range (for example, integer not in the accepted range)
- */
-export const QUERY_PARAM_INVALID = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "Invalid request parameter" },
-  ErrorStatusCode.BAD_REQUEST
-);
-
-/**
- * To be used when an expected path variable exists but is invalid
- * Could be invalid because:
- *  - has the wrong form (for example, uuid expected but won't parse)
- */
-export const PATH_VARIABLE_INVALID = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "Invalid path variable" },
-  ErrorStatusCode.BAD_REQUEST
-);
-
-/**
- * To be used when the specified Portfolio Draft is not found
- */
-export const NO_SUCH_PORTFOLIO_DRAFT = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "Portfolio Draft with the given ID does not exist" },
-  ErrorStatusCode.NOT_FOUND
-);
-
-/**
- * To be used when a Portfolio Step is not found for a specified Portfolio Draft
- */
-export const NO_SUCH_PORTFOLIO_STEP = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "Portfolio Step not found for this Portfolio Draft" },
-  ErrorStatusCode.NOT_FOUND
-);
-
-/**
- * To be used when a Funding Step is not found for a specified Portfolio Draft
- */
-export const NO_SUCH_FUNDING_STEP = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "Funding Step not found for this Portfolio Draft" },
-  ErrorStatusCode.NOT_FOUND
-);
-
-/**
- * To be used when a Application Step is not found for a specified Portfolio Draft
- */
-export const NO_SUCH_APPLICATION_STEP = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "Application Step not found for this Portfolio Draft" },
-  ErrorStatusCode.NOT_FOUND
-);

--- a/packages/api/utils/response.ts
+++ b/packages/api/utils/response.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyResult } from "aws-lambda";
-import { Error } from "../models/Error";
+import { Error, ErrorCodes } from "../models/Error";
 
 type Headers = { [header: string]: string | number | boolean } | undefined;
 type MultiValueHeaders = { [header: string]: (string | number | boolean)[] } | undefined;
@@ -137,3 +137,84 @@ export class ErrorResponse extends Response {
     super(JSON.stringify(error), statusCode, headers, multiValueHeaders, false);
   }
 }
+
+/**
+ * To be used when a database error occurs.  Hides error/implementation details.
+ */
+export const DATABASE_ERROR = new ErrorResponse(
+  { code: ErrorCodes.OTHER, message: "Database error" },
+  ErrorStatusCode.INTERNAL_SERVER_ERROR
+);
+
+/**
+ * To be used when a request body is required but was not provided
+ */
+export const REQUEST_BODY_EMPTY = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Request body must not be empty" },
+  ErrorStatusCode.BAD_REQUEST
+);
+
+/**
+ * To be used when a request body exists but is invalid
+ * Could be invalid because:
+ *  - request body is not of the expected Content-Type (for example, application/json, or application/pdf)
+ *  - is not valid JSON / PDF
+ *  - when JSON, is not of the expected type (for example, doesn't look like PortfolioStep/FundingStep/ApplicationStep)
+ */
+export const REQUEST_BODY_INVALID = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "A valid request body must be provided" },
+  ErrorStatusCode.BAD_REQUEST
+);
+
+/**
+ * To be used when a request parameter exists but is invalid
+ * Could be invalid because:
+ *  - has the wrong form (for example, uuid or date expected but won't parse)
+ *  - is out of range (for example, integer not in the accepted range)
+ */
+export const QUERY_PARAM_INVALID = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Invalid request parameter" },
+  ErrorStatusCode.BAD_REQUEST
+);
+
+/**
+ * To be used when an expected path variable exists but is invalid
+ * Could be invalid because:
+ *  - has the wrong form (for example, uuid expected but won't parse)
+ */
+export const PATH_VARIABLE_INVALID = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Invalid path variable" },
+  ErrorStatusCode.BAD_REQUEST
+);
+
+/**
+ * To be used when the specified Portfolio Draft is not found
+ */
+export const NO_SUCH_PORTFOLIO_DRAFT = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Portfolio Draft with the given ID does not exist" },
+  ErrorStatusCode.NOT_FOUND
+);
+
+/**
+ * To be used when a Portfolio Step is not found for a specified Portfolio Draft
+ */
+export const NO_SUCH_PORTFOLIO_STEP = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Portfolio Step not found for this Portfolio Draft" },
+  ErrorStatusCode.NOT_FOUND
+);
+
+/**
+ * To be used when a Funding Step is not found for a specified Portfolio Draft
+ */
+export const NO_SUCH_FUNDING_STEP = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Funding Step not found for this Portfolio Draft" },
+  ErrorStatusCode.NOT_FOUND
+);
+
+/**
+ * To be used when a Application Step is not found for a specified Portfolio Draft
+ */
+export const NO_SUCH_APPLICATION_STEP = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Application Step not found for this Portfolio Draft" },
+  ErrorStatusCode.NOT_FOUND
+);


### PR DESCRIPTION
- Added reusable instances of `ErrorResponse` for use across functions to new `errors` module
- Applied same to `createFundingStep` function

Ticket: AT-6409