### PR TITLE
Update 'FundingStepEx' to remove description

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -680,7 +680,6 @@ components:
       value:
         - task_order_number: "12345678910"
           task_order_file:
-            description: "Mock description"
             id: "1234"
             created_at: "2021-08-03T16:21:07.978Z"
             updated_at: "2021-08-03T16:21:07.978Z"
@@ -690,10 +689,10 @@ components:
           csp: 
             - "aws"
           clins: 
-            - clin_number:  "0001"
-              idiq_clin:  "1234"
-              total_clin_value:  200000
-              obligated_funds:  10000
+            - clin_number: "0001"
+              idiq_clin: "1234"
+              total_clin_value: 200000
+              obligated_funds: 10000
               pop_start_date: "2021-09-01"
               pop_end_date: "2022-09-01"
     ApplicationStepEx:


### PR DESCRIPTION
This updates the example data to remove a mistaken property named `description`.  Also removes stray space chars.

Schema `FileMetadata` contains no property `description`.
FileMetadata combines model definitions for both subschemas `BaseObject` (:504) and `FileMetadataSummary` (:505)
This yields a property list: `id`, `created_at`, `updated_at`, `id` (repeated), `name`, `size`, `status`

This was likely a misinterpretation of the description for property `task_order_file` (:563) of schema `FundingStep`.