### PR TITLE
Normalize environment names and IDs

### DIFF
--- a/infrastructure/jest.config.js
+++ b/infrastructure/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   testEnvironment: 'node',
-  roots: ['<rootDir>/test'],
+  roots: ['<rootDir>/test', '<rootDir>'],
   testMatch: ['**/*.test.ts'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest'

--- a/infrastructure/lib/atat-auth-stack.ts
+++ b/infrastructure/lib/atat-auth-stack.ts
@@ -21,7 +21,7 @@ export class AtatAuthStack extends cdk.Stack {
       groupsAttributeName: "groups",
       adminsGroupName: props.adminsGroupName ?? "atat-admins",
       usersGroupName: props.adminsGroupName ?? "atat-users",
-      cognitoDomain: "atat-api-" + props.environmentId.toLowerCase(),
+      cognitoDomain: "atat-api-" + props.environmentId,
       userPoolProps: {
         removalPolicy: props?.removalPolicy,
       },

--- a/infrastructure/lib/util.test.ts
+++ b/infrastructure/lib/util.test.ts
@@ -1,0 +1,78 @@
+import { isString, lowerCaseEnvironmentId, normalizeEnvironmentName } from "./util";
+
+const testEnvironmentIds = [
+  // Jira ticket ID-looking strings should be valid regardless of how they
+  // get entered
+  {
+    inputs: ["AT-0001", "AT0001", "at0001", "aT0001", "At0001", "AT_0_0_0_1"],
+    expectedName: "At0001",
+    expectedId: "at0001",
+  },
+  // And "special" environment names should work the same as sandbox environments
+  {
+    inputs: ["Dev", "Dev!", "dev", "DEV", "dEv", "_dev_"],
+    expectedName: "Dev",
+    expectedId: "dev",
+  },
+  {
+    inputs: ["Staging", "Staging!", "staging", "STAGING", "sTaGiNg", "_staging_"],
+    expectedName: "Staging",
+    expectedId: "staging",
+  },
+  {
+    inputs: ["Prod", "Prod!", "prod", "PROD", "PrOd", "_prod_"],
+    expectedName: "Prod",
+    expectedId: "prod",
+  },
+  // Numbered "special" environment names should be treated like any other
+  // string
+  {
+    inputs: ["Dev1", "dev1", "DEV1", "dEv1", "_dev1_", "Dev1!"],
+    expectedName: "Dev1",
+    expectedId: "dev1",
+  },
+  // Totally special or empty names should not break the function
+  {
+    inputs: ["", "&*(^&%^&$^%%*&", "_-__--_"],
+    expectedName: "",
+    expectedId: "",
+  },
+  // Even multi-word names get only one capital letter
+  {
+    inputs: ["LongEnvironmentName", "longenvironmentname", "lOnGeNvIrOnMeNtNaMe"],
+    expectedName: "Longenvironmentname",
+    expectedId: "longenvironmentname",
+  },
+  // Very short names should still work too
+  {
+    inputs: ["A", "a", "_A_", "_a_"],
+    expectedName: "A",
+    expectedId: "a",
+  },
+];
+
+describe("Validate environment normalization", () => {
+  it.each(["AT-1234", "&!@#!@", "", "at1234"])("should not contain special characters", async (testStr) => {
+    expect(normalizeEnvironmentName(testStr)).not.toMatch(/[\W_-]+/g);
+  });
+
+  it.each(testEnvironmentIds)("should return a normalized name for ticket ID", async ({ inputs, expectedName }) => {
+    inputs.forEach((item) => expect(normalizeEnvironmentName(item)).toEqual(expectedName));
+  });
+
+  it.each(testEnvironmentIds)("should return a normalized ID for ticket IDs", async ({ inputs, expectedId }) => {
+    inputs.forEach((item) => expect(lowerCaseEnvironmentId(item)).toEqual(expectedId));
+  });
+});
+
+describe("Validate string type guards", () => {
+  it.each([1, {}, [], null, undefined, false, true])("should reject non-strings", async (item) => {
+    expect(isString(item)).toEqual(false);
+  });
+  it("should reject the empty string", async () => {
+    expect(isString("")).toEqual(false);
+  });
+  it.each(["a", "longstring", "1312987A*&(^&*AHL"])("should accept strings", async (item) => {
+    expect(isString(item)).toEqual(true);
+  });
+});

--- a/infrastructure/lib/util.ts
+++ b/infrastructure/lib/util.ts
@@ -1,6 +1,4 @@
 // This is a suboptimal solution to finding the relative directory to the
-// package root. This is necessary because it is possible for this file to be
-// run with the a cwd of either the infrastructure directory or the root of the
 // git repo.
 export function packageRoot(): string {
   const cwd = process.cwd();
@@ -8,4 +6,54 @@ export function packageRoot(): string {
     return `${cwd}/../packages`;
   }
   return `${cwd}/packages`;
+}
+
+const normalizationRejectionRegex = /[\W_-]/g;
+
+/**
+ * Normalizes environment names.
+ *
+ * The first letter is capitalized and the rest is made lowercase.
+ * Any hyphens or other special characters are stripped.
+ *
+ * This ensures that accidentally typing "dev" doesn't result in a new
+ * environment from "Dev" and that ticket IDs such as "AT-0001" and
+ * "AT0001" are treated the same and still mostly look like ticket IDs.
+ *
+ * @param id The environment identifier
+ * @returns The normalized environment name
+ */
+export function normalizeEnvironmentName(id: string): string {
+  const strippedId = id.replace(normalizationRejectionRegex, "");
+  if (!strippedId) {
+    return strippedId;
+  }
+  return strippedId[0].toUpperCase() + lowerCaseEnvironmentId(strippedId.slice(1));
+}
+
+/**
+ * Normalize a lowercase version of the environment ID.
+ *
+ * In some scenarios, it is idiomatic (or required) to use a lowercase
+ * version of the environment ID without special characters. This
+ * strips all non-word characters, underscores, and hyphens and returns
+ * the lowercase identifier.
+ *
+ * @param id The environment identifier
+ * @returns the normalized lowercase identifier for the environment
+ */
+export function lowerCaseEnvironmentId(id: string): string {
+  return id.toLowerCase().replace(normalizationRejectionRegex, "");
+}
+
+/**
+ * Helper type guard to check whether an input is a string
+ * @param str the input to test
+ * @returns true if the input is a non-empty string and false otherwise
+ */
+export function isString(str: unknown): str is string {
+  if (str && typeof str === "string") {
+    return true;
+  }
+  return false;
 }

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
+    "test": "jest --config=jest.config.js",
     "cdk": "cdk",
     "lint": "eslint --ext .js,.ts,.json -c ../.eslintrc.json .",
     "lint:fix": "npm run lint -- --fix"


### PR DESCRIPTION
There are some places (like stack names) where the title-case variant of
the environment name looks and is best; however, there are some
scenarios where we need a lowercase identifier as well.

This gives us a consistent way to handle environment names and moves all
of that logic to the app level so that it is not happening in individual
stacks and constructs. Previously, we would have had problems if an
environment ID with special characters was entered but that is no longer
an issue.

Currently, we are only passing the environment ID anywhere and it is
only to one stack. The Environment Name is purely used for
CloudFormation stack names. Both are still declared and initialized so
that we can pass them in Prop structs in the future as needed. Similar
code will need to be added to the UI repo since there isn't a
particularly great way to share code between the two repositories.

Tests are added for this code; however, we have not and are not
collecting coverage data for the CDK code yet.