### PR TITLE
Rename 'taskOrderFiles' function definitions and implementation files using OperationIds from API spec

### DIFF
--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -138,21 +138,24 @@ function addTaskOrderRoutes(scope: cdk.Stack, restApi: apigw.RestApi) {
   const taskOrderFiles = restApi.root.addResource("taskOrderFiles");
   const taskOrderId = taskOrderFiles.addResource("{taskOrderId}");
   const taskOrderManagement = new TaskOrderLifecycle(scope, "TaskOrders");
-  const createTaskOrderFile = new ApiS3Function(scope, "CreateTaskOrderFile", {
+  // OperationIds from API spec are used to identify functions below
+
+  const uploadTaskOrder = new ApiS3Function(scope, "UploadTaskOrder", {
     resource: taskOrderFiles,
     bucket: taskOrderManagement.pendingBucket,
     method: HttpMethod.POST,
-    handlerPath: packageRoot() + "/api/taskOrderFiles/createTaskOrderFile.ts",
+    handlerPath: packageRoot() + "/api/taskOrderFiles/uploadTaskOrder.ts",
     functionPropsOverride: {
       memorySize: 256,
     },
   });
-  const deleteTaskOrderFile = new ApiS3Function(scope, "DeleteTaskOrderFile", {
+  const deleteTaskOrder = new ApiS3Function(scope, "DeleteTaskOrder", {
     resource: taskOrderId,
     bucket: taskOrderManagement.acceptedBucket,
     method: HttpMethod.DELETE,
-    handlerPath: packageRoot() + "/api/taskOrderFiles/deleteTaskOrderFile.ts",
+    handlerPath: packageRoot() + "/api/taskOrderFiles/deleteTaskOrder.ts",
   });
 
-  // TODO: getTaskOrderFiles
+  // TODO: getTaskOrder (for metadata)
+  // TODO: downloadTaskOrder
 }

--- a/packages/api/taskOrderFiles/README.md
+++ b/packages/api/taskOrderFiles/README.md
@@ -1,1 +1,0 @@
-Placeholder for /taskOrderFiles implementation

--- a/packages/api/taskOrderFiles/deleteTaskOrder.ts
+++ b/packages/api/taskOrderFiles/deleteTaskOrder.ts
@@ -11,7 +11,7 @@ export const NO_SUCH_TASK_ORDER_FILE = new ErrorResponse(
 );
 
 /**
- * Delete a Task Order File
+ * Deletes a Task Order PDF
  *
  * @param event - The DELETE request from API Gateway
  */

--- a/packages/api/taskOrderFiles/uploadTaskOrder.ts
+++ b/packages/api/taskOrderFiles/uploadTaskOrder.ts
@@ -9,7 +9,7 @@ import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode }
 const bucketName = process.env.DATA_BUCKET;
 
 /**
- * Creates a new Task Order File
+ * Uploads a Task Order PDF
  *
  * @param event - The POST request from API Gateway
  */


### PR DESCRIPTION
This is the approach is used for 'portfolioDrafts' functions.

I suggest API operation `getTaskOrder` be renamed `getTaskOrderMetadata`.  The current name is too easily confused with `downloadTaskOrder`.

Note that...
- we'd previously listed only three (3) of the four (4) operations in the stack definition file
- the old placeholder `getTaskOrderFiles` was clearly being conflated with `downloadTaskOrder`