### PR TITLE
Implement 'deleteTaskOrderFile` function

### DIFF
--- a/packages/api/taskOrderFiles/deleteTaskOrderFile.ts
+++ b/packages/api/taskOrderFiles/deleteTaskOrderFile.ts
@@ -7,9 +7,9 @@ import * as parser from "lambda-multipart-parser";
 import { ErrorCodes } from "../models/Error";
 import { isPathParameterPresent } from "../utils/validation";
 
-const bucketName = process.env.PENDING_BUCKET;
+const bucketName = process.env.ACCEPTED_BUCKET;
 export const NO_SUCH_TASK_ORDER_FILE = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "TaskOrderNumber must be specified in the URL path" },
+  { code: ErrorCodes.INVALID_INPUT, message: "TaskOrderId must be specified in the URL path" },
   ErrorStatusCode.BAD_REQUEST
 );
 
@@ -19,13 +19,13 @@ export const NO_SUCH_TASK_ORDER_FILE = new ErrorResponse(
  * @param event - The DELETE request from API Gateway
  */
 export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
-  const taskOrderNumber = event.pathParameters?.taskOrderNumber;
-  if (!isPathParameterPresent(taskOrderNumber)) {
+  const taskOrderId = event.pathParameters?.taskOrderId;
+  if (!isPathParameterPresent(taskOrderId)) {
     return NO_SUCH_TASK_ORDER_FILE;
   }
 
   try {
-    await deleteFile(taskOrderNumber);
+    await deleteFile(taskOrderId);
   } catch (err) {
     console.log("Unexpected error: " + err);
     return new ErrorResponse(
@@ -36,11 +36,11 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   return new NoContentResponse();
 }
 
-async function deleteFile(taskOrderNumber: string): Promise<DeleteObjectCommandOutput> {
+async function deleteFile(taskOrderId: string): Promise<DeleteObjectCommandOutput> {
   const client = new S3Client({});
   const command = new DeleteObjectCommand({
     Bucket: bucketName,
-    Key: taskOrderNumber,
+    Key: taskOrderId,
   });
   const result = await client.send(command);
   return result;

--- a/packages/api/taskOrderFiles/deleteTaskOrderFile.ts
+++ b/packages/api/taskOrderFiles/deleteTaskOrderFile.ts
@@ -14,12 +14,11 @@ export const NO_SUCH_TASK_ORDER_FILE = new ErrorResponse(
 );
 
 /**
- * Creates a new Task Order File
+ * Delete a Task Order File
  *
- * @param event - The POST request from API Gateway
+ * @param event - The DELETE request from API Gateway
  */
 export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
-  // const result = await parser.parse(event);
   const taskOrderNumber = event.pathParameters?.taskOrderNumber;
   if (!isPathParameterPresent(taskOrderNumber)) {
     return NO_SUCH_TASK_ORDER_FILE;

--- a/packages/api/taskOrderFiles/deleteTaskOrderFile.ts
+++ b/packages/api/taskOrderFiles/deleteTaskOrderFile.ts
@@ -1,0 +1,48 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { v4 as uuid } from "uuid";
+import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, NoContentResponse } from "../utils/response";
+import { S3Client, DeleteObjectCommand, DeleteObjectCommandOutput } from "@aws-sdk/client-s3";
+import { FileMetadata, FileScanStatus } from "../models/FileMetadata";
+import * as parser from "lambda-multipart-parser";
+import { ErrorCodes } from "../models/Error";
+import { isPathParameterPresent } from "../utils/validation";
+
+const bucketName = process.env.PENDING_BUCKET;
+export const NO_SUCH_TASK_ORDER_FILE = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "TaskOrderNumber must be specified in the URL path" },
+  ErrorStatusCode.BAD_REQUEST
+);
+
+/**
+ * Creates a new Task Order File
+ *
+ * @param event - The POST request from API Gateway
+ */
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  // const result = await parser.parse(event);
+  const taskOrderNumber = event.pathParameters?.taskOrderNumber;
+  if (!isPathParameterPresent(taskOrderNumber)) {
+    return NO_SUCH_TASK_ORDER_FILE;
+  }
+
+  try {
+    await deleteFile(taskOrderNumber);
+  } catch (err) {
+    console.log("Unexpected error: " + err);
+    return new ErrorResponse(
+      { code: ErrorCodes.OTHER, message: "Unexpected error" },
+      ErrorStatusCode.INTERNAL_SERVER_ERROR
+    );
+  }
+  return new NoContentResponse();
+}
+
+async function deleteFile(taskOrderNumber: string): Promise<DeleteObjectCommandOutput> {
+  const client = new S3Client({});
+  const command = new DeleteObjectCommand({
+    Bucket: bucketName,
+    Key: taskOrderNumber,
+  });
+  const result = await client.send(command);
+  return result;
+}


### PR DESCRIPTION
### Overview
Ticket: AT-6418

### Problems
There is no way to check if an object has been deleted with a single `DeleteObjectCommand`. This means we will need to make a `GetObjectCommand` or  `HeadObjectCommand` to check if it exists as part of the function. 
[HeadObjectCommand docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/classes/headobjectcommand.html)
However, this solution is a problem because S3 has eventually consistent deletes, and a `GetObjectCommand` or  `HeadObjectCommand` may return a false positive.
A solution with versioning may be viable if we rework how we are creating the S3 bucket, but for now this PR only deletes the object in the bucket and **does not** check if it exists before doing so.