### PR TITLE
Implement function 'GetApplicationStep'

### DIFF
--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -75,6 +75,7 @@ export class AtatWebApiStack extends cdk.Stack {
     const portfolioDraftId = portfolioDrafts.addResource("{portfolioDraftId}");
     const portfolio = portfolioDraftId.addResource("portfolio");
     const funding = portfolioDraftId.addResource("funding");
+    const application = portfolioDraftId.addResource("application");
     // OperationIds from API spec are used to identify functions below
 
     const createPortfolioDraft = new ApiDynamoDBFunction(this, "CreatePortfolioDraft", {
@@ -126,8 +127,14 @@ export class AtatWebApiStack extends cdk.Stack {
       handlerPath: packageRoot() + "/api/portfolioDrafts/funding/getFundingStep.ts",
     });
 
+    const getApplicationStep = new ApiDynamoDBFunction(this, "GetApplicationStep", {
+      resource: application,
+      table: table,
+      method: HttpMethod.GET,
+      handlerPath: packageRoot() + "/api/portfolioDrafts/application/getApplicationStep.ts",
+    });
+
     // TODO: getPortfolioDraft
-    // TODO: getApplicationStep
     // TODO: createApplicationStep
     // TODO: submitPortfolioDraft
     addTaskOrderRoutes(this, restApi);

--- a/packages/api/models/AccessLevel.ts
+++ b/packages/api/models/AccessLevel.ts
@@ -1,0 +1,4 @@
+export enum AccessLevel {
+  ADMINISTRATOR = "administrator",
+  READ_ONLY = "read_only",
+}

--- a/packages/api/models/ApplicationStep.ts
+++ b/packages/api/models/ApplicationStep.ts
@@ -1,0 +1,6 @@
+import { Environment } from "./Environment";
+export interface ApplicationStep {
+  name: string;
+  description: string;
+  emvironments: Array<Environment>;
+}

--- a/packages/api/models/ApplicationStep.ts
+++ b/packages/api/models/ApplicationStep.ts
@@ -2,5 +2,5 @@ import { Environment } from "./Environment";
 export interface ApplicationStep {
   name: string;
   description: string;
-  emvironments: Array<Environment>;
+  environments: Array<Environment>;
 }

--- a/packages/api/models/Environment.ts
+++ b/packages/api/models/Environment.ts
@@ -1,0 +1,5 @@
+import { Operator } from "./Operator";
+export interface Environment {
+  name: string;
+  operators: Array<Operator>;
+}

--- a/packages/api/models/FileMetadata.ts
+++ b/packages/api/models/FileMetadata.ts
@@ -1,4 +1,5 @@
 import { BaseDocument } from "./BaseDocument";
+import { FileMetadataSummary } from "./FileMetadataSummary";
 
 export enum FileScanStatus {
   PENDING = "pending",
@@ -6,8 +7,7 @@ export enum FileScanStatus {
   REJECTED = "rejected",
 }
 
-export interface FileMetadata extends BaseDocument {
-  name: string;
+export interface FileMetadata extends BaseDocument, FileMetadataSummary {
   size: number;
   status: FileScanStatus;
 }

--- a/packages/api/models/Operator.ts
+++ b/packages/api/models/Operator.ts
@@ -1,0 +1,7 @@
+import { AccessLevel } from "./AccessLevel";
+export interface Operator {
+  first_name: string;
+  last_name: string;
+  email: string;
+  access: AccessLevel;
+}

--- a/packages/api/models/PortfolioDraft.ts
+++ b/packages/api/models/PortfolioDraft.ts
@@ -1,6 +1,10 @@
-import { PortfolioStep } from "./PortfolioStep";
 import { PortfolioDraftSummary } from "./PortfolioDraftSummary";
+import { PortfolioStep } from "./PortfolioStep";
+import { FundingStep } from "./FundingStep";
+import { ApplicationStep } from "./ApplicationStep";
 
 export interface PortfolioDraft extends PortfolioDraftSummary {
-  portfolio: PortfolioStep;
+  portfolio_step: PortfolioStep;
+  funding_step: FundingStep;
+  application_step: ApplicationStep;
 }

--- a/packages/api/models/PortfolioDraft.ts
+++ b/packages/api/models/PortfolioDraft.ts
@@ -3,8 +3,12 @@ import { PortfolioStep } from "./PortfolioStep";
 import { FundingStep } from "./FundingStep";
 import { ApplicationStep } from "./ApplicationStep";
 
+export const PORTFOLIO_STEP = "portfolio_step";
+export const FUNDING_STEP = "funding_step";
+export const APPLICATION_STEP = "application_step";
+
 export interface PortfolioDraft extends PortfolioDraftSummary {
-  portfolio_step: PortfolioStep;
-  funding_step: FundingStep;
-  application_step: ApplicationStep;
+  [PORTFOLIO_STEP]: PortfolioStep;
+  [FUNDING_STEP]: FundingStep;
+  [APPLICATION_STEP]: ApplicationStep;
 }

--- a/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
@@ -1,21 +1,132 @@
+import { AccessLevel } from "../../models/AccessLevel";
 import { APIGatewayProxyEvent } from "aws-lambda";
-// import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { ApplicationStep } from "../../models/ApplicationStep";
+import { Clin } from "../../models/Clin";
+import { CloudServiceProvider } from "../../models/CloudServiceProvider";
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { Environment } from "../../models/Environment";
 import { ErrorCodes } from "../../models/Error";
-import { ErrorStatusCode } from "../../utils/response";
-import { handler } from "./getApplicationStep";
-// import { mockClient } from "aws-sdk-client-mock";
-import { PATH_VARIABLE_REQUIRED_BUT_MISSING } from "../../utils/errors";
+import { ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
+import { FileMetadata, FileScanStatus } from "../../models/FileMetadata";
+import { FundingStep } from "../../models/FundingStep";
+import { getApplicationStep, handler } from "./getApplicationStep";
+import { isApplicationStep } from "../../utils/validation";
+import { mockClient } from "aws-sdk-client-mock";
+import { Operator } from "../../models/Operator";
+import { PortfolioDraft } from "../../models/PortfolioDraft";
+import { PortfolioStep } from "../../models/PortfolioStep";
+import { ProvisioningStatus } from "../../models/ProvisioningStatus";
 import { v4 as uuid } from "uuid";
+import {
+  NO_SUCH_PORTFOLIO_DRAFT,
+  PATH_VARIABLE_REQUIRED_BUT_MISSING,
+  DATABASE_ERROR,
+  PATH_VARIABLE_INVALID,
+} from "../../utils/errors";
 
+const ddbMock = mockClient(DynamoDBDocumentClient);
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+// Implementation of PortfolioDraftSummaryEx from API spec
+const mockOperatorDarthVader: Operator = {
+  first_name: "Darth",
+  last_name: "Vader",
+  email: "iam@yourfather.com",
+  access: AccessLevel.ADMINISTRATOR,
+};
+const mockOperatorHanSolo: Operator = {
+  first_name: "Han",
+  last_name: "Solo",
+  email: "frozen@carbonite.com",
+  access: AccessLevel.READ_ONLY,
+};
+const mockOperatorLukeSkywalker: Operator = {
+  first_name: "Luke",
+  last_name: "Skywalker",
+  email: "lostmy@hand.com",
+  access: AccessLevel.READ_ONLY,
+};
+const mockOperatorSalaciousCrumb: Operator = {
+  first_name: "Salacious",
+  last_name: "Crumb",
+  email: "monkey@lizard.com",
+  access: AccessLevel.ADMINISTRATOR,
+};
+const mockOperatorBobaFett: Operator = {
+  first_name: "Boba",
+  last_name: "Fett",
+  email: "original@mandalorian.com",
+  access: AccessLevel.READ_ONLY,
+};
+const mockEnvironmentCloudCity: Environment = {
+  name: "Cloud City",
+  operators: [mockOperatorDarthVader, mockOperatorHanSolo, mockOperatorLukeSkywalker],
+};
+const mockEnvironmentJabbasPalace: Environment = {
+  name: "Jabba's Palace",
+  operators: [mockOperatorSalaciousCrumb, mockOperatorHanSolo, mockOperatorBobaFett],
+};
+// const mockPortfolioStep: PortfolioStep = {
+//   name: "Mock Portfolio",
+//   description: "Mock portfolio description",
+//   dod_components: ["air_force", "army", "marine_corps", "navy", "space_force"],
+//   portfolio_managers: ["joe.manager@example.com", "jane.manager@example.com"],
+// };
+// const mockFileMetadata: FileMetadata = {
+//   id: "1234",
+//   created_at: "2021-08-03T16:21:07.978Z",
+//   updated_at: "2021-08-03T16:21:07.978Z",
+//   size: 100,
+//   name: "Mock task order file",
+//   status: FileScanStatus.PENDING,
+// };
+// const mockClin: Clin = {
+//   clin_number: "0001",
+//   idiq_clin: "1234",
+//   total_clin_value: 200000,
+//   obligated_funds: 10000,
+//   pop_start_date: "2021-09-01",
+//   pop_end_date: "2022-09-01",
+// };
+// const mockFundingStep: FundingStep = {
+//   task_order_number: "12345678910",
+//   task_order_file: mockFileMetadata,
+//   csp: CloudServiceProvider.AWS,
+//   clins: [mockClin],
+// };
+const mockApplicationStep: ApplicationStep = {
+  name: "Mock Application",
+  description: "The description of the Mock Application",
+  environments: [mockEnvironmentCloudCity, mockEnvironmentJabbasPalace],
+};
+// const now = new Date();
 const mockPortfolioDraftId = uuid();
+// const mockPortfolioDraft: PortfolioDraft = {
+//   updated_at: now.toISOString(),
+//   created_at: now.toISOString(),
+//   portfolio_step: mockPortfolioStep,
+//   funding_step: mockFundingStep,
+//   application_step: mockApplicationStep,
+//   num_portfolio_managers: 1,
+//   status: ProvisioningStatus.NOT_STARTED,
+//   id: mockPortfolioDraftId,
+// };
+
 const normalRequest: APIGatewayProxyEvent = {
   body: "",
   pathParameters: { portfolioDraftId: mockPortfolioDraftId },
 } as any;
 
 const missingPathVariableRequest: APIGatewayProxyEvent = {
-  body: "",
+  ...normalRequest,
   pathParameters: {}, // missing portfolioDraftId
+} as any;
+
+const invalidPathVariableRequest: APIGatewayProxyEvent = {
+  ...normalRequest,
+  pathParameters: { portfolioDraftId: "invalid_portfolio_draft_id" }, // invalid
 } as any;
 
 describe("TODO list", function () {
@@ -40,5 +151,50 @@ describe("when handler() does not receive required parameter 'portfolioDraftId'"
   it("should return a response body containing message 'Required path variable is missing'", async () => {
     const response = await handler(missingPathVariableRequest);
     expect(JSON.parse(response.body).message).toEqual("Required path variable is missing");
+  });
+});
+
+describe("when handler() receives an invalid 'portfolioDraftId'", function () {
+  it("should return error response PATH_VARIABLE_INVALID", async () => {
+    const response = await handler(invalidPathVariableRequest);
+    expect(response).toEqual(PATH_VARIABLE_INVALID);
+  });
+  it("should return HTTP response status code 400 Bad Request", async () => {
+    const response = await handler(invalidPathVariableRequest);
+    expect(response.statusCode).toEqual(ErrorStatusCode.BAD_REQUEST);
+  });
+  it("should return a response body containing code 'INVALID_INPUT'", async () => {
+    const response = await handler(invalidPathVariableRequest);
+    expect(JSON.parse(response.body).code).toEqual(ErrorCodes.INVALID_INPUT);
+  });
+  it("should return a response body containing message 'Invalid path variable'", async () => {
+    const response = await handler(invalidPathVariableRequest);
+    expect(JSON.parse(response.body).message).toEqual("Invalid path variable");
+  });
+});
+
+describe("getApplicationStep()", function () {
+  it("should return an object that looks like an Application Step given a valid portfolioDraftId", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: mockApplicationStep,
+    });
+    const data = await getApplicationStep(mockPortfolioDraftId);
+    expect(data.Item).toStrictEqual(mockApplicationStep);
+  });
+});
+
+describe("when handler() receives a valid 'portfolioDraftId' but the portfolio draft does not exist", function () {
+  it("should return an error response can not find that portfolio draft", async () => {
+    ddbMock.on(GetCommand).rejects({ name: "ResourceNotFoundException" });
+    const data = await handler(normalRequest);
+    expect(data).toEqual(NO_SUCH_PORTFOLIO_DRAFT);
+  });
+});
+
+describe("when handler() fails to service the request", function () {
+  it("should return database error when unknown internal problem occurs", async () => {
+    ddbMock.on(GetCommand).rejects({ name: "InternalServiceError" });
+    const data = await handler(normalRequest);
+    expect(data).toEqual(DATABASE_ERROR);
   });
 });

--- a/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
@@ -1,0 +1,44 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+// import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { ErrorCodes } from "../../models/Error";
+import { ErrorStatusCode } from "../../utils/response";
+import { handler } from "./getApplicationStep";
+// import { mockClient } from "aws-sdk-client-mock";
+import { PATH_VARIABLE_REQUIRED_BUT_MISSING } from "../../utils/errors";
+import { v4 as uuid } from "uuid";
+
+const mockPortfolioDraftId = uuid();
+const normalRequest: APIGatewayProxyEvent = {
+  body: "",
+  pathParameters: { portfolioDraftId: mockPortfolioDraftId },
+} as any;
+
+const missingPathVariableRequest: APIGatewayProxyEvent = {
+  body: "",
+  pathParameters: {}, // missing portfolioDraftId
+} as any;
+
+describe("TODO list", function () {
+  it.todo("should return http status 200 on happy path");
+  it.todo("should return http status 404 when Application Step not found the given Portfolio Draft");
+  it.todo("should return http status 404 when the given Portfolio Draft does not exist");
+});
+
+describe("when handler() does not receive required parameter 'portfolioDraftId'", function () {
+  it("should return error response PATH_VARIABLE_REQUIRED_BUT_MISSING", async () => {
+    const response = await handler(missingPathVariableRequest);
+    expect(response).toEqual(PATH_VARIABLE_REQUIRED_BUT_MISSING);
+  });
+  it("should return HTTP response status code 400 Bad Request", async () => {
+    const response = await handler(missingPathVariableRequest);
+    expect(response.statusCode).toEqual(ErrorStatusCode.BAD_REQUEST);
+  });
+  it("should return a response body containing code 'INVALID_INPUT'", async () => {
+    const response = await handler(missingPathVariableRequest);
+    expect(JSON.parse(response.body).code).toEqual(ErrorCodes.INVALID_INPUT);
+  });
+  it("should return a response body containing message 'Required path variable is missing'", async () => {
+    const response = await handler(missingPathVariableRequest);
+    expect(JSON.parse(response.body).message).toEqual("Required path variable is missing");
+  });
+});

--- a/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
@@ -1,21 +1,13 @@
 import { AccessLevel } from "../../models/AccessLevel";
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { ApplicationStep } from "../../models/ApplicationStep";
-import { Clin } from "../../models/Clin";
-import { CloudServiceProvider } from "../../models/CloudServiceProvider";
 import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 import { Environment } from "../../models/Environment";
 import { ErrorCodes } from "../../models/Error";
-import { ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
-import { FileMetadata, FileScanStatus } from "../../models/FileMetadata";
-import { FundingStep } from "../../models/FundingStep";
+import { ErrorStatusCode } from "../../utils/response";
 import { getApplicationStep, handler } from "./getApplicationStep";
-import { isApplicationStep } from "../../utils/validation";
 import { mockClient } from "aws-sdk-client-mock";
 import { Operator } from "../../models/Operator";
-import { PortfolioDraft } from "../../models/PortfolioDraft";
-import { PortfolioStep } from "../../models/PortfolioStep";
-import { ProvisioningStatus } from "../../models/ProvisioningStatus";
 import { v4 as uuid } from "uuid";
 import {
   NO_SUCH_PORTFOLIO_DRAFT,
@@ -69,51 +61,12 @@ const mockEnvironmentJabbasPalace: Environment = {
   name: "Jabba's Palace",
   operators: [mockOperatorSalaciousCrumb, mockOperatorHanSolo, mockOperatorBobaFett],
 };
-// const mockPortfolioStep: PortfolioStep = {
-//   name: "Mock Portfolio",
-//   description: "Mock portfolio description",
-//   dod_components: ["air_force", "army", "marine_corps", "navy", "space_force"],
-//   portfolio_managers: ["joe.manager@example.com", "jane.manager@example.com"],
-// };
-// const mockFileMetadata: FileMetadata = {
-//   id: "1234",
-//   created_at: "2021-08-03T16:21:07.978Z",
-//   updated_at: "2021-08-03T16:21:07.978Z",
-//   size: 100,
-//   name: "Mock task order file",
-//   status: FileScanStatus.PENDING,
-// };
-// const mockClin: Clin = {
-//   clin_number: "0001",
-//   idiq_clin: "1234",
-//   total_clin_value: 200000,
-//   obligated_funds: 10000,
-//   pop_start_date: "2021-09-01",
-//   pop_end_date: "2022-09-01",
-// };
-// const mockFundingStep: FundingStep = {
-//   task_order_number: "12345678910",
-//   task_order_file: mockFileMetadata,
-//   csp: CloudServiceProvider.AWS,
-//   clins: [mockClin],
-// };
 const mockApplicationStep: ApplicationStep = {
   name: "Mock Application",
   description: "The description of the Mock Application",
   environments: [mockEnvironmentCloudCity, mockEnvironmentJabbasPalace],
 };
-// const now = new Date();
 const mockPortfolioDraftId = uuid();
-// const mockPortfolioDraft: PortfolioDraft = {
-//   updated_at: now.toISOString(),
-//   created_at: now.toISOString(),
-//   portfolio_step: mockPortfolioStep,
-//   funding_step: mockFundingStep,
-//   application_step: mockApplicationStep,
-//   num_portfolio_managers: 1,
-//   status: ProvisioningStatus.NOT_STARTED,
-//   id: mockPortfolioDraftId,
-// };
 
 const normalRequest: APIGatewayProxyEvent = {
   body: "",
@@ -132,24 +85,14 @@ const invalidPathVariableRequest: APIGatewayProxyEvent = {
 
 describe("TODO list", function () {
   it.todo("should return http status 200 on happy path");
-  it.todo("should return http status 404 when the given Portfolio Draft does not exist");
 });
 
 describe("when handler() does not receive required parameter 'portfolioDraftId'", function () {
   it("should return error response PATH_VARIABLE_REQUIRED_BUT_MISSING", async () => {
     const response = await handler(missingPathVariableRequest);
     expect(response).toEqual(PATH_VARIABLE_REQUIRED_BUT_MISSING);
-  });
-  it("should return HTTP response status code 400 Bad Request", async () => {
-    const response = await handler(missingPathVariableRequest);
     expect(response.statusCode).toEqual(ErrorStatusCode.BAD_REQUEST);
-  });
-  it("should return a response body containing code 'INVALID_INPUT'", async () => {
-    const response = await handler(missingPathVariableRequest);
     expect(JSON.parse(response.body).code).toEqual(ErrorCodes.INVALID_INPUT);
-  });
-  it("should return a response body containing message 'Required path variable is missing'", async () => {
-    const response = await handler(missingPathVariableRequest);
     expect(JSON.parse(response.body).message).toEqual("Required path variable is missing");
   });
 });
@@ -158,28 +101,9 @@ describe("when handler() receives an invalid 'portfolioDraftId'", function () {
   it("should return error response PATH_VARIABLE_INVALID", async () => {
     const response = await handler(invalidPathVariableRequest);
     expect(response).toEqual(PATH_VARIABLE_INVALID);
-  });
-  it("should return HTTP response status code 400 Bad Request", async () => {
-    const response = await handler(invalidPathVariableRequest);
     expect(response.statusCode).toEqual(ErrorStatusCode.BAD_REQUEST);
-  });
-  it("should return a response body containing code 'INVALID_INPUT'", async () => {
-    const response = await handler(invalidPathVariableRequest);
     expect(JSON.parse(response.body).code).toEqual(ErrorCodes.INVALID_INPUT);
-  });
-  it("should return a response body containing message 'Invalid path variable'", async () => {
-    const response = await handler(invalidPathVariableRequest);
     expect(JSON.parse(response.body).message).toEqual("Invalid path variable");
-  });
-});
-
-describe("getApplicationStep()", function () {
-  it("should return an object that looks like an Application Step given a valid portfolioDraftId", async () => {
-    ddbMock.on(GetCommand).resolves({
-      Item: mockApplicationStep,
-    });
-    const response = await getApplicationStep(mockPortfolioDraftId);
-    expect(response.Item).toStrictEqual(mockApplicationStep);
   });
 });
 
@@ -190,6 +114,8 @@ describe("when handler() can not find the Application Step in the given Portfoli
     });
     const response = await handler(normalRequest);
     expect(response).toEqual(NO_SUCH_APPLICATION_STEP);
+    expect(response.statusCode).toEqual(ErrorStatusCode.NOT_FOUND);
+    expect(JSON.parse(response.body).message).toEqual("Application Step not found for this Portfolio Draft");
   });
 });
 
@@ -198,13 +124,30 @@ describe("when handler() can not find the given Portfolio Draft", function () {
     ddbMock.on(GetCommand).resolves({});
     const response = await handler(normalRequest);
     expect(response).toEqual(NO_SUCH_PORTFOLIO_DRAFT);
+    expect(response.statusCode).toEqual(ErrorStatusCode.NOT_FOUND);
+    expect(JSON.parse(response.body).message).toEqual("Portfolio Draft with the given ID does not exist");
   });
 });
 
 describe("when handler() fails to service the request", function () {
-  it("should return database error when unknown internal problem occurs", async () => {
+  it("should return error response DATABASE_ERROR when unknown internal problem occurs", async () => {
     ddbMock.on(GetCommand).rejects({ name: "InternalServiceError" });
-    const data = await handler(normalRequest);
-    expect(data).toEqual(DATABASE_ERROR);
+    const response = await handler(normalRequest);
+    expect(response).toEqual(DATABASE_ERROR);
+    expect(response.statusCode).toEqual(ErrorStatusCode.INTERNAL_SERVER_ERROR);
+    expect(JSON.parse(response.body).message).toEqual("Database error");
+  });
+});
+
+describe("when getApplicationStep() given a valid portfolioDraftId ", function () {
+  it("should return an object that looks like an Application Step", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: mockApplicationStep,
+    });
+    const response = await getApplicationStep(mockPortfolioDraftId);
+    expect(response.Item).toStrictEqual(mockApplicationStep);
+    expect(() => {
+      getApplicationStep(mockPortfolioDraftId);
+    }).not.toThrow();
   });
 });

--- a/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
@@ -193,6 +193,14 @@ describe("when handler() can not find the Application Step in the given Portfoli
   });
 });
 
+describe("when handler() can not find the given Portfolio Draft", function () {
+  it("should return error response NO_SUCH_PORTFOLIO_DRAFT", async () => {
+    ddbMock.on(GetCommand).resolves({});
+    const response = await handler(normalRequest);
+    expect(response).toEqual(NO_SUCH_PORTFOLIO_DRAFT);
+  });
+});
+
 describe("when handler() fails to service the request", function () {
   it("should return database error when unknown internal problem occurs", async () => {
     ddbMock.on(GetCommand).rejects({ name: "InternalServiceError" });

--- a/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
@@ -22,6 +22,7 @@ import {
   PATH_VARIABLE_REQUIRED_BUT_MISSING,
   DATABASE_ERROR,
   PATH_VARIABLE_INVALID,
+  NO_SUCH_APPLICATION_STEP,
 } from "../../utils/errors";
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
@@ -131,7 +132,6 @@ const invalidPathVariableRequest: APIGatewayProxyEvent = {
 
 describe("TODO list", function () {
   it.todo("should return http status 200 on happy path");
-  it.todo("should return http status 404 when Application Step not found the given Portfolio Draft");
   it.todo("should return http status 404 when the given Portfolio Draft does not exist");
 });
 
@@ -178,16 +178,18 @@ describe("getApplicationStep()", function () {
     ddbMock.on(GetCommand).resolves({
       Item: mockApplicationStep,
     });
-    const data = await getApplicationStep(mockPortfolioDraftId);
-    expect(data.Item).toStrictEqual(mockApplicationStep);
+    const response = await getApplicationStep(mockPortfolioDraftId);
+    expect(response.Item).toStrictEqual(mockApplicationStep);
   });
 });
 
-describe("when handler() receives a valid 'portfolioDraftId' but the portfolio draft does not exist", function () {
-  it("should return an error response can not find that portfolio draft", async () => {
-    ddbMock.on(GetCommand).rejects({ name: "ResourceNotFoundException" });
-    const data = await handler(normalRequest);
-    expect(data).toEqual(NO_SUCH_PORTFOLIO_DRAFT);
+describe("when handler() can not find the Application Step in the given Portfolio Draft", function () {
+  it("should return error response NO_SUCH_APPLICATION_STEP", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {},
+    });
+    const response = await handler(normalRequest);
+    expect(response).toEqual(NO_SUCH_APPLICATION_STEP);
   });
 });
 

--- a/packages/api/portfolioDrafts/application/getApplicationStep.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.ts
@@ -3,7 +3,12 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ApplicationStep } from "../../models/ApplicationStep";
 import { dynamodbDocumentClient as client } from "../../utils/dynamodb";
 import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
-import { DATABASE_ERROR, NO_SUCH_PORTFOLIO_DRAFT, NO_SUCH_APPLICATION_STEP } from "../../utils/errors";
+import {
+  DATABASE_ERROR,
+  NO_SUCH_PORTFOLIO_DRAFT,
+  NO_SUCH_APPLICATION_STEP,
+  PATH_VARIABLE_REQUIRED_BUT_MISSING,
+} from "../../utils/errors";
 
 export async function getApplicationStep(portfolioDraftId: string): Promise<GetCommandOutput> {
   return client.send(
@@ -25,7 +30,7 @@ export async function getApplicationStep(portfolioDraftId: string): Promise<GetC
 export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
   const portfolioDraftId = event.pathParameters?.portfolioDraftId;
   if (!portfolioDraftId) {
-    return NO_SUCH_PORTFOLIO_DRAFT;
+    return PATH_VARIABLE_REQUIRED_BUT_MISSING;
   }
   try {
     const data = await getApplicationStep(portfolioDraftId);

--- a/packages/api/portfolioDrafts/application/getApplicationStep.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.ts
@@ -1,15 +1,17 @@
-import { GetCommand, GetCommandOutput } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
+import { APPLICATION_STEP } from "../../models/PortfolioDraft";
 import { ApplicationStep } from "../../models/ApplicationStep";
 import { dynamodbDocumentClient as client } from "../../utils/dynamodb";
-import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
+import { GetCommand, GetCommandOutput } from "@aws-sdk/lib-dynamodb";
+import { isPathParameterPresent, isValidUuidV4 } from "../../utils/validation";
 import {
   DATABASE_ERROR,
   NO_SUCH_PORTFOLIO_DRAFT,
   NO_SUCH_APPLICATION_STEP,
   PATH_VARIABLE_REQUIRED_BUT_MISSING,
+  PATH_VARIABLE_INVALID,
 } from "../../utils/errors";
-import { APPLICATION_STEP } from "../../models/PortfolioDraft";
 
 export async function getApplicationStep(portfolioDraftId: string): Promise<GetCommandOutput> {
   return client.send(
@@ -30,19 +32,22 @@ export async function getApplicationStep(portfolioDraftId: string): Promise<GetC
  */
 export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
   const portfolioDraftId = event.pathParameters?.portfolioDraftId;
-  if (!portfolioDraftId) {
+  if (!isPathParameterPresent(portfolioDraftId)) {
     return PATH_VARIABLE_REQUIRED_BUT_MISSING;
+  }
+  if (!isValidUuidV4(portfolioDraftId)) {
+    return PATH_VARIABLE_INVALID;
   }
   try {
     const data = await getApplicationStep(portfolioDraftId);
-    if (!data.Item) {
-      return NO_SUCH_PORTFOLIO_DRAFT;
-    }
     if (!data.Item?.application_step) {
       return NO_SUCH_APPLICATION_STEP;
     }
     return new ApiSuccessResponse<ApplicationStep>(data.Item.application_step as ApplicationStep, SuccessStatusCode.OK);
   } catch (error) {
+    if (error.name === "ResourceNotFoundException") {
+      return NO_SUCH_PORTFOLIO_DRAFT;
+    }
     console.error("Database error: " + error);
     return DATABASE_ERROR;
   }

--- a/packages/api/portfolioDrafts/application/getApplicationStep.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.ts
@@ -40,14 +40,14 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   }
   try {
     const data = await getApplicationStep(portfolioDraftId);
+    if (!data.Item) {
+      return NO_SUCH_PORTFOLIO_DRAFT;
+    }
     if (!data.Item?.application_step) {
       return NO_SUCH_APPLICATION_STEP;
     }
     return new ApiSuccessResponse<ApplicationStep>(data.Item.application_step as ApplicationStep, SuccessStatusCode.OK);
   } catch (error) {
-    if (error.name === "ResourceNotFoundException") {
-      return NO_SUCH_PORTFOLIO_DRAFT;
-    }
     console.error("Database error: " + error);
     return DATABASE_ERROR;
   }

--- a/packages/api/portfolioDrafts/application/getApplicationStep.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.ts
@@ -1,0 +1,43 @@
+import { GetCommand, GetCommandOutput } from "@aws-sdk/lib-dynamodb";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { ApplicationStep } from "../../models/ApplicationStep";
+import { dynamodbDocumentClient as client } from "../../utils/dynamodb";
+import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
+import { DATABASE_ERROR, NO_SUCH_PORTFOLIO_DRAFT, NO_SUCH_APPLICATION_STEP } from "../../utils/errors";
+
+export async function getApplicationStep(portfolioDraftId: string): Promise<GetCommandOutput> {
+  return client.send(
+    new GetCommand({
+      TableName: process.env.ATAT_TABLE_NAME ?? "",
+      Key: {
+        id: portfolioDraftId,
+      },
+      ProjectionExpression: "application_step",
+    })
+  );
+}
+
+/**
+ * Gets the Application Step of the specified Portfolio Draft if it exists
+ *
+ * @param event - The GET request from API Gateway
+ */
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const portfolioDraftId = event.pathParameters?.portfolioDraftId;
+  if (!portfolioDraftId) {
+    return NO_SUCH_PORTFOLIO_DRAFT;
+  }
+  try {
+    const data = await getApplicationStep(portfolioDraftId);
+    if (!data.Item) {
+      return NO_SUCH_PORTFOLIO_DRAFT;
+    }
+    if (!data.Item?.application_step) {
+      return NO_SUCH_APPLICATION_STEP;
+    }
+    return new ApiSuccessResponse<ApplicationStep>(data.Item.application_step as ApplicationStep, SuccessStatusCode.OK);
+  } catch (error) {
+    console.error("Database error: " + error);
+    return DATABASE_ERROR;
+  }
+}

--- a/packages/api/portfolioDrafts/application/getApplicationStep.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.ts
@@ -9,6 +9,7 @@ import {
   NO_SUCH_APPLICATION_STEP,
   PATH_VARIABLE_REQUIRED_BUT_MISSING,
 } from "../../utils/errors";
+import { APPLICATION_STEP } from "../../models/PortfolioDraft";
 
 export async function getApplicationStep(portfolioDraftId: string): Promise<GetCommandOutput> {
   return client.send(
@@ -17,7 +18,7 @@ export async function getApplicationStep(portfolioDraftId: string): Promise<GetC
       Key: {
         id: portfolioDraftId,
       },
-      ProjectionExpression: "application_step",
+      ProjectionExpression: APPLICATION_STEP,
     })
   );
 }

--- a/packages/api/portfolioDrafts/funding/createFundingStep.ts
+++ b/packages/api/portfolioDrafts/funding/createFundingStep.ts
@@ -1,6 +1,7 @@
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { FundingStep } from "../../models/FundingStep";
+import { FUNDING_STEP } from "../../models/PortfolioDraft";
 import { dynamodbClient as client } from "../../utils/dynamodb";
 import { DATABASE_ERROR, NO_SUCH_PORTFOLIO_DRAFT, REQUEST_BODY_EMPTY, REQUEST_BODY_INVALID } from "../../utils/errors";
 import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
@@ -42,7 +43,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     },
     UpdateExpression: "set #portfolioVariable = :portfolio, updated_at = :now",
     ExpressionAttributeNames: {
-      "#portfolioVariable": "funding_step",
+      "#portfolioVariable": FUNDING_STEP,
     },
     ExpressionAttributeValues: {
       ":portfolio": fundingStep,

--- a/packages/api/portfolioDrafts/funding/getFundingStep.ts
+++ b/packages/api/portfolioDrafts/funding/getFundingStep.ts
@@ -1,6 +1,7 @@
 import { GetCommand, GetCommandOutput } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { FundingStep } from "../../models/FundingStep";
+import { FUNDING_STEP } from "../../models/PortfolioDraft";
 import { dynamodbDocumentClient as client } from "../../utils/dynamodb";
 import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
 import { DATABASE_ERROR, NO_SUCH_PORTFOLIO_DRAFT, NO_SUCH_FUNDING_STEP } from "../../utils/errors";
@@ -14,7 +15,7 @@ async function getFundingStepCommand(table: string, portfolioDraftId: string): P
       Key: {
         id: portfolioDraftId,
       },
-      ProjectionExpression: "funding_step",
+      ProjectionExpression: FUNDING_STEP,
     })
   );
   return result;

--- a/packages/api/portfolioDrafts/portfolio/createPortfolioStep.ts
+++ b/packages/api/portfolioDrafts/portfolio/createPortfolioStep.ts
@@ -3,6 +3,7 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, UpdateCommand, UpdateCommandOutput } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ErrorCodes } from "../../models/Error";
+import { PORTFOLIO_STEP } from "../../models/PortfolioDraft";
 import { PortfolioStep } from "../../models/PortfolioStep";
 import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
 import { isBodyPresent, isPathParameterPresent, isPortfolioStep, isValidJson } from "../../utils/validation";
@@ -78,7 +79,7 @@ export async function createPortfolioStepCommand(
       },
       UpdateExpression: "set #portfolioVariable = :portfolio, updated_at = :now",
       ExpressionAttributeNames: {
-        "#portfolioVariable": "portfolio_step",
+        "#portfolioVariable": PORTFOLIO_STEP,
       },
       ExpressionAttributeValues: {
         ":portfolio": portfolioStep,

--- a/packages/api/portfolioDrafts/portfolio/getPortfolioStep.ts
+++ b/packages/api/portfolioDrafts/portfolio/getPortfolioStep.ts
@@ -1,6 +1,7 @@
 import { GetCommand, GetCommandOutput } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ErrorCodes } from "../../models/Error";
+import { PORTFOLIO_STEP } from "../../models/PortfolioDraft";
 import { PortfolioStep } from "../../models/PortfolioStep";
 import { dynamodbDocumentClient as client } from "../../utils/dynamodb";
 import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
@@ -22,7 +23,7 @@ async function getPortfolioStepCommand(table: string, portfolioDraftId: string):
       Key: {
         id: portfolioDraftId,
       },
-      ProjectionExpression: "portfolio_step",
+      ProjectionExpression: PORTFOLIO_STEP,
     })
   );
   return result;

--- a/packages/api/utils/errors.ts
+++ b/packages/api/utils/errors.ts
@@ -51,6 +51,14 @@ export const PATH_VARIABLE_INVALID = new ErrorResponse(
 );
 
 /**
+ * To be used when a required path variable is not received (not present in path parameters)
+ */
+export const PATH_VARIABLE_REQUIRED_BUT_MISSING = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Required path variable is missing" },
+  ErrorStatusCode.BAD_REQUEST
+);
+
+/**
  * To be used when the specified Portfolio Draft is not found
  */
 export const NO_SUCH_PORTFOLIO_DRAFT = new ErrorResponse(

--- a/packages/api/utils/validation.ts
+++ b/packages/api/utils/validation.ts
@@ -1,6 +1,7 @@
 import { ApplicationStep } from "../models/ApplicationStep";
 import { FundingStep } from "../models/FundingStep";
 import { PortfolioStep } from "../models/PortfolioStep";
+import { version as uuidVersion, validate as uuidValidate } from "uuid";
 
 /**
  * Check whether a given string is valid JSON.
@@ -15,6 +16,15 @@ export function isValidJson(str: string): boolean {
     return false;
   }
   return true;
+}
+
+/**
+ * Check whether a given string is a valid v4 UUID.
+ * @param str - The string to check
+ * @returns true if the string is valid v4 UUID and false otherwise
+ */
+export function isValidUuidV4(str: string): boolean {
+  return uuidValidate(str) && uuidVersion(str) === 4;
 }
 
 /**

--- a/packages/api/utils/validation.ts
+++ b/packages/api/utils/validation.ts
@@ -1,3 +1,4 @@
+import { ApplicationStep } from "../models/ApplicationStep";
 import { FundingStep } from "../models/FundingStep";
 import { PortfolioStep } from "../models/PortfolioStep";
 
@@ -58,6 +59,22 @@ export function isFundingStep(object: unknown): object is FundingStep {
     return false;
   }
   return ["task_order_number", "task_order_file", "csp", "clins"].every((item) => item in object);
+}
+
+/**
+ * Check whether a given object is a {@link ApplicationStep}.
+ *
+ * Note that this only asserts that the given object meets the interface. It does not validate
+ * that the object is a valid {@link ApplicationStep}.
+ *
+ * @param object - The object to check
+ * @returns true if the object has all the attributes of a {@link ApplicationStep}
+ */
+export function isApplicationStep(object: unknown): object is ApplicationStep {
+  if (!isValidObject(object)) {
+    return false;
+  }
+  return ["name", "description", "environments"].every((item) => item in object);
 }
 
 /**


### PR DESCRIPTION
Implements function `GetApplicationStep`

- Adds models `ApplicationStep`, `Environment`, `Operator`, `AccessLevel`
- Updates existing models `PortfolioDraft`, `FileMetadata` per the API spec
- Adds step key constants `PORTFOLIO_STEP`, `FUNDING_STEP`, `APPLICATION_STEP` to model `PortfolioDraft` so they can be referenced by functions
- Updates existing functions to reference the aforementioned step key constants
- Defines function and adds to stack
- Adds GET method to new route '/portfolioDrafts/{portfolioDraftId}/application'
- Adds unit test for function

Ticket: AT-6466