### PR TITLE
Bump AWS SDK to 3.31.0

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -114,15 +114,15 @@
 			}
 		},
 		"@aws-sdk/client-dynamodb": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.30.0.tgz",
-			"integrity": "sha512-J2yRwBoVD6MVQMJ3FnGSdBIDvG8ktIFmHv8CN3tPiE8tPqP45Io3cSdXWKBdA4AzDkp/p9HFcaitgQbj5+nTcg==",
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.31.0.tgz",
+			"integrity": "sha512-J5V6DYQsTCgGRLQXl6UHgUP3dAP6WWjJsX7RP71iEM+vqalJvYUzfMU03SdwqmrQ00s/4fdzJOvVl1/LYwAhsA==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "^1.0.0",
 				"@aws-crypto/sha256-js": "^1.0.0",
-				"@aws-sdk/client-sts": "3.30.0",
+				"@aws-sdk/client-sts": "3.31.0",
 				"@aws-sdk/config-resolver": "3.30.0",
-				"@aws-sdk/credential-provider-node": "3.30.0",
+				"@aws-sdk/credential-provider-node": "3.31.0",
 				"@aws-sdk/fetch-http-handler": "3.29.0",
 				"@aws-sdk/hash-node": "3.29.0",
 				"@aws-sdk/invalid-dependency": "3.29.0",
@@ -138,7 +138,7 @@
 				"@aws-sdk/node-config-provider": "3.29.0",
 				"@aws-sdk/node-http-handler": "3.29.0",
 				"@aws-sdk/protocol-http": "3.29.0",
-				"@aws-sdk/smithy-client": "3.30.0",
+				"@aws-sdk/smithy-client": "3.31.0",
 				"@aws-sdk/types": "3.29.0",
 				"@aws-sdk/url-parser": "3.29.0",
 				"@aws-sdk/util-base64-browser": "3.29.0",
@@ -155,15 +155,15 @@
 			}
 		},
 		"@aws-sdk/client-s3": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.30.0.tgz",
-			"integrity": "sha512-prp5MSs+ysS9XRb/BrH1eG/Az2nmxl2A6vbQ147nvuy/cAIMWPoDRwSlOXhD57i5EfAvAoJjSooEh1dfcvna+Q==",
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.31.0.tgz",
+			"integrity": "sha512-1r0GT55Hg6j5HwIsSZRQD/UyixaqGxeslMKyriYW6EGY3hc+1DP6vV4MUSiPxmMjLsCRPpeKhxdGzAryTiWFQQ==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "^1.0.0",
 				"@aws-crypto/sha256-js": "^1.0.0",
-				"@aws-sdk/client-sts": "3.30.0",
+				"@aws-sdk/client-sts": "3.31.0",
 				"@aws-sdk/config-resolver": "3.30.0",
-				"@aws-sdk/credential-provider-node": "3.30.0",
+				"@aws-sdk/credential-provider-node": "3.31.0",
 				"@aws-sdk/eventstream-serde-browser": "3.29.0",
 				"@aws-sdk/eventstream-serde-config-resolver": "3.29.0",
 				"@aws-sdk/eventstream-serde-node": "3.29.0",
@@ -190,7 +190,7 @@
 				"@aws-sdk/node-config-provider": "3.29.0",
 				"@aws-sdk/node-http-handler": "3.29.0",
 				"@aws-sdk/protocol-http": "3.29.0",
-				"@aws-sdk/smithy-client": "3.30.0",
+				"@aws-sdk/smithy-client": "3.31.0",
 				"@aws-sdk/types": "3.29.0",
 				"@aws-sdk/url-parser": "3.29.0",
 				"@aws-sdk/util-base64-browser": "3.29.0",
@@ -209,9 +209,9 @@
 			}
 		},
 		"@aws-sdk/client-sso": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.30.0.tgz",
-			"integrity": "sha512-Ctt9CXV8ElFBs05oXGjOIYhJ/aTJZsGEX+dsRP7C3D/oswE/z+Uo7rS7sGkiLo4GOroeqSFduMYRcZtl6gvzyw==",
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.31.0.tgz",
+			"integrity": "sha512-fbquWlOS8+uotT2aZexK/3g85NYt2T5LpfWnk9mPV5HWfoevqTz9kwsZEW4DTnW9zibRl89vwXKolNpyszuZnw==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "^1.0.0",
 				"@aws-crypto/sha256-js": "^1.0.0",
@@ -229,7 +229,7 @@
 				"@aws-sdk/node-config-provider": "3.29.0",
 				"@aws-sdk/node-http-handler": "3.29.0",
 				"@aws-sdk/protocol-http": "3.29.0",
-				"@aws-sdk/smithy-client": "3.30.0",
+				"@aws-sdk/smithy-client": "3.31.0",
 				"@aws-sdk/types": "3.29.0",
 				"@aws-sdk/url-parser": "3.29.0",
 				"@aws-sdk/util-base64-browser": "3.29.0",
@@ -244,14 +244,14 @@
 			}
 		},
 		"@aws-sdk/client-sts": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.30.0.tgz",
-			"integrity": "sha512-iJm5XlAcgLiRO3lHbAuVkjT8FpueJsCBZQOmjP7JVk9D8DUTV1NdMQOoqY9iuOZsuY5q8725teIqKL9SmZJqfA==",
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.31.0.tgz",
+			"integrity": "sha512-XL8l88iUHPxfByFPp9a9eZV6Shb9QijHM+aGJPFU5zYvX3ruclfuBIs/3gLgqeX8rsmjt8AfeICxaP4BwJcaZA==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "^1.0.0",
 				"@aws-crypto/sha256-js": "^1.0.0",
 				"@aws-sdk/config-resolver": "3.30.0",
-				"@aws-sdk/credential-provider-node": "3.30.0",
+				"@aws-sdk/credential-provider-node": "3.31.0",
 				"@aws-sdk/fetch-http-handler": "3.29.0",
 				"@aws-sdk/hash-node": "3.29.0",
 				"@aws-sdk/invalid-dependency": "3.29.0",
@@ -267,7 +267,7 @@
 				"@aws-sdk/node-config-provider": "3.29.0",
 				"@aws-sdk/node-http-handler": "3.29.0",
 				"@aws-sdk/protocol-http": "3.29.0",
-				"@aws-sdk/smithy-client": "3.30.0",
+				"@aws-sdk/smithy-client": "3.31.0",
 				"@aws-sdk/types": "3.29.0",
 				"@aws-sdk/url-parser": "3.29.0",
 				"@aws-sdk/util-base64-browser": "3.29.0",
@@ -316,13 +316,13 @@
 			}
 		},
 		"@aws-sdk/credential-provider-ini": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.30.0.tgz",
-			"integrity": "sha512-EEg3x60sAPO8xQc/tm631pk5yxOMOoiw2fsE0ojBeF8X78pYKT6sE2Uz0aj8/d8RtqqA3lsXr4O0txtdYbRokg==",
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.31.0.tgz",
+			"integrity": "sha512-t95Gix2fWLIxrM2c2QZfRgJ1aCY1zGSlhb1JBlzPwxVRay7iUKa9U2dPoPhbOTsD1abQMjE4AnpDt9Bj+AXgyA==",
 			"requires": {
 				"@aws-sdk/credential-provider-env": "3.29.0",
 				"@aws-sdk/credential-provider-imds": "3.29.0",
-				"@aws-sdk/credential-provider-sso": "3.30.0",
+				"@aws-sdk/credential-provider-sso": "3.31.0",
 				"@aws-sdk/credential-provider-web-identity": "3.29.0",
 				"@aws-sdk/property-provider": "3.29.0",
 				"@aws-sdk/shared-ini-file-loader": "3.29.0",
@@ -332,15 +332,15 @@
 			}
 		},
 		"@aws-sdk/credential-provider-node": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.30.0.tgz",
-			"integrity": "sha512-mT1ImT8nvo062Yf4WE5xZoEl2Wz4lkkA1oewOjvmNUi/AfBkf0YgIK6+XtoC06O2VWqXUhYv7N357/CzGP2I+w==",
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.31.0.tgz",
+			"integrity": "sha512-T5309Q/MPHmaKYX0gSo6dv8w1ll4wsXvAUDXFC3MMdL/WYBfYvJa9H5nB9D9bL0xmtsm9e3WtfAcvEkN8Qz1xg==",
 			"requires": {
 				"@aws-sdk/credential-provider-env": "3.29.0",
 				"@aws-sdk/credential-provider-imds": "3.29.0",
-				"@aws-sdk/credential-provider-ini": "3.30.0",
+				"@aws-sdk/credential-provider-ini": "3.31.0",
 				"@aws-sdk/credential-provider-process": "3.29.0",
-				"@aws-sdk/credential-provider-sso": "3.30.0",
+				"@aws-sdk/credential-provider-sso": "3.31.0",
 				"@aws-sdk/credential-provider-web-identity": "3.29.0",
 				"@aws-sdk/property-provider": "3.29.0",
 				"@aws-sdk/shared-ini-file-loader": "3.29.0",
@@ -362,11 +362,11 @@
 			}
 		},
 		"@aws-sdk/credential-provider-sso": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.30.0.tgz",
-			"integrity": "sha512-zZ9T7QLGxOHryDTEEojtpZbDtI3Xu5tSNDvAIg7AzCIE75cRbcc8X9bXD2RUFRZTYDCVg2sSHHOcki1uIonOzA==",
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.31.0.tgz",
+			"integrity": "sha512-x+xQvq8AFt+V1EpwRWa3Obsd1w2L7pQyP/P6O9Q5Enq6OwmdrM+i51jMD58QMRz4h+Ys5eaLLfi0wE0AjrUbng==",
 			"requires": {
-				"@aws-sdk/client-sso": "3.30.0",
+				"@aws-sdk/client-sso": "3.31.0",
 				"@aws-sdk/property-provider": "3.29.0",
 				"@aws-sdk/shared-ini-file-loader": "3.29.0",
 				"@aws-sdk/types": "3.29.0",
@@ -505,11 +505,22 @@
 			}
 		},
 		"@aws-sdk/lib-dynamodb": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.30.0.tgz",
-			"integrity": "sha512-b4ClfBpa781LjUgbUrwPlhoK43eOA4HcxK+dvRKTmY5yv2EdlwVL4DnpENrcf4RJ7xat4+Rfkl4INnCaz6DO4g==",
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.31.0.tgz",
+			"integrity": "sha512-wGFaQyQZ57RG2ETHp1rOsHrS0UiBtgJiqGoUPBmWljXlZj1w6WLoZzqSdBdZnAWrY35kvSz4TR6Zr4bUHWJWkg==",
 			"requires": {
+				"@aws-sdk/util-dynamodb": "3.31.0",
 				"tslib": "^2.3.0"
+			},
+			"dependencies": {
+				"@aws-sdk/util-dynamodb": {
+					"version": "3.31.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.31.0.tgz",
+					"integrity": "sha512-5EJxAcuBa3Ukc5FhqvADiTyMFoN4k0Ia4lmMdg18yn5m7s0WJ+rn5HIouJ619uy5Ivs76rkPvlIMhcQu7EclKg==",
+					"requires": {
+						"tslib": "^2.3.0"
+					}
+				}
 			}
 		},
 		"@aws-sdk/md5-js": {
@@ -786,9 +797,9 @@
 			}
 		},
 		"@aws-sdk/smithy-client": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.30.0.tgz",
-			"integrity": "sha512-Kokc3OHDY0T5ppjeMnsJEaxOBvonzNvYSQrCEvPbj9yUCLHvEWw4g6USQDfzqyofCwwhuFKFS6hS/bbiW6cXvQ==",
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.31.0.tgz",
+			"integrity": "sha512-QZHOMM6npFyDEW8wrp8rLs+YGZIPRfuItlWHm6Upejp6a7s1ksb/1c44vNeqwnAeUJrdXfOX9QFkbh1+gZF21A==",
 			"requires": {
 				"@aws-sdk/middleware-stack": "3.29.0",
 				"@aws-sdk/types": "3.29.0",
@@ -866,14 +877,6 @@
 			"integrity": "sha512-xCWQizP5d6SwbwB2HmxpDqu0WYY7/E7pNrZ+7tSMrJxZlT8Zsd+lFaO23JVFMEBqjjBnpLBr+XkNZgOpD1BYwA==",
 			"requires": {
 				"@aws-sdk/shared-ini-file-loader": "3.29.0",
-				"tslib": "^2.3.0"
-			}
-		},
-		"@aws-sdk/util-dynamodb": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.30.0.tgz",
-			"integrity": "sha512-1PqW9ey2w4+47SpHaWiujaQ01P/p/Jgva8dcRBBVXPci0KGIv8vvPxqPnw6uxMndhl4mQAs5KkM9lmRCc3Fg1w==",
-			"requires": {
 				"tslib": "^2.3.0"
 			}
 		},

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,10 +8,9 @@
     "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.30.0",
-    "@aws-sdk/client-s3": "^3.30.0",
-    "@aws-sdk/lib-dynamodb": "^3.30.0",
-    "@aws-sdk/util-dynamodb": "^3.30.0",
+    "@aws-sdk/client-dynamodb": "^3.31.0",
+    "@aws-sdk/client-s3": "^3.31.0",
+    "@aws-sdk/lib-dynamodb": "^3.31.0",
     "@types/aws-lambda": "^8.10.83",
     "lambda-multipart-parser": "^1.0.1",
     "uuid": "^8.3.2"


### PR DESCRIPTION
This updates the AWS SDK from 3.30.0 to 3.31.0. Due to upstream
packaging changes, we no longer need to depend on `@aws-sdk/util-dynamodb`
directly. It was previously incorrectly a peer dependency of
`@aws-sdk/lib-dynamodb`; however, it has been corrected to be a regular
production dependency. For more information, see the
[release notes](https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.31.0).