### PR TITLE
Rename operation 'getTaskOrder' to 'getTaskOrderMetadata'

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -356,8 +356,8 @@ paths:
     get:
       tags:
         - taskOrder
-      description: Gets File Metadata for a Task Order
-      operationId: getTaskOrder
+      description: Gets File Metadata for a Task Order PDF
+      operationId: getTaskOrderMetadata
       parameters:
         - name: taskOrderId
           in: path
@@ -395,7 +395,7 @@ paths:
     get:
       tags:
         - taskOrder
-      description: Gets a Task Order PDF
+      description: Downloads a Task Order PDF
       operationId: downloadTaskOrder
       parameters:
         - name: taskOrderId

--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -356,7 +356,7 @@ paths:
     get:
       tags:
         - taskOrder
-      description: Gets File Metadata for a Task Order PDF
+      description: Gets File Metadata for a Task Order
       operationId: getTaskOrderMetadata
       parameters:
         - name: taskOrderId


### PR DESCRIPTION
Renames operation `getTaskOrder` to `getTaskOrderMetadata`.
This will eliminate potential confusion with operation `downloadTaskOrder`.

Updates some operation descriptions for consistency.
