### PR TITLE
Change API spec schema objects 'FundingStep' and 'ApplicationStep' to handle multiple task orders and applications respectively

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -553,86 +553,82 @@ components:
             format: "email"
     FundingStep:
       description: Represents step 2 of the Portfolio Draft Wizard
-      type: array
-      items:
-        type: object
-        properties:
-          task_order_number:
-            type: string
-          task_order_file:
-            allOf:
-              - $ref: '#/components/schemas/FileMetadataSummary'
-            description: Metadata associated with file which was previously uploaded by POST /taskOrderFiles
-          csp:
-            type: string
-            enum:
-              - "aws"
-              - "azure"
-          clins:
-            type: array
-            items:
-              type: object
-              properties:
-                clin_number:
-                  type: string
-                idiq_clin:
-                  type: string
-                total_clin_value:
-                  type: "integer"
-                obligated_funds:
-                  type: "integer"
-                pop_start_date:
-                  type: string
-                  format: date
-                  example: '2021-07-01'
-                pop_end_date:
-                  type: string
-                  format: date
-                  example: '2022-07-01'
+      type: object
+      properties:
+        task_order_number:
+          type: string
+        task_order_file:
+          allOf:
+            - $ref: '#/components/schemas/FileMetadataSummary'
+          description: Metadata associated with file which was previously uploaded by POST /taskOrderFiles
+        csp:
+          type: string
+          enum:
+            - "aws"
+            - "azure"
+        clins:
+          type: array
+          items:
+            type: object
+            properties:
+              clin_number:
+                type: string
+              idiq_clin:
+                type: string
+              total_clin_value:
+                type: "integer"
+              obligated_funds:
+                type: "integer"
+              pop_start_date:
+                type: string
+                format: date
+                example: '2021-07-01'
+              pop_end_date:
+                type: string
+                format: date
+                example: '2022-07-01'
     ApplicationStep:
       description: Represents step 3 of the Portfolio Draft Wizard
-      type: array
       xml:
         name: "application"
         wrapped: true
-      items:
-        type: object
-        properties:
-          name:
-            type: string
-          description:
-            type: string
-          environments:
-            type: array
-            xml:
-              name: "environment"
-              wrapped: true
-            items:
-              type: object
-              properties:
-                name:
-                  type: string
-                operators:
-                  type: array
-                  xml:
-                    name: "operator"
-                    wrapped: true
-                  items:
-                    type: object
-                    properties:
-                      first_name:
-                        type: string
-                      last_name:
-                        type: string
-                      email:
-                        type: string
-                        format: "email"
-                      access:
-                        type: string
-                        description: Operator Access Level to Environment
-                        enum:
-                          - administrator
-                          - read_only
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        environments:
+          type: array
+          xml:
+            name: "environment"
+            wrapped: true
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              operators:
+                type: array
+                xml:
+                  name: "operator"
+                  wrapped: true
+                items:
+                  type: object
+                  properties:
+                    first_name:
+                      type: string
+                    last_name:
+                      type: string
+                    email:
+                      type: string
+                      format: "email"
+                    access:
+                      type: string
+                      description: Operator Access Level to Environment
+                      enum:
+                        - administrator
+                        - read_only
     PortfolioDraft:
       allOf:
         - $ref: '#/components/schemas/PortfolioDraftSummary'

--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -516,6 +516,7 @@ components:
                 - "accepted"
                 - "rejected"
     PortfolioStep:
+      description: Represents step 1 of the Portfolio Draft Wizard
       type: object
       required:
         - name
@@ -551,6 +552,7 @@ components:
             type: string
             format: "email"
     FundingStep:
+      description: Represents step 2 of the Portfolio Draft Wizard
       type: array
       items:
         type: object
@@ -588,7 +590,7 @@ components:
                   format: date
                   example: '2022-07-01'
     ApplicationStep:
-      description: Represents the Application Step of the Portfolio Draft Wizard
+      description: Represents step 3 of the Portfolio Draft Wizard
       type: array
       xml:
         name: "application"

--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -527,9 +527,6 @@ components:
           type: string
         dod_components:
           type: array
-          xml:
-            name: "dod_component"
-            wrapped: true
           items:
             type: string
             enum:
@@ -545,9 +542,6 @@ components:
               - "nsa"
         portfolio_managers:
           type: array
-          xml:
-            name: "portfolio_managers"
-            wrapped: true
           items:
             type: string
             format: "email"
@@ -589,9 +583,6 @@ components:
                 example: '2022-07-01'
     ApplicationStep:
       description: Represents step 3 of the Portfolio Draft Wizard
-      xml:
-        name: "application"
-        wrapped: true
       type: object
       properties:
         name:
@@ -600,9 +591,6 @@ components:
           type: string
         environments:
           type: array
-          xml:
-            name: "environment"
-            wrapped: true
           items:
             type: object
             properties:
@@ -610,9 +598,6 @@ components:
                 type: string
               operators:
                 type: array
-                xml:
-                  name: "operator"
-                  wrapped: true
                 items:
                   type: object
                   properties:

--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -549,71 +549,81 @@ components:
       description: Represents step 2 of the Portfolio Draft Wizard
       type: object
       properties:
-        task_order_number:
-          type: string
-        task_order_file:
-          allOf:
-            - $ref: '#/components/schemas/FileMetadataSummary'
-          description: Metadata associated with file which was previously uploaded by POST /taskOrderFiles
-        csp:
-          type: string
-          enum:
-            - "aws"
-            - "azure"
-        clins:
+        task_orders:
           type: array
           items:
             type: object
             properties:
-              clin_number:
+              task_order_number:
                 type: string
-              idiq_clin:
+              task_order_file:
+                allOf:
+                  - $ref: '#/components/schemas/FileMetadataSummary'
+                description: Metadata associated with file which was previously uploaded by POST /taskOrderFiles
+              csp:
                 type: string
-              total_clin_value:
-                type: "integer"
-              obligated_funds:
-                type: "integer"
-              pop_start_date:
-                type: string
-                format: date
-                example: '2021-07-01'
-              pop_end_date:
-                type: string
-                format: date
-                example: '2022-07-01'
+                enum:
+                  - "aws"
+                  - "azure"
+              clins:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    clin_number:
+                      type: string
+                    idiq_clin:
+                      type: string
+                    total_clin_value:
+                      type: "integer"
+                    obligated_funds:
+                      type: "integer"
+                    pop_start_date:
+                      type: string
+                      format: date
+                      example: '2021-07-01'
+                    pop_end_date:
+                      type: string
+                      format: date
+                      example: '2022-07-01'
     ApplicationStep:
       description: Represents step 3 of the Portfolio Draft Wizard
       type: object
       properties:
-        name:
-          type: string
-        description:
-          type: string
-        environments:
+        applications:
           type: array
           items:
             type: object
             properties:
               name:
                 type: string
-              operators:
+              description:
+                type: string
+              environments:
                 type: array
                 items:
                   type: object
                   properties:
-                    first_name:
+                    name:
                       type: string
-                    last_name:
-                      type: string
-                    email:
-                      type: string
-                      format: "email"
-                    access:
-                      type: string
-                      description: Operator Access Level to Environment
-                      enum:
-                        - administrator
-                        - read_only
+                    operators:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          first_name:
+                            type: string
+                          last_name:
+                            type: string
+                          email:
+                            type: string
+                            format: "email"
+                          access:
+                            type: string
+                            description: Operator Access Level to Environment
+                            enum:
+                              - administrator
+                              - read_only
     PortfolioDraft:
       allOf:
         - $ref: '#/components/schemas/PortfolioDraftSummary'


### PR DESCRIPTION
Removes array wrappers around schema objects `FundingStep` and `ApplicationStep`.
Alters `FundingStep` schema object to include a `task_orders` array.
Alters `ApplicationStep` schema object to include an `applications` array.
Adds descriptions to all `*Step` schema object definitions.
Removes properties used to [fine-tune XML output](https://swagger.io/docs/specification/data-models/representing-xml/).  Outputing JSON only.