### PR TITLE
Add checking for invalid Clin Numbers and Funding Amounts

### DIFF
--- a/packages/api/models/FundingStep.ts
+++ b/packages/api/models/FundingStep.ts
@@ -10,6 +10,7 @@ export enum ValidationMessage {
   TOTAL_GT_ZERO = "total clin value must be greater than zero",
   OBLIGATED_GT_ZERO = "obligated funds must be greater than zero",
   TOTAL_GT_OBLIGATED = "total clin value must be greater than obligated funds",
+  INVALID_CLIN_NUMBER = "clin number must be four numbers and in range 0001 through 9999",
 }
 
 export interface FundingStep {

--- a/packages/api/models/FundingStep.ts
+++ b/packages/api/models/FundingStep.ts
@@ -7,8 +7,7 @@ export enum ValidationMessage {
   END_VALID = "end date must be a valid date",
   START_BEFORE_END = "start date must be before end date",
   END_FUTURE = "end date must be in the future",
-  TOTAL_GT_ZERO = "total clin value must be greater than zero",
-  OBLIGATED_GT_ZERO = "obligated funds must be greater than zero",
+  INVALID_FUNDING_AMOUNT = "funding amount must be numbers and amount must be greater than zero",
   TOTAL_GT_OBLIGATED = "total clin value must be greater than obligated funds",
   INVALID_CLIN_NUMBER = "clin number must be four numbers and in range 0001 through 9999",
 }

--- a/packages/api/portfolioDrafts/funding/createFundingStep.test.ts
+++ b/packages/api/portfolioDrafts/funding/createFundingStep.test.ts
@@ -208,37 +208,52 @@ describe("Individual Clin input validation tests", function () {
       validationMessage: ValidationMessage.END_FUTURE,
     });
   });
-  it("should return error map entries when given Clin has invalid funding values (total<0, obligated<0)", () => {
+  it("should return error map entries when given Clin has invalid funding amounts (not numbers)", () => {
+    const errors = validateClin(mockClinNotANumberFunds());
+    expect(errors).toContainEqual({
+      clinNumber: "0001",
+      invalidParameterName: "total_clin_value",
+      invalidParameterValue: "not a number",
+      validationMessage: ValidationMessage.INVALID_FUNDING_AMOUNT,
+    });
+    expect(errors).toContainEqual({
+      clinNumber: "0001",
+      invalidParameterName: "obligated_funds",
+      invalidParameterValue: "not a number",
+      validationMessage: ValidationMessage.INVALID_FUNDING_AMOUNT,
+    });
+  });
+  it("should return error map entries when given Clin has invalid funding amounts (total<0, obligated<0)", () => {
     const errors = validateClin(mockClinLessThanZeroFunds());
     expect(errors).toContainEqual({
       clinNumber: "0001",
       invalidParameterName: "total_clin_value",
       invalidParameterValue: "-1",
-      validationMessage: ValidationMessage.TOTAL_GT_ZERO,
+      validationMessage: ValidationMessage.INVALID_FUNDING_AMOUNT,
     });
     expect(errors).toContainEqual({
       clinNumber: "0001",
       invalidParameterName: "obligated_funds",
       invalidParameterValue: "-1",
-      validationMessage: ValidationMessage.OBLIGATED_GT_ZERO,
+      validationMessage: ValidationMessage.INVALID_FUNDING_AMOUNT,
     });
   });
-  it("should return error map entries when given Clin has invalid funding values (total=0, obligated=0)", () => {
+  it("should return error map entries when given Clin has invalid funding amounts (total=0, obligated=0)", () => {
     const errors = validateClin(mockClinZeroFunds());
     expect(errors).toContainEqual({
       clinNumber: "0001",
       invalidParameterName: "total_clin_value",
       invalidParameterValue: "0",
-      validationMessage: ValidationMessage.TOTAL_GT_ZERO,
+      validationMessage: ValidationMessage.INVALID_FUNDING_AMOUNT,
     });
     expect(errors).toContainEqual({
       clinNumber: "0001",
       invalidParameterName: "obligated_funds",
       invalidParameterValue: "0",
-      validationMessage: ValidationMessage.OBLIGATED_GT_ZERO,
+      validationMessage: ValidationMessage.INVALID_FUNDING_AMOUNT,
     });
   });
-  it("should return error map entries when given Clin has invalid funding values (obligated>total)", () => {
+  it("should return error map entries when given Clin has invalid funding amounts (obligated>total)", () => {
     const errors = validateClin(mockClinObligatedGreaterThanTotal());
     expect(errors).toContainEqual({
       clinNumber: "0001",
@@ -361,13 +376,13 @@ describe("All Clins in Funding Step input validation tests", function () {
       clinNumber: "0001",
       invalidParameterName: "total_clin_value",
       invalidParameterValue: "0",
-      validationMessage: ValidationMessage.TOTAL_GT_ZERO,
+      validationMessage: ValidationMessage.INVALID_FUNDING_AMOUNT,
     });
     expect(errors).toContainEqual({
       clinNumber: "0001",
       invalidParameterName: "obligated_funds",
       invalidParameterValue: "0",
-      validationMessage: ValidationMessage.OBLIGATED_GT_ZERO,
+      validationMessage: ValidationMessage.INVALID_FUNDING_AMOUNT,
     });
     expect(errors).toContainEqual({
       clinNumber: "0001",
@@ -460,6 +475,7 @@ function mockFundingStepBadData(): FundingStep {
       mockClinAlreadyEnded(),
       mockClinZeroFunds(),
       mockClinObligatedGreaterThanTotal(),
+      // Note, can't add mockClinNotANumberFunds() here
     ],
   };
 }
@@ -606,5 +622,20 @@ function mockClinObligatedEqualsTotal(): Clin {
     ...mockClin(),
     obligated_funds: 1,
     total_clin_value: 1,
+  };
+}
+/**
+ * Returns a static almost-clin containing bad inputs
+ * - obligated funds is not a number
+ * - total clin value is not a number
+ * @returns an almost-Clin with values that should cause validation errors
+ */
+function mockClinNotANumberFunds() {
+  // return type can't be Clin for this mock because strings
+  // below don't meet the Clin interface
+  return {
+    ...mockClin(),
+    obligated_funds: "not a number",
+    total_clin_value: "not a number",
   };
 }

--- a/packages/api/portfolioDrafts/funding/createFundingStep.ts
+++ b/packages/api/portfolioDrafts/funding/createFundingStep.ts
@@ -19,6 +19,7 @@ import {
   isClin,
   isValidUuidV4,
   isClinNumber,
+  isFundingAmount,
 } from "../../utils/validation";
 
 export interface ClinValidationError {
@@ -170,20 +171,20 @@ export function validateClin(clin: unknown): Array<ClinValidationError> {
       validationMessage: ValidationMessage.END_FUTURE,
     });
   }
-  if (clin.total_clin_value <= 0) {
+  if (!isFundingAmount(clin.total_clin_value.toString())) {
     errors.push({
       clinNumber: clin.clin_number,
       invalidParameterName: "total_clin_value",
       invalidParameterValue: clin.total_clin_value.toString(),
-      validationMessage: ValidationMessage.TOTAL_GT_ZERO,
+      validationMessage: ValidationMessage.INVALID_FUNDING_AMOUNT,
     });
   }
-  if (clin.obligated_funds <= 0) {
+  if (!isFundingAmount(clin.obligated_funds.toString())) {
     errors.push({
       clinNumber: clin.clin_number,
       invalidParameterName: "obligated_funds",
       invalidParameterValue: clin.obligated_funds.toString(),
-      validationMessage: ValidationMessage.OBLIGATED_GT_ZERO,
+      validationMessage: ValidationMessage.INVALID_FUNDING_AMOUNT,
     });
   }
   if (clin.obligated_funds > clin.total_clin_value) {

--- a/packages/api/portfolioDrafts/funding/createFundingStep.ts
+++ b/packages/api/portfolioDrafts/funding/createFundingStep.ts
@@ -18,6 +18,7 @@ import {
   isPathParameterPresent,
   isClin,
   isValidUuidV4,
+  isClinNumber,
 } from "../../utils/validation";
 
 export interface ClinValidationError {
@@ -120,6 +121,15 @@ export function validateClin(clin: unknown): Array<ClinValidationError> {
     throw Error("Input must be a Clin object");
   }
   const errors = Array<ClinValidationError>();
+
+  if (!isClinNumber(clin.clin_number)) {
+    errors.push({
+      clinNumber: clin.clin_number,
+      invalidParameterName: "clin_number",
+      invalidParameterValue: clin.clin_number,
+      validationMessage: ValidationMessage.INVALID_CLIN_NUMBER,
+    });
+  }
   if (!isValidDate(clin.pop_start_date)) {
     errors.push({
       clinNumber: clin.clin_number,

--- a/packages/api/utils/validation.test.ts
+++ b/packages/api/utils/validation.test.ts
@@ -237,11 +237,11 @@ describe("isClin()", function () {
 
 describe("isClinNumber()", function () {
   const goodClinNumbers = ["0001", "0010", "0500", "5000", "9999"];
-  it.each(goodClinNumbers)("should reject a clin number with incorrect length or not in valid range", (num) => {
+  it.each(goodClinNumbers)("should accept a clin number with expected length and within accepted range", (num) => {
     expect(isClinNumber(num)).toEqual(true);
   });
   const badClinNumbers = ["", "0", "1", "02", "111", "0000", "10000", "99999"];
-  it.each(badClinNumbers)("should reject a clin number with incorrect length or not in valid range", (num) => {
+  it.each(badClinNumbers)("should reject a clin number with unexpected length or not within accepted range", (num) => {
     expect(isClinNumber(num)).toEqual(false);
   });
 });

--- a/packages/api/utils/validation.test.ts
+++ b/packages/api/utils/validation.test.ts
@@ -260,7 +260,7 @@ describe("isFundingAmount()", function () {
   // Reject?  Accept and round?  Accept and truncate?
   // This formatter rounds the values to nearest cent:
   // Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
-  // So the values below yield ["$1.99", "$1.99", "$2.00", "$2.00"];
+  // The values below yield ["$1.99", "$1.99", "$2.00", "$2.00"];
   const questionableAmounts = ["1.991", "1.994", "1.995", "1.999"];
   it.each(questionableAmounts)("should accept a funding amount that is valid", (num) => {
     expect(isFundingAmount(num)).toEqual(true);

--- a/packages/api/utils/validation.test.ts
+++ b/packages/api/utils/validation.test.ts
@@ -6,6 +6,7 @@ import {
   isValidJson,
   isValidDate,
   isClin,
+  isClinNumber,
 } from "./validation";
 
 describe("Testing validation of request body", function () {
@@ -231,5 +232,16 @@ describe("isClin()", function () {
   });
   it.each(badClins)("should reject a Clin missing any field", async (badClin) => {
     expect(isClin(badClin)).toEqual(false);
+  });
+});
+
+describe("isClinNumber()", function () {
+  const goodClinNumbers = ["0001", "0010", "0500", "5000", "9999"];
+  it.each(goodClinNumbers)("should reject a clin number with incorrect length or not in valid range", (num) => {
+    expect(isClinNumber(num)).toEqual(true);
+  });
+  const badClinNumbers = ["", "0", "1", "02", "111", "0000", "10000", "99999"];
+  it.each(badClinNumbers)("should reject a clin number with incorrect length or not in valid range", (num) => {
+    expect(isClinNumber(num)).toEqual(false);
   });
 });

--- a/packages/api/utils/validation.test.ts
+++ b/packages/api/utils/validation.test.ts
@@ -7,6 +7,7 @@ import {
   isValidDate,
   isClin,
   isClinNumber,
+  isFundingAmount,
 } from "./validation";
 
 describe("Testing validation of request body", function () {
@@ -243,5 +244,25 @@ describe("isClinNumber()", function () {
   const badClinNumbers = ["", "0", "1", "02", "111", "0000", "10000", "99999"];
   it.each(badClinNumbers)("should reject a clin number with unexpected length or not within accepted range", (num) => {
     expect(isClinNumber(num)).toEqual(false);
+  });
+});
+
+describe("isFundingAmount()", function () {
+  const goodAmounts = ["1", "1.1", "1.50", "1.99", "250000"];
+  it.each(goodAmounts)("should accept a funding amount that is valid", (num) => {
+    expect(isFundingAmount(num)).toEqual(true);
+  });
+  const badAmounts = ["", "0", "-1", "not a number"];
+  it.each(badAmounts)("should reject a funding amount that is invalid", (num) => {
+    expect(isFundingAmount(num)).toEqual(false);
+  });
+  // TODO: What should be done with decimals greater than two digits?
+  // Reject?  Accept and round?  Accept and truncate?
+  // This formatter rounds the values to nearest cent:
+  // Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
+  // So the values below yield ["$1.99", "$1.99", "$2.00", "$2.00"];
+  const questionableAmounts = ["1.991", "1.994", "1.995", "1.999"];
+  it.each(questionableAmounts)("should accept a funding amount that is valid", (num) => {
+    expect(isFundingAmount(num)).toEqual(true);
   });
 });

--- a/packages/api/utils/validation.ts
+++ b/packages/api/utils/validation.ts
@@ -137,3 +137,16 @@ export function isClin(object: unknown): object is Clin {
     (item) => item in object
   );
 }
+
+/**
+ * Check whether a given string is a valid CLIN number.
+ * @param str - The string to check
+ * @returns true if the string is a valid CLIN number; false otherwise
+ */
+export function isClinNumber(str: string): boolean {
+  if (str.length !== 4) {
+    return false;
+  }
+  const num: number = parseInt(str);
+  return num >= 1 && num <= 9999;
+}

--- a/packages/api/utils/validation.ts
+++ b/packages/api/utils/validation.ts
@@ -150,3 +150,16 @@ export function isClinNumber(str: string): boolean {
   const num: number = parseInt(str);
   return num >= 1 && num <= 9999;
 }
+
+/**
+ * Check whether a given string is a valid Funding Amount.
+ * @param str - The string to check
+ * @returns true if the string is a valid Funding Amount; false otherwise
+ */
+export function isFundingAmount(str: string): boolean {
+  if (str.length === 0) {
+    return false;
+  }
+  const num: number = parseFloat(str);
+  return num > 0;
+}


### PR DESCRIPTION
Adds checking for invalid Clin Numbers and Funding Amounts (Total Clin Value and Obligated Funds), including unit tests

Adds `isClinNumber()` and `isFundingAmount()` to validation module. including unit tests

Replaced two specific Funding Step validation messages (`TOTAL_GT_ZERO`, `OBLIGATED_GT_ZERO`) with the more general `INVALID_FUNDING_AMOUNT`

Ticket: AT-6409