### PR TITLE
Add missing 404 status to POST for ApplicationStep

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -289,6 +289,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ValidationError'
+        '404':
+          description: Portfolio Draft with the given ID does not exist
       requestBody:
         description: Input data from the Application Step of the Portfolio Draft Wizard.
         required: true


### PR DESCRIPTION
Add missing 404 status to POST `/portfolioDrafts/{portfolioDraftId}/application`

@hannahposeyscholl-ccpo Noted this was missing in the ticket.

Ticket: AT-6467