### PR TITLE
Implement function 'SubmitPortfolioDraft'

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -557,10 +557,10 @@ components:
               type: string
               description: CSP Provisioning Status
               enum:
-                - "NOT_STARTED"
-                - "IN_PROGRESS"
-                - "COMPLETE"
-                - "FAILED"
+                - "not_started"
+                - "in_progress"
+                - "complete"
+                - "failed"
     Error:
       type: object
       description: Generic error model
@@ -735,15 +735,15 @@ components:
     PortfolioDraftSummaryEx:
       value:
         - id: "dc2bbee6-8cdb-477e-a363-f9f1593a0a9b"
-          status: "NOT_STARTED"
+          status: "not_started"
           created_at: "2021-08-03T16:19:51.686Z"
           updated_at: "2021-08-03T16:19:51.686Z"
         - id: "c3e8c444-a971-4515-bc43-3cdfef072ccc"
-          status: "IN_PROGRESS"
+          status: "in_progress"
           created_at: "2021-08-03T16:19:24.362Z"
           updated_at: "2021-08-03T16:19:24.362Z"
         - id: "3f44ef42-2322-4a42-a381-6770e18eceba"
-          status: "COMPLETED"
+          status: "complete"
           created_at: "2021-08-03T16:21:07.978Z"
           updated_at: "2021-08-03T16:21:07.978Z"
     PortfolioDraftEx:

--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -377,8 +377,8 @@ paths:
           schema:
             type: string
       responses:
-        '201':
-          description: Successful operation
+        '202':
+          description: Accepted
         '400':
           description: Validation failed
           content:
@@ -396,10 +396,11 @@ paths:
             example: '{}'
           text/plain:
             example: ''
+      x-amazon-apigateway-request-validator: "request-params-validator"
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri: 
-          Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${NotImplementedFunction.Arn}/invocations"
+          Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SubmitPortfolioDraftFunction.Arn}/invocations"
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
   /taskOrderFiles:

--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -557,10 +557,10 @@ components:
               type: string
               description: CSP Provisioning Status
               enum:
-                - "not_started"
-                - "in_progress"
-                - "complete"
-                - "failed"
+                - "NOT_STARTED"
+                - "IN_PROGRESS"
+                - "COMPLETE"
+                - "FAILED"
     Error:
       type: object
       description: Generic error model
@@ -735,15 +735,15 @@ components:
     PortfolioDraftSummaryEx:
       value:
         - id: "dc2bbee6-8cdb-477e-a363-f9f1593a0a9b"
-          status: "not_started"
+          status: "NOT_STARTED"
           created_at: "2021-08-03T16:19:51.686Z"
           updated_at: "2021-08-03T16:19:51.686Z"
         - id: "c3e8c444-a971-4515-bc43-3cdfef072ccc"
-          status: "in_progress"
+          status: "IN_PROGRESS"
           created_at: "2021-08-03T16:19:24.362Z"
           updated_at: "2021-08-03T16:19:24.362Z"
         - id: "3f44ef42-2322-4a42-a381-6770e18eceba"
-          status: "complete"
+          status: "COMPLETED"
           created_at: "2021-08-03T16:21:07.978Z"
           updated_at: "2021-08-03T16:21:07.978Z"
     PortfolioDraftEx:

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -79,6 +79,12 @@ export class AtatWebApiStack extends cdk.Stack {
       handlerPath: packageRoot() + "/api/portfolioDrafts/getPortfolioDraft.ts",
     });
 
+    const submitPortfolioDraft = new ApiDynamoDBFunction(this, "SubmitPortfolioDraft", {
+      table: table,
+      method: HttpMethod.POST,
+      handlerPath: packageRoot() + "/api/portfolioDrafts/submit/submitPortfolioDraft.ts",
+    });
+
     // All TODO functions will be pointed at this lambda function (in the atat_provisioning_wizard_api.yaml, search NotImplementedFunction)
     const notImplemented = new ApiDynamoDBFunction(this, "NotImplemented", {
       table: table,
@@ -116,7 +122,6 @@ export class AtatWebApiStack extends cdk.Stack {
     // TODO: getPortfolioDraft
     // TODO: getApplicationStep
     // TODO: createApplicationStep
-    // TODO: submitPortfolioDraft
     addTaskOrderRoutes(this);
   }
 }

--- a/packages/api/models/ProvisioningStatus.ts
+++ b/packages/api/models/ProvisioningStatus.ts
@@ -1,6 +1,6 @@
 export enum ProvisioningStatus {
-  NOT_STARTED = "not_started",
-  IN_PROGRESS = "in_progress",
-  FAILED = "failed",
-  COMPLETED = "completed",
+  NOT_STARTED = "NOT_STARTED",
+  IN_PROGRESS = "IN_PROGRESS",
+  FAILED = "FAILED",
+  COMPLETED = "COMPLETED",
 }

--- a/packages/api/models/ProvisioningStatus.ts
+++ b/packages/api/models/ProvisioningStatus.ts
@@ -1,6 +1,6 @@
 export enum ProvisioningStatus {
-  NOT_STARTED = "NOT_STARTED",
-  IN_PROGRESS = "IN_PROGRESS",
-  FAILED = "FAILED",
-  COMPLETED = "COMPLETED",
+  NOT_STARTED = "not_started",
+  IN_PROGRESS = "in_progress",
+  FAILED = "failed",
+  COMPLETE = "complete",
 }

--- a/packages/api/portfolioDrafts/portfolio/createPortfolioStep.test.ts
+++ b/packages/api/portfolioDrafts/portfolio/createPortfolioStep.test.ts
@@ -27,7 +27,7 @@ describe("Dynamodb mock validation", function () {
         dod_components: [Array],
       },
       num_portfolio_managers: 0,
-      status: "NOT_STARTED",
+      status: "not_started",
       id: "595c31d3-190c-42c3-a9b6-77325fa5ed38",
     };
 

--- a/packages/api/portfolioDrafts/portfolio/createPortfolioStep.test.ts
+++ b/packages/api/portfolioDrafts/portfolio/createPortfolioStep.test.ts
@@ -27,7 +27,7 @@ describe("Dynamodb mock validation", function () {
         dod_components: [Array],
       },
       num_portfolio_managers: 0,
-      status: "not_started",
+      status: "NOT_STARTED",
       id: "595c31d3-190c-42c3-a9b6-77325fa5ed38",
     };
 

--- a/packages/api/portfolioDrafts/submit/submitPortfolioDraft.test.ts
+++ b/packages/api/portfolioDrafts/submit/submitPortfolioDraft.test.ts
@@ -1,0 +1,69 @@
+import { GetCommand, DynamoDBDocumentClient, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { mockClient } from "aws-sdk-client-mock";
+import { handler } from "./submitPortfolioDraft";
+import {
+  NO_SUCH_PORTFOLIO_DRAFT,
+  REQUEST_BODY_NOT_EMPTY,
+  PORTFOLIO_ALREADY_SUBMITTED,
+  PATH_PARAMETER_REQUIRED_BUT_MISSING,
+  DATABASE_ERROR,
+} from "../../utils/errors";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+const validRequest: APIGatewayProxyEvent = {
+  pathParameters: { portfolioDraftId: "1234" },
+} as any;
+
+describe("Validation tests", () => {
+  it("should require path param", async () => {
+    const emptyRequest: APIGatewayProxyEvent = {} as any;
+    expect(await handler(emptyRequest)).toEqual(PATH_PARAMETER_REQUIRED_BUT_MISSING);
+  });
+
+  it("should return generic Error if exception caught", async () => {
+    ddbMock.on(GetCommand).rejects("Some error occurred");
+    expect(await handler(validRequest)).toEqual(DATABASE_ERROR);
+  });
+
+  it("should return REQUEST_BODY_NOT_EMPTY when request body is not empty", async () => {
+    const requestBodyShouldBeEmpty = {
+      hi: "This should be empty",
+    };
+    const request: APIGatewayProxyEvent = {
+      body: JSON.stringify(requestBodyShouldBeEmpty),
+      pathParameters: { portfolioDraftId: "1234" },
+    } as any;
+
+    const response = await handler(request);
+    expect(response).toEqual(REQUEST_BODY_NOT_EMPTY);
+  });
+});
+describe("Handler response with mock dynamodb", function () {
+  it("should return error when the submitPortfolioDraftCommand fails, and portfolioDraft exists", async () => {
+    ddbMock.on(UpdateCommand).rejects({ name: "ConditionalCheckFailedException" });
+    const item = { foo: "bar" };
+    ddbMock.on(GetCommand).resolves({
+      Item: item,
+    });
+    // setting up new request
+    const request: APIGatewayProxyEvent = {
+      pathParameters: { portfolioDraftId: "1234" },
+    } as any;
+
+    expect(await handler(request)).toEqual(PORTFOLIO_ALREADY_SUBMITTED);
+  });
+  it("should return error when the submitPortfolioDraftCommand fails, and portfolioDraft doesn't exist", async () => {
+    ddbMock.on(UpdateCommand).rejects({ name: "ConditionalCheckFailedException" });
+    ddbMock.on(GetCommand).resolves({}); // resolves, but doesn't include an Item (!results.Item)
+    // setting up new request
+    const request: APIGatewayProxyEvent = {
+      pathParameters: { portfolioDraftId: "1234" },
+    } as any;
+    expect(await handler(request)).toEqual(NO_SUCH_PORTFOLIO_DRAFT);
+  });
+});

--- a/packages/api/portfolioDrafts/submit/submitPortfolioDraft.test.ts
+++ b/packages/api/portfolioDrafts/submit/submitPortfolioDraft.test.ts
@@ -35,8 +35,8 @@ describe("Validation tests", () => {
       hi: "This should be empty",
     };
     const request: APIGatewayProxyEvent = {
+      ...validRequest,
       body: JSON.stringify(requestBodyShouldBeEmpty),
-      pathParameters: { portfolioDraftId: "1234" },
     } as any;
 
     const response = await handler(request);

--- a/packages/api/portfolioDrafts/submit/submitPortfolioDraft.test.ts
+++ b/packages/api/portfolioDrafts/submit/submitPortfolioDraft.test.ts
@@ -50,20 +50,11 @@ describe("Handler response with mock dynamodb", function () {
     ddbMock.on(GetCommand).resolves({
       Item: item,
     });
-    // setting up new request
-    const request: APIGatewayProxyEvent = {
-      pathParameters: { portfolioDraftId: "1234" },
-    } as any;
-
-    expect(await handler(request)).toEqual(PORTFOLIO_ALREADY_SUBMITTED);
+    expect(await handler(validRequest)).toEqual(PORTFOLIO_ALREADY_SUBMITTED);
   });
   it("should return error when the submitPortfolioDraftCommand fails, and portfolioDraft doesn't exist", async () => {
     ddbMock.on(UpdateCommand).rejects({ name: "ConditionalCheckFailedException" });
     ddbMock.on(GetCommand).resolves({}); // resolves, but doesn't include an Item (!results.Item)
-    // setting up new request
-    const request: APIGatewayProxyEvent = {
-      pathParameters: { portfolioDraftId: "1234" },
-    } as any;
-    expect(await handler(request)).toEqual(NO_SUCH_PORTFOLIO_DRAFT);
+    expect(await handler(validRequest)).toEqual(NO_SUCH_PORTFOLIO_DRAFT);
   });
 });

--- a/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
@@ -1,0 +1,88 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, UpdateCommand, UpdateCommandOutput } from "@aws-sdk/lib-dynamodb";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { ErrorCodes } from "../../models/Error";
+import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
+import { isBodyPresent, isPathParameterPresent, isPortfolioStep, isValidJson } from "../../utils/validation";
+import { DATABASE_ERROR } from "../../utils/errors";
+import { PortfolioDraft } from "../../models/PortfolioDraft";
+import { v4 as uuidv4 } from "uuid";
+
+const TABLE_NAME = process.env.ATAT_TABLE_NAME ?? "";
+export const NO_SUCH_PORTFOLIO = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Portfolio Draft with the given ID does not exist" },
+  ErrorStatusCode.NOT_FOUND
+);
+export const EMPTY_REQUEST_BODY = new ErrorResponse(
+  { code: ErrorCodes.INVALID_INPUT, message: "Request body must be empty" },
+  ErrorStatusCode.BAD_REQUEST
+);
+
+/**
+ * Submits all progress from the Portfolio Provisioning Wizard
+ *
+ * @param event - The POST request from API Gateway
+ */
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  if (isBodyPresent(event.body)) {
+    return EMPTY_REQUEST_BODY;
+  }
+
+  const portfolioDraftId = event.pathParameters?.portfolioDraftId;
+
+  if (!isPathParameterPresent(portfolioDraftId)) {
+    return NO_SUCH_PORTFOLIO;
+  }
+  /*
+  try {
+    const result = await submitPortfolioDraftCommand(TABLE_NAME, portfolioDraftId);
+    const formatResult: PortfolioDraft = result;
+    return new ApiSuccessResponse<PortfolioDraft>(formatResult, SuccessStatusCode.ACCEPTED);
+  } catch (error) {
+    if (error.name === "ConditionalCheckFailedException") {
+      return NO_SUCH_PORTFOLIO;
+    }
+    console.log("Database error: " + error.name);
+    return new ErrorResponse(
+      { code: ErrorCodes.OTHER, message: "Database error: " + error.name },
+      ErrorStatusCode.INTERNAL_SERVER_ERROR
+    );
+  } */
+  // return new ApiSuccessResponse<PortfolioStep>(result, SuccessStatusCode.ACCEPTED);
+  try {
+    const result = await submitPortfolioDraftCommand(TABLE_NAME, portfolioDraftId);
+
+    return new ApiSuccessResponse(result.Attributes as PortfolioDraft, SuccessStatusCode.ACCEPTED);
+  } catch (err) {
+    console.log("Database error: " + err);
+    return DATABASE_ERROR;
+  }
+}
+export async function submitPortfolioDraftCommand(
+  table: string,
+  portfolioDraftId: string
+): Promise<UpdateCommandOutput> {
+  const dynamodb = new DynamoDBClient({});
+  const ddb = DynamoDBDocumentClient.from(dynamodb);
+  const now = new Date().toISOString();
+  const submitId = uuidv4();
+  const result = await ddb.send(
+    new UpdateCommand({
+      TableName: table,
+      Key: {
+        id: portfolioDraftId,
+      },
+      UpdateExpression: "set #portfolioVariable = :portfolio, updated_at = :now",
+      ExpressionAttributeNames: {
+        "#portfolioVariable": "submit_id",
+      },
+      ExpressionAttributeValues: {
+        ":now": now,
+        ":portfolio": submitId,
+      },
+      ConditionExpression: "attribute_exists(created_at)",
+      ReturnValues: "ALL_NEW",
+    })
+  );
+  return result;
+}

--- a/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
@@ -1,11 +1,23 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, UpdateCommand, UpdateCommandOutput } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  UpdateCommand,
+  UpdateCommandOutput,
+  GetCommand,
+  GetCommandOutput,
+} from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
 import { isBodyPresent, isPathParameterPresent } from "../../utils/validation";
-import { DATABASE_ERROR, NO_SUCH_PORTFOLIO_DRAFT, REQUEST_BODY_NOT_EMPTY } from "../../utils/errors";
+import {
+  DATABASE_ERROR,
+  NO_SUCH_PORTFOLIO_DRAFT,
+  REQUEST_BODY_NOT_EMPTY,
+  PORTFOLIO_ALREADY_SUBMITTED,
+} from "../../utils/errors";
 import { PortfolioDraft } from "../../models/PortfolioDraft";
 import { v4 as uuidv4 } from "uuid";
+import { ProvisioningStatus } from "../../models/ProvisioningStatus";
 const TABLE_NAME = process.env.ATAT_TABLE_NAME ?? "";
 
 /**
@@ -21,18 +33,24 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   const portfolioDraftId = event.pathParameters?.portfolioDraftId;
 
   if (!isPathParameterPresent(portfolioDraftId)) {
-    return NO_SUCH_PORTFOLIO_DRAFT;
+    return PORTFOLIO_ALREADY_SUBMITTED;
   }
 
   try {
     const result = await submitPortfolioDraftCommand(TABLE_NAME, portfolioDraftId);
-
     return new ApiSuccessResponse(result.Attributes as PortfolioDraft, SuccessStatusCode.ACCEPTED);
   } catch (error) {
+    console.log("Error: " + error);
+    // Check if the portfolioDraft exists
     if (error.name === "ConditionalCheckFailedException") {
-      return NO_SUCH_PORTFOLIO_DRAFT;
+      const getResult = await doesPortfolioDraftExistCommand(TABLE_NAME, portfolioDraftId);
+      console.log("getResult: " + JSON.stringify(getResult));
+      if (!getResult.Item) {
+        return NO_SUCH_PORTFOLIO_DRAFT;
+      }
+      return PORTFOLIO_ALREADY_SUBMITTED;
     }
-    console.log("Database error: " + error.name);
+    console.log("Database error: " + error);
     return DATABASE_ERROR;
   }
 }
@@ -43,23 +61,43 @@ export async function submitPortfolioDraftCommand(
   const dynamodb = new DynamoDBClient({});
   const ddb = DynamoDBDocumentClient.from(dynamodb);
   const now = new Date().toISOString();
-  const submitId = uuidv4();
+  // const submitId = uuidv4();
   const result = await ddb.send(
     new UpdateCommand({
       TableName: table,
       Key: {
         id: portfolioDraftId,
       },
-      UpdateExpression: "set #submitId = :submitIdValue, updated_at = :now",
+      UpdateExpression: "set #submitId = :submitIdValue, updated_at = :now, #status = :statusUpdate",
       ExpressionAttributeNames: {
         "#submitId": "submit_id",
+        "#status": "status",
       },
       ExpressionAttributeValues: {
         ":now": now,
-        ":submitIdValue": submitId,
+        ":submitIdValue": uuidv4(),
+        ":statusUpdate": ProvisioningStatus.IN_PROGRESS,
       },
-      ConditionExpression: "attribute_exists(created_at)",
+      ConditionExpression: "attribute_exists(created_at) AND attribute_not_exists(submit_id)",
       ReturnValues: "ALL_NEW",
+    })
+  );
+  return result;
+}
+// We cannot use ConditionExpression to differentiate between a 404 and 400 response, so we need
+// to make an additional query to check if the portfolioDraft exists.
+export async function doesPortfolioDraftExistCommand(
+  table: string,
+  portfolioDraftId: string
+): Promise<GetCommandOutput> {
+  const dynamodb = new DynamoDBClient({});
+  const ddb = DynamoDBDocumentClient.from(dynamodb);
+  const result = await ddb.send(
+    new GetCommand({
+      TableName: table,
+      Key: {
+        id: portfolioDraftId,
+      },
     })
   );
   return result;

--- a/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
@@ -33,11 +33,11 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   if (!isPathParameterPresent(portfolioDraftId)) {
     return NO_SUCH_PORTFOLIO;
   }
-  /*
+
   try {
     const result = await submitPortfolioDraftCommand(TABLE_NAME, portfolioDraftId);
-    const formatResult: PortfolioDraft = result;
-    return new ApiSuccessResponse<PortfolioDraft>(formatResult, SuccessStatusCode.ACCEPTED);
+
+    return new ApiSuccessResponse(result.Attributes as PortfolioDraft, SuccessStatusCode.ACCEPTED);
   } catch (error) {
     if (error.name === "ConditionalCheckFailedException") {
       return NO_SUCH_PORTFOLIO;
@@ -47,15 +47,6 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       { code: ErrorCodes.OTHER, message: "Database error: " + error.name },
       ErrorStatusCode.INTERNAL_SERVER_ERROR
     );
-  } */
-  // return new ApiSuccessResponse<PortfolioStep>(result, SuccessStatusCode.ACCEPTED);
-  try {
-    const result = await submitPortfolioDraftCommand(TABLE_NAME, portfolioDraftId);
-
-    return new ApiSuccessResponse(result.Attributes as PortfolioDraft, SuccessStatusCode.ACCEPTED);
-  } catch (err) {
-    console.log("Database error: " + err);
-    return DATABASE_ERROR;
   }
 }
 export async function submitPortfolioDraftCommand(

--- a/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
@@ -14,6 +14,7 @@ import {
   NO_SUCH_PORTFOLIO_DRAFT,
   REQUEST_BODY_NOT_EMPTY,
   PORTFOLIO_ALREADY_SUBMITTED,
+  PATH_PARAMETER_REQUIRED_BUT_MISSING,
 } from "../../utils/errors";
 import { PortfolioDraft } from "../../models/PortfolioDraft";
 import { v4 as uuidv4 } from "uuid";
@@ -33,7 +34,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   const portfolioDraftId = event.pathParameters?.portfolioDraftId;
 
   if (!isPathParameterPresent(portfolioDraftId)) {
-    return PORTFOLIO_ALREADY_SUBMITTED;
+    return PATH_PARAMETER_REQUIRED_BUT_MISSING;
   }
 
   try {
@@ -61,7 +62,6 @@ export async function submitPortfolioDraftCommand(
   const dynamodb = new DynamoDBClient({});
   const ddb = DynamoDBDocumentClient.from(dynamodb);
   const now = new Date().toISOString();
-  // const submitId = uuidv4();
   const result = await ddb.send(
     new UpdateCommand({
       TableName: table,

--- a/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
@@ -56,8 +56,7 @@ export async function submitPortfolioDraftCommand(
   table: string,
   portfolioDraftId: string
 ): Promise<UpdateCommandOutput> {
-  const now = new Date().toISOString();
-  const result = await client.send(
+  return client.send(
     new UpdateCommand({
       TableName: table,
       Key: {
@@ -69,7 +68,7 @@ export async function submitPortfolioDraftCommand(
         "#status": "status",
       },
       ExpressionAttributeValues: {
-        ":now": now,
+        ":now": new Date().toISOString(),
         ":submitIdValue": uuidv4(),
         ":statusUpdate": ProvisioningStatus.IN_PROGRESS,
         ":expectedStatus": ProvisioningStatus.NOT_STARTED,
@@ -79,7 +78,6 @@ export async function submitPortfolioDraftCommand(
       ReturnValues: "ALL_NEW",
     })
   );
-  return result;
 }
 export async function doesPortfolioDraftExistCommand(
   table: string,

--- a/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
@@ -67,10 +67,10 @@ export async function submitPortfolioDraftCommand(
         ":now": now,
         ":submitIdValue": uuidv4(),
         ":statusUpdate": ProvisioningStatus.IN_PROGRESS,
-        ":currentStatus": ProvisioningStatus.NOT_STARTED,
+        ":expectedStatus": ProvisioningStatus.NOT_STARTED,
       },
       ConditionExpression:
-        "attribute_exists(created_at) AND attribute_not_exists(submit_id) AND #status = :currentStatus",
+        "attribute_exists(created_at) AND attribute_not_exists(submit_id) AND #status = :expectedStatus",
       ReturnValues: "ALL_NEW",
     })
   );

--- a/packages/api/utils/errors.ts
+++ b/packages/api/utils/errors.ts
@@ -95,3 +95,10 @@ export const NOT_IMPLEMENTED = new ErrorResponse(
   { code: ErrorCodes.INVALID_INPUT, message: "Not implemented" },
   ErrorStatusCode.NOT_FOUND
 );
+/**
+ * To be used when a function has not been implemented
+ */
+export const PORTFOLIO_ALREADY_SUBMITTED = new ErrorResponse(
+  { code: ErrorCodes.OTHER, message: "Portfolio Draft with the given ID has already been submitted" },
+  ErrorStatusCode.BAD_REQUEST
+);


### PR DESCRIPTION
## Overview
Implement SubmitPortfolioDraft function, which _currently_ adds a `submit_id` to an existing portfolioDraft.
It returns `202 Accepted` along with the entire PortfolioDraft (this may need to be changed).
The ACs aren't especially clear if the response is an empty body, or the entire portfolioDraft.

### Ticket
[AT-6494](https://ccpo.atlassian.net/browse/AT-6494)