### PR TITLE
Update TypeScript to 4.4.2

### DIFF
--- a/infrastructure/package-lock.json
+++ b/infrastructure/package-lock.json
@@ -16789,6 +16789,15 @@
 					"integrity": "sha512-wtUNIKNK80d/YDh04imshlvYV/e6+Z0fDrrbfImJzkwwFR3bdAOKafi8Fo2YsjzLYQiqwthVOZFv+Z2Oh6pBGA==",
 					"dev": true
 				},
+				"@jsii/check-node": {
+					"version": "1.33.0",
+					"resolved": "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.33.0.tgz#55d75cbef1c84e2012c67ab8d6de63f773be4a9b",
+					"integrity": "sha512-Bajxa09dhkuQ8bM1ve6qtm2oFNhW9/+GaKRh4Deewsk/G86ovLXI/rRS6TfCsSw4E0TGPFWzWy0tBeJuEDo7sw==",
+					"requires": {
+						"chalk": "^4.1.2",
+						"semver": "^7.3.5"
+					}
+				},
 				"@tootallnate/once": {
 					"version": "1.1.2",
 					"resolved": "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82",
@@ -16832,7 +16841,6 @@
 					"version": "4.3.0",
 					"resolved": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937",
 					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^2.0.1"
 					}
@@ -17044,6 +17052,726 @@
 						"glob": "^7.1.7",
 						"mime": "^2.5.2",
 						"yargs": "^16.2.0"
+					},
+					"dependencies": {
+						"@aws-cdk/cloud-assembly-schema": {
+							"version": "1.120.0",
+							"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.120.0.tgz",
+							"integrity": "sha512-W8CfFYLekobHxQ4on/mygfx8HOFIYverUl0LzvNMxzjpvOl5JQVRYG1azDDLRFomuLvw/6RZpJas8nDUi0y4oA==",
+							"dev": true,
+							"requires": {
+								"jsonschema": "^1.4.0",
+								"semver": "^7.3.5"
+							}
+						},
+						"@aws-cdk/cx-api": {
+							"version": "1.120.0",
+							"resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.120.0.tgz",
+							"integrity": "sha512-ETlLjWyHwLEWEoggTCFs+BVEIFtgxAUHjkVkgYPfqnqFl29C6kQqgcXuOlIfRgisImRSQnWlzHf+6Tse5nR5Jw==",
+							"dev": true,
+							"requires": {
+								"@aws-cdk/cloud-assembly-schema": "1.120.0",
+								"semver": "^7.3.5"
+							}
+						},
+						"ansi-regex": {
+							"version": "5.0.0",
+							"resolved": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75",
+							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+							"dev": true
+						},
+						"ansi-styles": {
+							"version": "4.3.0",
+							"resolved": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937",
+							"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+							"dev": true,
+							"requires": {
+								"color-convert": "^2.0.1"
+							}
+						},
+						"archiver": {
+							"version": "5.3.0",
+							"resolved": "https://registry.yarnpkg.com/archiver/-/archiver-5.3.0.tgz#dd3e097624481741df626267564f7dd8640a45ba",
+							"integrity": "sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==",
+							"dev": true,
+							"requires": {
+								"archiver-utils": "^2.1.0",
+								"async": "^3.2.0",
+								"buffer-crc32": "^0.2.1",
+								"readable-stream": "^3.6.0",
+								"readdir-glob": "^1.0.0",
+								"tar-stream": "^2.2.0",
+								"zip-stream": "^4.1.0"
+							}
+						},
+						"archiver-utils": {
+							"version": "2.1.0",
+							"resolved": "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-2.1.0.tgz#e8a460e94b693c3e3da182a098ca6285ba9249e2",
+							"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+							"dev": true,
+							"requires": {
+								"glob": "^7.1.4",
+								"graceful-fs": "^4.2.0",
+								"lazystream": "^1.0.0",
+								"lodash.defaults": "^4.2.0",
+								"lodash.difference": "^4.5.0",
+								"lodash.flatten": "^4.4.0",
+								"lodash.isplainobject": "^4.0.6",
+								"lodash.union": "^4.6.0",
+								"normalize-path": "^3.0.0",
+								"readable-stream": "^2.0.0"
+							},
+							"dependencies": {
+								"readable-stream": {
+									"version": "2.3.7",
+									"resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57",
+									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+									"dev": true,
+									"requires": {
+										"core-util-is": "~1.0.0",
+										"inherits": "~2.0.3",
+										"isarray": "~1.0.0",
+										"process-nextick-args": "~2.0.0",
+										"safe-buffer": "~5.1.1",
+										"string_decoder": "~1.1.1",
+										"util-deprecate": "~1.0.1"
+									}
+								}
+							}
+						},
+						"async": {
+							"version": "3.2.0",
+							"resolved": "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720",
+							"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+							"dev": true
+						},
+						"aws-sdk": {
+							"version": "2.950.0",
+							"resolved": "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.950.0.tgz#cffb65590c50de9479c87ed04df57d355d1d8a22",
+							"integrity": "sha512-iFC5fKLuFLEV27xeKmxDHDZzIDj4upm5+Ts3NpYYRbwPlOG0nE0gZzf9fRYkLkLgTr0TQq26CbKorgeo+6ailw==",
+							"dev": true,
+							"requires": {
+								"buffer": "4.9.2",
+								"events": "1.1.1",
+								"ieee754": "1.1.13",
+								"jmespath": "0.15.0",
+								"querystring": "0.2.0",
+								"sax": "1.2.1",
+								"url": "0.10.3",
+								"uuid": "3.3.2",
+								"xml2js": "0.4.19"
+							},
+							"dependencies": {
+								"buffer": {
+									"version": "4.9.2",
+									"resolved": "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8",
+									"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+									"dev": true,
+									"requires": {
+										"base64-js": "^1.0.2",
+										"ieee754": "^1.1.4",
+										"isarray": "^1.0.0"
+									},
+									"dependencies": {
+										"ieee754": {
+											"version": "1.2.1",
+											"resolved": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352",
+											"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+											"dev": true
+										}
+									}
+								},
+								"ieee754": {
+									"version": "1.1.13",
+									"resolved": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84",
+									"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+									"dev": true
+								}
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.2",
+							"resolved": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
+							"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+							"dev": true
+						},
+						"base64-js": {
+							"version": "1.5.1",
+							"resolved": "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a",
+							"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+							"dev": true
+						},
+						"bl": {
+							"version": "4.1.0",
+							"resolved": "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a",
+							"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+							"dev": true,
+							"requires": {
+								"buffer": "^5.5.0",
+								"inherits": "^2.0.4",
+								"readable-stream": "^3.4.0"
+							}
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"resolved": "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+							"dev": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"buffer": {
+							"version": "5.7.1",
+							"resolved": "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0",
+							"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+							"dev": true,
+							"requires": {
+								"base64-js": "^1.3.1",
+								"ieee754": "^1.1.13"
+							}
+						},
+						"buffer-crc32": {
+							"version": "0.2.13",
+							"resolved": "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242",
+							"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+							"dev": true
+						},
+						"cliui": {
+							"version": "7.0.4",
+							"resolved": "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f",
+							"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+							"dev": true,
+							"requires": {
+								"string-width": "^4.2.0",
+								"strip-ansi": "^6.0.0",
+								"wrap-ansi": "^7.0.0"
+							}
+						},
+						"color-convert": {
+							"version": "2.0.1",
+							"resolved": "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
+							"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+							"dev": true,
+							"requires": {
+								"color-name": "~1.1.4"
+							}
+						},
+						"color-name": {
+							"version": "1.1.4",
+							"resolved": "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2",
+							"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+							"dev": true
+						},
+						"compress-commons": {
+							"version": "4.1.1",
+							"resolved": "https://registry.yarnpkg.com/compress-commons/-/compress-commons-4.1.1.tgz#df2a09a7ed17447642bad10a85cc9a19e5c42a7d",
+							"integrity": "sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==",
+							"dev": true,
+							"requires": {
+								"buffer-crc32": "^0.2.13",
+								"crc32-stream": "^4.0.2",
+								"normalize-path": "^3.0.0",
+								"readable-stream": "^3.6.0"
+							}
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"resolved": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+							"dev": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"resolved": "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7",
+							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+							"dev": true
+						},
+						"crc-32": {
+							"version": "1.2.0",
+							"resolved": "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208",
+							"integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+							"dev": true,
+							"requires": {
+								"exit-on-epipe": "~1.0.1",
+								"printj": "~1.1.0"
+							}
+						},
+						"crc32-stream": {
+							"version": "4.0.2",
+							"resolved": "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-4.0.2.tgz#c922ad22b38395abe9d3870f02fa8134ed709007",
+							"integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
+							"dev": true,
+							"requires": {
+								"crc-32": "^1.2.0",
+								"readable-stream": "^3.4.0"
+							}
+						},
+						"emoji-regex": {
+							"version": "8.0.0",
+							"resolved": "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37",
+							"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+							"dev": true
+						},
+						"end-of-stream": {
+							"version": "1.4.4",
+							"resolved": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0",
+							"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+							"dev": true,
+							"requires": {
+								"once": "^1.4.0"
+							}
+						},
+						"escalade": {
+							"version": "3.1.1",
+							"resolved": "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40",
+							"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+							"dev": true
+						},
+						"events": {
+							"version": "1.1.1",
+							"resolved": "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924",
+							"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+							"dev": true
+						},
+						"exit-on-epipe": {
+							"version": "1.0.1",
+							"resolved": "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692",
+							"integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
+							"dev": true
+						},
+						"fs-constants": {
+							"version": "1.0.0",
+							"resolved": "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad",
+							"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+							"dev": true
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"resolved": "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f",
+							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+							"dev": true
+						},
+						"get-caller-file": {
+							"version": "2.0.5",
+							"resolved": "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e",
+							"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+							"dev": true
+						},
+						"glob": {
+							"version": "7.1.7",
+							"resolved": "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90",
+							"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+							"dev": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"graceful-fs": {
+							"version": "4.2.6",
+							"resolved": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee",
+							"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+							"dev": true
+						},
+						"ieee754": {
+							"version": "1.2.1",
+							"resolved": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352",
+							"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+							"dev": true
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"resolved": "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+							"dev": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.4",
+							"resolved": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c",
+							"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "3.0.0",
+							"resolved": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d",
+							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+							"dev": true
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"dev": true
+						},
+						"jmespath": {
+							"version": "0.15.0",
+							"resolved": "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217",
+							"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+							"dev": true
+						},
+						"jsonschema": {
+							"version": "1.4.0",
+							"resolved": "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.0.tgz#1afa34c4bc22190d8e42271ec17ac8b3404f87b2",
+							"integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==",
+							"dev": true
+						},
+						"lazystream": {
+							"version": "1.0.0",
+							"resolved": "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4",
+							"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+							"dev": true,
+							"requires": {
+								"readable-stream": "^2.0.5"
+							},
+							"dependencies": {
+								"readable-stream": {
+									"version": "2.3.7",
+									"resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57",
+									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+									"dev": true,
+									"requires": {
+										"core-util-is": "~1.0.0",
+										"inherits": "~2.0.3",
+										"isarray": "~1.0.0",
+										"process-nextick-args": "~2.0.0",
+										"safe-buffer": "~5.1.1",
+										"string_decoder": "~1.1.1",
+										"util-deprecate": "~1.0.1"
+									}
+								}
+							}
+						},
+						"lodash.defaults": {
+							"version": "4.2.0",
+							"resolved": "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c",
+							"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+							"dev": true
+						},
+						"lodash.difference": {
+							"version": "4.5.0",
+							"resolved": "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c",
+							"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+							"dev": true
+						},
+						"lodash.flatten": {
+							"version": "4.4.0",
+							"resolved": "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f",
+							"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+							"dev": true
+						},
+						"lodash.isplainobject": {
+							"version": "4.0.6",
+							"resolved": "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb",
+							"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+							"dev": true
+						},
+						"lodash.union": {
+							"version": "4.6.0",
+							"resolved": "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88",
+							"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+							"dev": true
+						},
+						"lru-cache": {
+							"version": "6.0.0",
+							"resolved": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94",
+							"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+							"dev": true,
+							"requires": {
+								"yallist": "^4.0.0"
+							}
+						},
+						"mime": {
+							"version": "2.5.2",
+							"resolved": "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe",
+							"integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+							"dev": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"resolved": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
+							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+							"dev": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"normalize-path": {
+							"version": "3.0.0",
+							"resolved": "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65",
+							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+							"dev": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"resolved": "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+							"dev": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"resolved": "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+							"dev": true
+						},
+						"printj": {
+							"version": "1.1.2",
+							"resolved": "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222",
+							"integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+							"dev": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.1",
+							"resolved": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2",
+							"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+							"dev": true
+						},
+						"punycode": {
+							"version": "1.3.2",
+							"resolved": "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d",
+							"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+							"dev": true
+						},
+						"querystring": {
+							"version": "0.2.0",
+							"resolved": "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620",
+							"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "3.6.0",
+							"resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+							"dev": true,
+							"requires": {
+								"inherits": "^2.0.3",
+								"string_decoder": "^1.1.1",
+								"util-deprecate": "^1.0.1"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.2.1",
+									"resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+									"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+									"dev": true
+								},
+								"string_decoder": {
+									"version": "1.3.0",
+									"resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+									"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+									"dev": true,
+									"requires": {
+										"safe-buffer": "~5.2.0"
+									}
+								}
+							}
+						},
+						"readdir-glob": {
+							"version": "1.1.1",
+							"resolved": "https://registry.yarnpkg.com/readdir-glob/-/readdir-glob-1.1.1.tgz#f0e10bb7bf7bfa7e0add8baffdc54c3f7dbee6c4",
+							"integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
+							"dev": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"require-directory": {
+							"version": "2.1.1",
+							"resolved": "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+							"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+							"dev": true
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+							"dev": true
+						},
+						"sax": {
+							"version": "1.2.1",
+							"resolved": "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a",
+							"integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+							"dev": true
+						},
+						"semver": {
+							"version": "7.3.5",
+							"resolved": "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7",
+							"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+							"dev": true,
+							"requires": {
+								"lru-cache": "^6.0.0"
+							}
+						},
+						"string-width": {
+							"version": "4.2.2",
+							"resolved": "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5",
+							"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^8.0.0",
+								"is-fullwidth-code-point": "^3.0.0",
+								"strip-ansi": "^6.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "6.0.0",
+							"resolved": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532",
+							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^5.0.0"
+							}
+						},
+						"tar-stream": {
+							"version": "2.2.0",
+							"resolved": "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287",
+							"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+							"dev": true,
+							"requires": {
+								"bl": "^4.0.3",
+								"end-of-stream": "^1.4.1",
+								"fs-constants": "^1.0.0",
+								"inherits": "^2.0.3",
+								"readable-stream": "^3.1.1"
+							}
+						},
+						"url": {
+							"version": "0.10.3",
+							"resolved": "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64",
+							"integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+							"dev": true,
+							"requires": {
+								"punycode": "1.3.2",
+								"querystring": "0.2.0"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"resolved": "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+							"dev": true
+						},
+						"uuid": {
+							"version": "3.3.2",
+							"resolved": "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131",
+							"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+							"dev": true
+						},
+						"wrap-ansi": {
+							"version": "7.0.0",
+							"resolved": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43",
+							"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.0.0",
+								"string-width": "^4.1.0",
+								"strip-ansi": "^6.0.0"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"resolved": "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+							"dev": true
+						},
+						"xml2js": {
+							"version": "0.4.19",
+							"resolved": "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7",
+							"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+							"dev": true,
+							"requires": {
+								"sax": ">=0.6.0",
+								"xmlbuilder": "~9.0.1"
+							},
+							"dependencies": {
+								"sax": {
+									"version": "1.2.4",
+									"resolved": "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9",
+									"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+									"dev": true
+								}
+							}
+						},
+						"xmlbuilder": {
+							"version": "9.0.7",
+							"resolved": "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d",
+							"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+							"dev": true
+						},
+						"y18n": {
+							"version": "5.0.8",
+							"resolved": "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55",
+							"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+							"dev": true
+						},
+						"yallist": {
+							"version": "4.0.0",
+							"resolved": "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72",
+							"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+							"dev": true
+						},
+						"yargs": {
+							"version": "16.2.0",
+							"resolved": "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66",
+							"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+							"dev": true,
+							"requires": {
+								"cliui": "^7.0.2",
+								"escalade": "^3.1.1",
+								"get-caller-file": "^2.0.5",
+								"require-directory": "^2.1.1",
+								"string-width": "^4.2.0",
+								"y18n": "^5.0.5",
+								"yargs-parser": "^20.2.2"
+							}
+						},
+						"yargs-parser": {
+							"version": "20.2.9",
+							"resolved": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee",
+							"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+							"dev": true
+						},
+						"zip-stream": {
+							"version": "4.1.0",
+							"resolved": "https://registry.yarnpkg.com/zip-stream/-/zip-stream-4.1.0.tgz#51dd326571544e36aa3f756430b313576dc8fc79",
+							"integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
+							"dev": true,
+							"requires": {
+								"archiver-utils": "^2.1.0",
+								"compress-commons": "^4.1.0",
+								"readable-stream": "^3.6.0"
+							}
+						}
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				},
 				"charenc": {
@@ -17076,7 +17804,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
 					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
 					"requires": {
 						"color-name": "~1.1.4"
 					}
@@ -17084,8 +17811,7 @@
 				"color-name": {
 					"version": "1.1.4",
 					"resolved": "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
 				"colors": {
 					"version": "1.4.0",
@@ -17427,6 +18153,11 @@
 					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
 					"dev": true
 				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
 				"heap": {
 					"version": "0.2.6",
 					"resolved": "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac",
@@ -17643,7 +18374,6 @@
 					"version": "6.0.0",
 					"resolved": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94",
 					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
@@ -17662,8 +18392,7 @@
 				"mime": {
 					"version": "2.5.2",
 					"resolved": "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe",
-					"integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
-					"dev": true
+					"integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
 				},
 				"minimatch": {
 					"version": "3.0.4",
@@ -17925,7 +18654,6 @@
 					"version": "7.3.5",
 					"resolved": "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7",
 					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -18023,6 +18751,14 @@
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^5.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
 					}
 				},
 				"table": {
@@ -18192,8 +18928,7 @@
 				"yallist": {
 					"version": "4.0.0",
 					"resolved": "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				},
 				"yaml": {
 					"version": "1.10.2",
@@ -22213,9 +22948,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+			"integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
 			"dev": true
 		},
 		"unbox-primitive": {

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -32,7 +32,7 @@
     "prettier": "^2.3.2",
     "ts-jest": "^27.0.4",
     "ts-node": "^10.2.0",
-    "typescript": "^4.3.5"
+    "typescript": "~4.4.2"
   },
   "dependencies": {
     "@aws-cdk/aws-apigateway": "1.119.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8758,9 +8758,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lerna": "^4.0.0",
     "prettier": "^2.3.2",
     "ts-node": "^10.2.0",
-    "typescript": "^4.3.5"
+    "typescript": "~4.4.2"
   },
   "dependencies": {
     "esbuild": "^0.12.17"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
     "resolveJsonModule": true,
+    "useUnknownInCatchVariables": false,
     "typeRoots": [
       "./node_modules/@types"
     ],


### PR DESCRIPTION
This binds typescript to a particular minor version. Since we're using
the `strict` flag, it seems like new updates may break our code so we
should do this in a more controlled way.

In this case, we should probably come back through and reconsider
whether to be more strict in our type checking on errors but that should
be done as part of a larger error handling ticket.