### PR TITLE
Avoid invalid uses of INVALID_INPUT

### DIFF
--- a/packages/api/models/Error.ts
+++ b/packages/api/models/Error.ts
@@ -1,13 +1,14 @@
-export enum ErrorCodes {
+export enum ErrorCode {
   INVALID_INPUT = "INVALID_INPUT",
   OTHER = "OTHER",
 }
 
 export interface Error {
-  code: string;
+  code: ErrorCode;
   message: string;
 }
 
 export interface ValidationError extends Error {
+  code: ErrorCode.INVALID_INPUT;
   errorMap: Record<string, unknown>;
 }

--- a/packages/api/portfolioDrafts/application/getApplicationStep.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.ts
@@ -4,11 +4,11 @@ import { ApplicationStep } from "../../models/ApplicationStep";
 import { APPLICATION_STEP } from "../../models/PortfolioDraft";
 import { dynamodbDocumentClient as client } from "../../utils/dynamodb";
 import { DATABASE_ERROR, NO_SUCH_APPLICATION_STEP, PATH_PARAMETER_REQUIRED_BUT_MISSING } from "../../utils/errors";
-import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
+import { ApiSuccessResponse, ErrorStatusCode, OtherErrorResponse, SuccessStatusCode } from "../../utils/response";
 import { isPathParameterPresent, isValidUuidV4 } from "../../utils/validation";
 
 // Note that API spec calls for 400 and not 404
-export const NO_SUCH_PORTFOLIO_DRAFT = new ErrorResponse(
+export const NO_SUCH_PORTFOLIO_DRAFT = new OtherErrorResponse(
   "The given Portfolio Draft does not exist",
   ErrorStatusCode.BAD_REQUEST
 );

--- a/packages/api/portfolioDrafts/application/getApplicationStep.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.ts
@@ -1,16 +1,15 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
-import { APPLICATION_STEP } from "../../models/PortfolioDraft";
-import { ApplicationStep } from "../../models/ApplicationStep";
-import { DATABASE_ERROR, NO_SUCH_APPLICATION_STEP, PATH_PARAMETER_REQUIRED_BUT_MISSING } from "../../utils/errors";
-import { dynamodbDocumentClient as client } from "../../utils/dynamodb";
-import { ErrorCodes } from "../../models/Error";
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { ApplicationStep } from "../../models/ApplicationStep";
+import { APPLICATION_STEP } from "../../models/PortfolioDraft";
+import { dynamodbDocumentClient as client } from "../../utils/dynamodb";
+import { DATABASE_ERROR, NO_SUCH_APPLICATION_STEP, PATH_PARAMETER_REQUIRED_BUT_MISSING } from "../../utils/errors";
+import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
 import { isPathParameterPresent, isValidUuidV4 } from "../../utils/validation";
 
 // Note that API spec calls for 400 and not 404
 export const NO_SUCH_PORTFOLIO_DRAFT = new ErrorResponse(
-  { code: ErrorCodes.OTHER, message: "The given Portfolio Draft does not exist" },
+  "The given Portfolio Draft does not exist",
   ErrorStatusCode.BAD_REQUEST
 );
 

--- a/packages/api/portfolioDrafts/deletePortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/deletePortfolioDraft.ts
@@ -1,7 +1,7 @@
 import { DeleteCommand, DeleteCommandInput } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { dynamodbClient as client } from "../utils/dynamodb";
-import { ErrorResponse, ErrorStatusCode, NoContentResponse } from "../utils/response";
+import { ErrorStatusCode, NoContentResponse, OtherErrorResponse } from "../utils/response";
 
 const TABLE_NAME = process.env.ATAT_TABLE_NAME;
 
@@ -14,7 +14,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   const portfolioDraftId = event.pathParameters?.portfolioDraftId;
 
   if (!portfolioDraftId) {
-    return new ErrorResponse("PortfolioDraftId must be specified in the URL path", ErrorStatusCode.BAD_REQUEST);
+    return new OtherErrorResponse("PortfolioDraftId must be specified in the URL path", ErrorStatusCode.BAD_REQUEST);
   }
 
   const params: DeleteCommandInput = {
@@ -30,11 +30,11 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   try {
     const data = await client.send(command);
     if (!data.Attributes) {
-      return new ErrorResponse("Portfolio Draft with the given ID does not exist", ErrorStatusCode.NOT_FOUND);
+      return new OtherErrorResponse("Portfolio Draft with the given ID does not exist", ErrorStatusCode.NOT_FOUND);
     }
     return new NoContentResponse();
   } catch (err) {
     console.log("Database error: " + err);
-    return new ErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
+    return new OtherErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
   }
 }

--- a/packages/api/portfolioDrafts/deletePortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/deletePortfolioDraft.ts
@@ -1,6 +1,5 @@
 import { DeleteCommand, DeleteCommandInput } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { ErrorCodes } from "../models/Error";
 import { dynamodbClient as client } from "../utils/dynamodb";
 import { ErrorResponse, ErrorStatusCode, NoContentResponse } from "../utils/response";
 
@@ -15,10 +14,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   const portfolioDraftId = event.pathParameters?.portfolioDraftId;
 
   if (!portfolioDraftId) {
-    return new ErrorResponse(
-      { code: ErrorCodes.INVALID_INPUT, message: "PortfolioDraftId must be specified in the URL path" },
-      ErrorStatusCode.BAD_REQUEST
-    );
+    return new ErrorResponse("PortfolioDraftId must be specified in the URL path", ErrorStatusCode.BAD_REQUEST);
   }
 
   const params: DeleteCommandInput = {
@@ -34,17 +30,11 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   try {
     const data = await client.send(command);
     if (!data.Attributes) {
-      return new ErrorResponse(
-        { code: ErrorCodes.INVALID_INPUT, message: "Portfolio Draft with the given ID does not exist" },
-        ErrorStatusCode.NOT_FOUND
-      );
+      return new ErrorResponse("Portfolio Draft with the given ID does not exist", ErrorStatusCode.NOT_FOUND);
     }
     return new NoContentResponse();
   } catch (err) {
     console.log("Database error: " + err);
-    return new ErrorResponse(
-      { code: ErrorCodes.OTHER, message: "Database error" },
-      ErrorStatusCode.INTERNAL_SERVER_ERROR
-    );
+    return new ErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
   }
 }

--- a/packages/api/portfolioDrafts/getPortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/getPortfolioDraft.ts
@@ -1,18 +1,17 @@
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { ErrorCodes } from "../models/Error";
-import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../utils/response";
 import { PortfolioDraft } from "../models/PortfolioDraft";
-import { isPathParameterPresent } from "../utils/validation";
 import { dynamodbDocumentClient as client } from "../utils/dynamodb";
 import { DATABASE_ERROR } from "../utils/errors";
+import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../utils/response";
+import { isPathParameterPresent } from "../utils/validation";
 
 export const NO_PORTFOLIO_PATH_PARAM = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "PortfolioDraftId must be specified in the URL path." },
+  "PortfolioDraftId must be specified in the URL path.",
   ErrorStatusCode.BAD_REQUEST
 );
 export const NO_SUCH_PORTFOLIO = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "Portfolio Draft with the given ID does not exist" },
+  "Portfolio Draft with the given ID does not exist",
   ErrorStatusCode.NOT_FOUND
 );
 

--- a/packages/api/portfolioDrafts/getPortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/getPortfolioDraft.ts
@@ -3,14 +3,14 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { PortfolioDraft } from "../models/PortfolioDraft";
 import { dynamodbDocumentClient as client } from "../utils/dynamodb";
 import { DATABASE_ERROR } from "../utils/errors";
-import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../utils/response";
+import { ApiSuccessResponse, ErrorStatusCode, OtherErrorResponse, SuccessStatusCode } from "../utils/response";
 import { isPathParameterPresent } from "../utils/validation";
 
-export const NO_PORTFOLIO_PATH_PARAM = new ErrorResponse(
+export const NO_PORTFOLIO_PATH_PARAM = new OtherErrorResponse(
   "PortfolioDraftId must be specified in the URL path.",
   ErrorStatusCode.BAD_REQUEST
 );
-export const NO_SUCH_PORTFOLIO = new ErrorResponse(
+export const NO_SUCH_PORTFOLIO = new OtherErrorResponse(
   "Portfolio Draft with the given ID does not exist",
   ErrorStatusCode.NOT_FOUND
 );

--- a/packages/api/portfolioDrafts/getPortfolioDrafts.ts
+++ b/packages/api/portfolioDrafts/getPortfolioDrafts.ts
@@ -2,10 +2,10 @@ import { ScanCommand, ScanCommandInput } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { PortfolioDraftSummary } from "../models/PortfolioDraftSummary";
 import { dynamodbDocumentClient as client } from "../utils/dynamodb";
-import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../utils/response";
+import { ApiSuccessResponse, ErrorStatusCode, OtherErrorResponse, SuccessStatusCode } from "../utils/response";
 
 const TABLE_NAME = process.env.ATAT_TABLE_NAME;
-const QUERY_PARAM_INVALID = new ErrorResponse("Invalid request parameter", ErrorStatusCode.BAD_REQUEST);
+const QUERY_PARAM_INVALID = new OtherErrorResponse("Invalid request parameter", ErrorStatusCode.BAD_REQUEST);
 
 /**
  * Evaluate query string parameter which is expected to be an integer.
@@ -49,6 +49,6 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     return new ApiSuccessResponse<PortfolioDraftSummary[]>(data.Items as PortfolioDraftSummary[], SuccessStatusCode.OK);
   } catch (error) {
     console.log("Database error (" + error.name + "): " + error);
-    return new ErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
+    return new OtherErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
   }
 }

--- a/packages/api/portfolioDrafts/getPortfolioDrafts.ts
+++ b/packages/api/portfolioDrafts/getPortfolioDrafts.ts
@@ -1,15 +1,11 @@
 import { ScanCommand, ScanCommandInput } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { ErrorCodes } from "../models/Error";
 import { PortfolioDraftSummary } from "../models/PortfolioDraftSummary";
 import { dynamodbDocumentClient as client } from "../utils/dynamodb";
 import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../utils/response";
 
 const TABLE_NAME = process.env.ATAT_TABLE_NAME;
-const QUERY_PARAM_INVALID = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "Invalid request parameter" },
-  ErrorStatusCode.BAD_REQUEST
-);
+const QUERY_PARAM_INVALID = new ErrorResponse("Invalid request parameter", ErrorStatusCode.BAD_REQUEST);
 
 /**
  * Evaluate query string parameter which is expected to be an integer.
@@ -53,9 +49,6 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     return new ApiSuccessResponse<PortfolioDraftSummary[]>(data.Items as PortfolioDraftSummary[], SuccessStatusCode.OK);
   } catch (error) {
     console.log("Database error (" + error.name + "): " + error);
-    return new ErrorResponse(
-      { code: ErrorCodes.OTHER, message: "Database error" },
-      ErrorStatusCode.INTERNAL_SERVER_ERROR
-    );
+    return new ErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
   }
 }

--- a/packages/api/portfolioDrafts/portfolio/createPortfolioStep.test.ts
+++ b/packages/api/portfolioDrafts/portfolio/createPortfolioStep.test.ts
@@ -122,6 +122,6 @@ describe("Handler response with mock dynamodb", function () {
     } as any;
 
     const data = await handler(request);
-    expect(data.body).toEqual(`{"code":"OTHER","message":"Database error: InternalServiceError"}`);
+    expect(data.body).toEqual(`{"code":"OTHER","message":"Database error"}`);
   });
 });

--- a/packages/api/portfolioDrafts/portfolio/createPortfolioStep.ts
+++ b/packages/api/portfolioDrafts/portfolio/createPortfolioStep.ts
@@ -4,19 +4,19 @@ import { DynamoDBDocumentClient, UpdateCommand, UpdateCommandOutput } from "@aws
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { PORTFOLIO_STEP } from "../../models/PortfolioDraft";
 import { PortfolioStep } from "../../models/PortfolioStep";
-import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
+import { ApiSuccessResponse, ErrorStatusCode, OtherErrorResponse, SuccessStatusCode } from "../../utils/response";
 import { isBodyPresent, isPathParameterPresent, isPortfolioStep, isValidJson } from "../../utils/validation";
 
 const TABLE_NAME = process.env.ATAT_TABLE_NAME ?? "";
-export const NO_SUCH_PORTFOLIO = new ErrorResponse(
+export const NO_SUCH_PORTFOLIO = new OtherErrorResponse(
   "Portfolio Draft with the given ID does not exist",
   ErrorStatusCode.NOT_FOUND
 );
-export const REQUEST_BODY_INVALID = new ErrorResponse(
+export const REQUEST_BODY_INVALID = new OtherErrorResponse(
   "A valid PortfolioStep object must be provided",
   ErrorStatusCode.BAD_REQUEST
 );
-export const EMPTY_REQUEST_BODY = new ErrorResponse("Request body must not be empty", ErrorStatusCode.BAD_REQUEST);
+export const EMPTY_REQUEST_BODY = new OtherErrorResponse("Request body must not be empty", ErrorStatusCode.BAD_REQUEST);
 
 /**
  * Submits the Portfolio Step of the Portfolio Draft Wizard
@@ -51,7 +51,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       return NO_SUCH_PORTFOLIO;
     }
     console.log("Database error: " + error.name);
-    return new ErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
+    return new OtherErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
   }
   return new ApiSuccessResponse<PortfolioStep>(portfolioStep, SuccessStatusCode.CREATED);
 }

--- a/packages/api/portfolioDrafts/portfolio/createPortfolioStep.ts
+++ b/packages/api/portfolioDrafts/portfolio/createPortfolioStep.ts
@@ -2,7 +2,6 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, UpdateCommand, UpdateCommandOutput } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { ErrorCodes } from "../../models/Error";
 import { PORTFOLIO_STEP } from "../../models/PortfolioDraft";
 import { PortfolioStep } from "../../models/PortfolioStep";
 import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
@@ -10,17 +9,14 @@ import { isBodyPresent, isPathParameterPresent, isPortfolioStep, isValidJson } f
 
 const TABLE_NAME = process.env.ATAT_TABLE_NAME ?? "";
 export const NO_SUCH_PORTFOLIO = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "Portfolio Draft with the given ID does not exist" },
+  "Portfolio Draft with the given ID does not exist",
   ErrorStatusCode.NOT_FOUND
 );
 export const REQUEST_BODY_INVALID = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "A valid PortfolioStep object must be provided" },
+  "A valid PortfolioStep object must be provided",
   ErrorStatusCode.BAD_REQUEST
 );
-export const EMPTY_REQUEST_BODY = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "Request body must not be empty" },
-  ErrorStatusCode.BAD_REQUEST
-);
+export const EMPTY_REQUEST_BODY = new ErrorResponse("Request body must not be empty", ErrorStatusCode.BAD_REQUEST);
 
 /**
  * Submits the Portfolio Step of the Portfolio Draft Wizard
@@ -55,10 +51,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       return NO_SUCH_PORTFOLIO;
     }
     console.log("Database error: " + error.name);
-    return new ErrorResponse(
-      { code: ErrorCodes.OTHER, message: "Database error: " + error.name },
-      ErrorStatusCode.INTERNAL_SERVER_ERROR
-    );
+    return new ErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
   }
   return new ApiSuccessResponse<PortfolioStep>(portfolioStep, SuccessStatusCode.CREATED);
 }

--- a/packages/api/taskOrderFiles/deleteTaskOrder.ts
+++ b/packages/api/taskOrderFiles/deleteTaskOrder.ts
@@ -1,12 +1,11 @@
 import { DeleteObjectCommand, DeleteObjectCommandOutput, S3Client } from "@aws-sdk/client-s3";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { ErrorCodes } from "../models/Error";
 import { ErrorResponse, ErrorStatusCode, NoContentResponse } from "../utils/response";
 import { isPathParameterPresent } from "../utils/validation";
 
 const bucketName = process.env.DATA_BUCKET;
 export const NO_SUCH_TASK_ORDER_FILE = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "TaskOrderId must be specified in the URL path" },
+  "TaskOrderId must be specified in the URL path",
   ErrorStatusCode.BAD_REQUEST
 );
 
@@ -25,10 +24,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     await deleteFile(taskOrderId);
   } catch (err) {
     console.log("Unexpected error: " + err);
-    return new ErrorResponse(
-      { code: ErrorCodes.OTHER, message: "Unexpected error" },
-      ErrorStatusCode.INTERNAL_SERVER_ERROR
-    );
+    return new ErrorResponse("Unexpected error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
   }
   return new NoContentResponse();
 }

--- a/packages/api/taskOrderFiles/deleteTaskOrder.ts
+++ b/packages/api/taskOrderFiles/deleteTaskOrder.ts
@@ -1,10 +1,10 @@
 import { DeleteObjectCommand, DeleteObjectCommandOutput, S3Client } from "@aws-sdk/client-s3";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { ErrorResponse, ErrorStatusCode, NoContentResponse } from "../utils/response";
+import { ErrorStatusCode, NoContentResponse, OtherErrorResponse } from "../utils/response";
 import { isPathParameterPresent } from "../utils/validation";
 
 const bucketName = process.env.DATA_BUCKET;
-export const NO_SUCH_TASK_ORDER_FILE = new ErrorResponse(
+export const NO_SUCH_TASK_ORDER_FILE = new OtherErrorResponse(
   "TaskOrderId must be specified in the URL path",
   ErrorStatusCode.BAD_REQUEST
 );
@@ -24,7 +24,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     await deleteFile(taskOrderId);
   } catch (err) {
     console.log("Unexpected error: " + err);
-    return new ErrorResponse("Unexpected error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
+    return new OtherErrorResponse("Unexpected error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
   }
   return new NoContentResponse();
 }

--- a/packages/api/taskOrderFiles/uploadTaskOrder.ts
+++ b/packages/api/taskOrderFiles/uploadTaskOrder.ts
@@ -3,7 +3,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import * as parser from "lambda-multipart-parser";
 import { v4 as uuidv4 } from "uuid";
 import { FileMetadata, FileScanStatus } from "../models/FileMetadata";
-import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../utils/response";
+import { ApiSuccessResponse, ErrorStatusCode, OtherErrorResponse, SuccessStatusCode } from "../utils/response";
 
 const bucketName = process.env.DATA_BUCKET;
 
@@ -16,19 +16,19 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   const result = await parser.parse(event);
 
   if (result.files.length !== 1) {
-    return new ErrorResponse("Expected exactly one file.", ErrorStatusCode.BAD_REQUEST);
+    return new OtherErrorResponse("Expected exactly one file.", ErrorStatusCode.BAD_REQUEST);
   }
 
   const file = result.files[0];
   if (file.contentType !== "application/pdf") {
-    return new ErrorResponse("Expected a PDF file", ErrorStatusCode.BAD_REQUEST);
+    return new OtherErrorResponse("Expected a PDF file", ErrorStatusCode.BAD_REQUEST);
   }
 
   try {
     return await uploadFile(file);
   } catch (error) {
     console.error("Unexpected error: " + error);
-    return new ErrorResponse("Unexpected error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
+    return new OtherErrorResponse("Unexpected error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
   }
 }
 

--- a/packages/api/taskOrderFiles/uploadTaskOrder.ts
+++ b/packages/api/taskOrderFiles/uploadTaskOrder.ts
@@ -2,7 +2,6 @@ import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import * as parser from "lambda-multipart-parser";
 import { v4 as uuidv4 } from "uuid";
-import { ErrorCodes } from "../models/Error";
 import { FileMetadata, FileScanStatus } from "../models/FileMetadata";
 import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../utils/response";
 
@@ -17,25 +16,19 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   const result = await parser.parse(event);
 
   if (result.files.length !== 1) {
-    return new ErrorResponse(
-      { code: ErrorCodes.OTHER, message: "Expected exactly one file." },
-      ErrorStatusCode.BAD_REQUEST
-    );
+    return new ErrorResponse("Expected exactly one file.", ErrorStatusCode.BAD_REQUEST);
   }
 
   const file = result.files[0];
   if (file.contentType !== "application/pdf") {
-    return new ErrorResponse({ code: ErrorCodes.OTHER, message: "Expected a PDF file" }, ErrorStatusCode.BAD_REQUEST);
+    return new ErrorResponse("Expected a PDF file", ErrorStatusCode.BAD_REQUEST);
   }
 
   try {
     return await uploadFile(file);
   } catch (error) {
     console.error("Unexpected error: " + error);
-    return new ErrorResponse(
-      { code: ErrorCodes.OTHER, message: "Unexpected error" },
-      ErrorStatusCode.INTERNAL_SERVER_ERROR
-    );
+    return new ErrorResponse("Unexpected error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
   }
 }
 

--- a/packages/api/utils/errors.ts
+++ b/packages/api/utils/errors.ts
@@ -1,29 +1,19 @@
-import { ErrorCodes } from "../models/Error";
-import { ErrorStatusCode, ErrorResponse } from "./response";
+import { ErrorResponse, ErrorStatusCode } from "./response";
 
 /**
  * To be used when a database error occurs.  Hides error/implementation details.
  */
-export const DATABASE_ERROR = new ErrorResponse(
-  { code: ErrorCodes.OTHER, message: "Database error" },
-  ErrorStatusCode.INTERNAL_SERVER_ERROR
-);
+export const DATABASE_ERROR = new ErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
 
 /**
  * To be used when a request body is required but was not provided
  */
-export const REQUEST_BODY_EMPTY = new ErrorResponse(
-  { code: ErrorCodes.OTHER, message: "Request body must not be empty" },
-  ErrorStatusCode.BAD_REQUEST
-);
+export const REQUEST_BODY_EMPTY = new ErrorResponse("Request body must not be empty", ErrorStatusCode.BAD_REQUEST);
 
 /**
  * To be used when a request body is provided but must be empty
  */
-export const REQUEST_BODY_NOT_EMPTY = new ErrorResponse(
-  { code: ErrorCodes.OTHER, message: "Request body must be empty" },
-  ErrorStatusCode.BAD_REQUEST
-);
+export const REQUEST_BODY_NOT_EMPTY = new ErrorResponse("Request body must be empty", ErrorStatusCode.BAD_REQUEST);
 
 /**
  * To be used when a request body exists but is invalid
@@ -33,7 +23,7 @@ export const REQUEST_BODY_NOT_EMPTY = new ErrorResponse(
  *  - when JSON, is not of the expected type (for example, doesn't look like PortfolioStep/FundingStep/ApplicationStep)
  */
 export const REQUEST_BODY_INVALID = new ErrorResponse(
-  { code: ErrorCodes.OTHER, message: "A valid request body must be provided" },
+  "A valid request body must be provided",
   ErrorStatusCode.BAD_REQUEST
 );
 
@@ -43,16 +33,13 @@ export const REQUEST_BODY_INVALID = new ErrorResponse(
  *  - has the wrong form (for example, uuid or date expected but won't parse)
  *  - is out of range (for example, integer not in the accepted range)
  */
-export const QUERY_PARAM_INVALID = new ErrorResponse(
-  { code: ErrorCodes.OTHER, message: "Invalid request parameter" },
-  ErrorStatusCode.BAD_REQUEST
-);
+export const QUERY_PARAM_INVALID = new ErrorResponse("Invalid request parameter", ErrorStatusCode.BAD_REQUEST);
 
 /**
  * To be used when a required path parameter is not received (not present or empty)
  */
 export const PATH_PARAMETER_REQUIRED_BUT_MISSING = new ErrorResponse(
-  { code: ErrorCodes.OTHER, message: "Required path parameter is missing" },
+  "Required path parameter is missing",
   ErrorStatusCode.BAD_REQUEST
 );
 
@@ -60,7 +47,7 @@ export const PATH_PARAMETER_REQUIRED_BUT_MISSING = new ErrorResponse(
  * To be used when the specified Portfolio Draft is not found
  */
 export const NO_SUCH_PORTFOLIO_DRAFT = new ErrorResponse(
-  { code: ErrorCodes.OTHER, message: "Portfolio Draft with the given ID does not exist" },
+  "Portfolio Draft with the given ID does not exist",
   ErrorStatusCode.NOT_FOUND
 );
 
@@ -68,7 +55,7 @@ export const NO_SUCH_PORTFOLIO_DRAFT = new ErrorResponse(
  * To be used when a Portfolio Step is not found for a specified Portfolio Draft
  */
 export const NO_SUCH_PORTFOLIO_STEP = new ErrorResponse(
-  { code: ErrorCodes.OTHER, message: "Portfolio Step not found for this Portfolio Draft" },
+  "Portfolio Step not found for this Portfolio Draft",
   ErrorStatusCode.NOT_FOUND
 );
 
@@ -76,7 +63,7 @@ export const NO_SUCH_PORTFOLIO_STEP = new ErrorResponse(
  * To be used when a Funding Step is not found for a specified Portfolio Draft
  */
 export const NO_SUCH_FUNDING_STEP = new ErrorResponse(
-  { code: ErrorCodes.OTHER, message: "Funding Step not found for this Portfolio Draft" },
+  "Funding Step not found for this Portfolio Draft",
   ErrorStatusCode.NOT_FOUND
 );
 
@@ -84,21 +71,19 @@ export const NO_SUCH_FUNDING_STEP = new ErrorResponse(
  * To be used when a Application Step is not found for a specified Portfolio Draft
  */
 export const NO_SUCH_APPLICATION_STEP = new ErrorResponse(
-  { code: ErrorCodes.OTHER, message: "Application Step not found for this Portfolio Draft" },
+  "Application Step not found for this Portfolio Draft",
   ErrorStatusCode.NOT_FOUND
 );
 
 /**
  * To be used when a function has not been implemented
  */
-export const NOT_IMPLEMENTED = new ErrorResponse(
-  { code: ErrorCodes.INVALID_INPUT, message: "Not implemented" },
-  ErrorStatusCode.NOT_FOUND
-);
+export const NOT_IMPLEMENTED = new ErrorResponse("Not implemented", ErrorStatusCode.NOT_FOUND);
+
 /**
  * To be used when a function has not been implemented
  */
 export const PORTFOLIO_ALREADY_SUBMITTED = new ErrorResponse(
-  { code: ErrorCodes.OTHER, message: "Portfolio Draft with the given ID has already been submitted" },
+  "Portfolio Draft with the given ID has already been submitted",
   ErrorStatusCode.BAD_REQUEST
 );

--- a/packages/api/utils/errors.ts
+++ b/packages/api/utils/errors.ts
@@ -1,19 +1,19 @@
-import { ErrorResponse, ErrorStatusCode } from "./response";
+import { ErrorStatusCode, OtherErrorResponse } from "./response";
 
 /**
  * To be used when a database error occurs.  Hides error/implementation details.
  */
-export const DATABASE_ERROR = new ErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
+export const DATABASE_ERROR = new OtherErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
 
 /**
  * To be used when a request body is required but was not provided
  */
-export const REQUEST_BODY_EMPTY = new ErrorResponse("Request body must not be empty", ErrorStatusCode.BAD_REQUEST);
+export const REQUEST_BODY_EMPTY = new OtherErrorResponse("Request body must not be empty", ErrorStatusCode.BAD_REQUEST);
 
 /**
  * To be used when a request body is provided but must be empty
  */
-export const REQUEST_BODY_NOT_EMPTY = new ErrorResponse("Request body must be empty", ErrorStatusCode.BAD_REQUEST);
+export const REQUEST_BODY_NOT_EMPTY = new OtherErrorResponse("Request body must be empty", ErrorStatusCode.BAD_REQUEST);
 
 /**
  * To be used when a request body exists but is invalid
@@ -22,7 +22,7 @@ export const REQUEST_BODY_NOT_EMPTY = new ErrorResponse("Request body must be em
  *  - is not valid JSON / PDF
  *  - when JSON, is not of the expected type (for example, doesn't look like PortfolioStep/FundingStep/ApplicationStep)
  */
-export const REQUEST_BODY_INVALID = new ErrorResponse(
+export const REQUEST_BODY_INVALID = new OtherErrorResponse(
   "A valid request body must be provided",
   ErrorStatusCode.BAD_REQUEST
 );
@@ -33,12 +33,12 @@ export const REQUEST_BODY_INVALID = new ErrorResponse(
  *  - has the wrong form (for example, uuid or date expected but won't parse)
  *  - is out of range (for example, integer not in the accepted range)
  */
-export const QUERY_PARAM_INVALID = new ErrorResponse("Invalid request parameter", ErrorStatusCode.BAD_REQUEST);
+export const QUERY_PARAM_INVALID = new OtherErrorResponse("Invalid request parameter", ErrorStatusCode.BAD_REQUEST);
 
 /**
  * To be used when a required path parameter is not received (not present or empty)
  */
-export const PATH_PARAMETER_REQUIRED_BUT_MISSING = new ErrorResponse(
+export const PATH_PARAMETER_REQUIRED_BUT_MISSING = new OtherErrorResponse(
   "Required path parameter is missing",
   ErrorStatusCode.BAD_REQUEST
 );
@@ -46,7 +46,7 @@ export const PATH_PARAMETER_REQUIRED_BUT_MISSING = new ErrorResponse(
 /**
  * To be used when the specified Portfolio Draft is not found
  */
-export const NO_SUCH_PORTFOLIO_DRAFT = new ErrorResponse(
+export const NO_SUCH_PORTFOLIO_DRAFT = new OtherErrorResponse(
   "Portfolio Draft with the given ID does not exist",
   ErrorStatusCode.NOT_FOUND
 );
@@ -54,7 +54,7 @@ export const NO_SUCH_PORTFOLIO_DRAFT = new ErrorResponse(
 /**
  * To be used when a Portfolio Step is not found for a specified Portfolio Draft
  */
-export const NO_SUCH_PORTFOLIO_STEP = new ErrorResponse(
+export const NO_SUCH_PORTFOLIO_STEP = new OtherErrorResponse(
   "Portfolio Step not found for this Portfolio Draft",
   ErrorStatusCode.NOT_FOUND
 );
@@ -62,7 +62,7 @@ export const NO_SUCH_PORTFOLIO_STEP = new ErrorResponse(
 /**
  * To be used when a Funding Step is not found for a specified Portfolio Draft
  */
-export const NO_SUCH_FUNDING_STEP = new ErrorResponse(
+export const NO_SUCH_FUNDING_STEP = new OtherErrorResponse(
   "Funding Step not found for this Portfolio Draft",
   ErrorStatusCode.NOT_FOUND
 );
@@ -70,7 +70,7 @@ export const NO_SUCH_FUNDING_STEP = new ErrorResponse(
 /**
  * To be used when a Application Step is not found for a specified Portfolio Draft
  */
-export const NO_SUCH_APPLICATION_STEP = new ErrorResponse(
+export const NO_SUCH_APPLICATION_STEP = new OtherErrorResponse(
   "Application Step not found for this Portfolio Draft",
   ErrorStatusCode.NOT_FOUND
 );
@@ -78,12 +78,12 @@ export const NO_SUCH_APPLICATION_STEP = new ErrorResponse(
 /**
  * To be used when a function has not been implemented
  */
-export const NOT_IMPLEMENTED = new ErrorResponse("Not implemented", ErrorStatusCode.NOT_FOUND);
+export const NOT_IMPLEMENTED = new OtherErrorResponse("Not implemented", ErrorStatusCode.NOT_FOUND);
 
 /**
  * To be used when a function has not been implemented
  */
-export const PORTFOLIO_ALREADY_SUBMITTED = new ErrorResponse(
+export const PORTFOLIO_ALREADY_SUBMITTED = new OtherErrorResponse(
   "Portfolio Draft with the given ID has already been submitted",
   ErrorStatusCode.BAD_REQUEST
 );

--- a/packages/api/utils/response.test.ts
+++ b/packages/api/utils/response.test.ts
@@ -1,4 +1,4 @@
-import { Error, ErrorCodes } from "../models/Error";
+import { Error, ErrorCode } from "../models/Error";
 import * as response from "./response";
 
 describe("Validation for No Content responses", () => {
@@ -16,8 +16,8 @@ describe("Validation for No Content responses", () => {
 
 describe("Validate parsing results in the same object", () => {
   it("should result in the same error after parsing", async () => {
-    const sampleError: Error = { code: ErrorCodes.OTHER, message: "Test Error" };
-    const errorResponse = new response.ErrorResponse(
+    const sampleError: Error = { code: ErrorCode.OTHER, message: "Test Error" };
+    const errorResponse = new response.OtherErrorResponse(
       sampleError.message,
       response.ErrorStatusCode.INTERNAL_SERVER_ERROR
     );

--- a/packages/api/utils/response.test.ts
+++ b/packages/api/utils/response.test.ts
@@ -17,7 +17,10 @@ describe("Validation for No Content responses", () => {
 describe("Validate parsing results in the same object", () => {
   it("should result in the same error after parsing", async () => {
     const sampleError: Error = { code: ErrorCodes.OTHER, message: "Test Error" };
-    const errorResponse = new response.ErrorResponse(sampleError, response.ErrorStatusCode.INTERNAL_SERVER_ERROR);
+    const errorResponse = new response.ErrorResponse(
+      sampleError.message,
+      response.ErrorStatusCode.INTERNAL_SERVER_ERROR
+    );
     expect(JSON.parse(errorResponse.body)).toEqual(sampleError);
   });
 

--- a/packages/api/utils/response.ts
+++ b/packages/api/utils/response.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyResult } from "aws-lambda";
-import { Error, ErrorCodes, ValidationError } from "../models/Error";
+import { Error, ErrorCode, ValidationError } from "../models/Error";
 
 type Headers = { [header: string]: string | number | boolean } | undefined;
 type MultiValueHeaders = { [header: string]: (string | number | boolean)[] } | undefined;
@@ -121,7 +121,7 @@ export class ApiSuccessResponse<T> extends SuccessResponse {
   }
 }
 
-abstract class BaseErrorResponse extends Response {
+abstract class ErrorResponse extends Response {
   /**
    * Create an error response.
    *
@@ -138,7 +138,7 @@ abstract class BaseErrorResponse extends Response {
 /**
  * An error response to an API request.
  */
-export class ErrorResponse extends BaseErrorResponse {
+export class OtherErrorResponse extends ErrorResponse {
   /**
    * Create an error response.
    *
@@ -149,7 +149,7 @@ export class ErrorResponse extends BaseErrorResponse {
    */
   constructor(message: string, statusCode: ErrorStatusCode, headers?: Headers, multiValueHeaders?: MultiValueHeaders) {
     const error: Error = {
-      code: ErrorCodes.OTHER,
+      code: ErrorCode.OTHER,
       message,
     };
     super(error, statusCode, headers, multiValueHeaders);
@@ -159,7 +159,7 @@ export class ErrorResponse extends BaseErrorResponse {
 /**
  * A response for validation errors in an API request.
  */
-export class ValidationErrorResponse extends BaseErrorResponse {
+export class ValidationErrorResponse extends ErrorResponse {
   /**
    * Create a 400 error response for validation errors.
    *
@@ -175,7 +175,7 @@ export class ValidationErrorResponse extends BaseErrorResponse {
     multiValueHeaders?: MultiValueHeaders
   ) {
     const error: ValidationError = {
-      code: ErrorCodes.INVALID_INPUT,
+      code: ErrorCode.INVALID_INPUT,
       message,
       errorMap,
     };

--- a/packages/api/utils/response.ts
+++ b/packages/api/utils/response.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyResult } from "aws-lambda";
-import { Error } from "../models/Error";
+import { Error, ErrorCodes, ValidationError } from "../models/Error";
 
 type Headers = { [header: string]: string | number | boolean } | undefined;
 type MultiValueHeaders = { [header: string]: (string | number | boolean)[] } | undefined;
@@ -121,10 +121,7 @@ export class ApiSuccessResponse<T> extends SuccessResponse {
   }
 }
 
-/**
- * An error response to an API request.
- */
-export class ErrorResponse extends Response {
+abstract class BaseErrorResponse extends Response {
   /**
    * Create an error response.
    *
@@ -135,5 +132,53 @@ export class ErrorResponse extends Response {
    */
   constructor(error: Error, statusCode: ErrorStatusCode, headers?: Headers, multiValueHeaders?: MultiValueHeaders) {
     super(JSON.stringify(error), statusCode, headers, multiValueHeaders, false);
+  }
+}
+
+/**
+ * An error response to an API request.
+ */
+export class ErrorResponse extends BaseErrorResponse {
+  /**
+   * Create an error response.
+   *
+   * @param message - The error message to return to the caller
+   * @param statusCode - The appropriate HTTP error status code
+   * @param headers - HTTP response headers
+   * @param multiValueHeaders - HTTP response headers, allowing multiple values for a header
+   */
+  constructor(message: string, statusCode: ErrorStatusCode, headers?: Headers, multiValueHeaders?: MultiValueHeaders) {
+    const error: Error = {
+      code: ErrorCodes.OTHER,
+      message,
+    };
+    super(error, statusCode, headers, multiValueHeaders);
+  }
+}
+
+/**
+ * A response for validation errors in an API request.
+ */
+export class ValidationErrorResponse extends BaseErrorResponse {
+  /**
+   * Create a 400 error response for validation errors.
+   *
+   * @param message - The top-level error message to return to the caller
+   * @param errorMap - The Error Map object that specifies the errors for various input elements
+   * @param headers - HTTP response headers
+   * @param multiValueHeaders - HTTP response headers, allowing multiple values for a header
+   */
+  constructor(
+    message: string,
+    errorMap: Record<string, unknown>,
+    headers?: Headers,
+    multiValueHeaders?: MultiValueHeaders
+  ) {
+    const error: ValidationError = {
+      code: ErrorCodes.INVALID_INPUT,
+      message,
+      errorMap,
+    };
+    super(error, ErrorStatusCode.BAD_REQUEST, headers, multiValueHeaders);
   }
 }


### PR DESCRIPTION
Using the INVALID_INPUT error code is supposed to be an indication that
the response is an actual ValidationError response. Unfortunately, we
have seen it used incorrectly for any time a 4xx error is being returned
and this has been inconsistent.

This introduces a change to the `utils/response.ts` to ensure that the
only time that INVALID_INPUT responses can be issued is by creating a
ValidationErrorResponse object and providing the error map and a
message. For all other error responses, OTHER will be used as is correct
per the API spec.