### PR TITLE
Implement 'CreateApplicationStep' function

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -360,7 +360,7 @@ paths:
       x-amazon-apigateway-integration:
           httpMethod: "POST"
           uri: 
-            Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${NotImplementedFunction.Arn}/invocations"
+            Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CreateApplicationStepFunction.Arn}/invocations"
           passthroughBehavior: "when_no_match"
           type: "aws_proxy"
   /portfolioDrafts/{portfolioDraftId}/submit:

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -72,6 +72,12 @@ export class AtatWebApiStack extends cdk.Stack {
       handlerPath: packageRoot() + "/api/portfolioDrafts/funding/getFundingStep.ts",
     });
 
+    const createApplicationStep = new ApiDynamoDBFunction(this, "CreateApplicationStep", {
+      table: table,
+      method: HttpMethod.POST,
+      handlerPath: packageRoot() + "/api/portfolioDrafts/application/createApplicationStep.ts",
+    });
+
     const getApplicationStep = new ApiDynamoDBFunction(this, "GetApplicationStep", {
       table: table,
       method: HttpMethod.GET,
@@ -124,9 +130,6 @@ export class AtatWebApiStack extends cdk.Stack {
         endpointConfigurationTypes: apigw.EndpointType.REGIONAL,
       },
     });
-    // TODO: getPortfolioDraft
-    // TODO: getApplicationStep
-    // TODO: createApplicationStep
     // TODO: submitPortfolioDraft
     this.addTaskOrderRoutes(props);
   }

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -130,7 +130,6 @@ export class AtatWebApiStack extends cdk.Stack {
         endpointConfigurationTypes: apigw.EndpointType.REGIONAL,
       },
     });
-    // TODO: submitPortfolioDraft
     this.addTaskOrderRoutes(props);
   }
 

--- a/packages/api/models/Application.ts
+++ b/packages/api/models/Application.ts
@@ -1,0 +1,7 @@
+import { Environment } from "./Environment";
+
+export interface Application {
+  name: string;
+  description: string;
+  environments: Array<Environment>;
+}

--- a/packages/api/models/ApplicationStep.ts
+++ b/packages/api/models/ApplicationStep.ts
@@ -1,6 +1,9 @@
-import { Environment } from "./Environment";
+import { Application } from "./Application";
+
+export enum ValidationMessage {
+  INVALID_APPLICATION_NAME = "application name must be between 4 and 100 characters",
+  INVALID_ENVIRONMENT_NAME = "environment name must be between 4 and 100 characters",
+}
 export interface ApplicationStep {
-  name: string;
-  description: string;
-  environments: Array<Environment>;
+  applications: Array<Application>;
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -21,7 +21,6 @@
     "aws-sdk-client-mock": "^0.5.3",
     "eslint": "^7.31.0",
     "jest": "^27.1.1",
-    "lodash.clonedeep": "^4.5.0",
     "ts-jest": "^27.0.4"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -21,6 +21,7 @@
     "aws-sdk-client-mock": "^0.5.3",
     "eslint": "^7.31.0",
     "jest": "^27.1.1",
+    "lodash.clonedeep": "^4.5.0",
     "ts-jest": "^27.0.4"
   }
 }

--- a/packages/api/portfolioDrafts/application/commonMockData.ts
+++ b/packages/api/portfolioDrafts/application/commonMockData.ts
@@ -1,0 +1,178 @@
+import { AccessLevel } from "../../models/AccessLevel";
+import { Application } from "../../models/Application";
+import { ApplicationStep } from "../../models/ApplicationStep";
+import { Environment } from "../../models/Environment";
+import { Operator } from "../../models/Operator";
+
+const mockOperatorDarthVader: Operator = {
+  first_name: "Darth",
+  last_name: "Vader",
+  email: "iam@yourfather.com",
+  access: AccessLevel.ADMINISTRATOR,
+};
+const mockOperatorLandonisCalrissian: Operator = {
+  first_name: "Landonis",
+  last_name: "Calrissian",
+  email: "thegambler@cloudcity.com",
+  access: AccessLevel.READ_ONLY,
+};
+const mockOperatorLukeSkywalker: Operator = {
+  first_name: "Luke",
+  last_name: "Skywalker",
+  email: "lostmy@hand.com",
+  access: AccessLevel.READ_ONLY,
+};
+const mockOperatorSalaciousCrumb: Operator = {
+  first_name: "Salacious",
+  last_name: "Crumb",
+  email: "monkey@lizard.com",
+  access: AccessLevel.ADMINISTRATOR,
+};
+const mockOperatorHanSolo: Operator = {
+  first_name: "Han",
+  last_name: "Solo",
+  email: "frozen@carbonite.com",
+  access: AccessLevel.READ_ONLY,
+};
+const mockOperatorBobaFett: Operator = {
+  first_name: "Boba",
+  last_name: "Fett",
+  email: "original@mandalorian.com",
+  access: AccessLevel.READ_ONLY,
+};
+
+const mockEnvironmentCcepProd: Environment = {
+  name: "production",
+  operators: [mockOperatorDarthVader, mockOperatorLandonisCalrissian, mockOperatorLukeSkywalker],
+};
+const mockEnvironmentJpeaDev: Environment = {
+  name: "development",
+  operators: [mockOperatorSalaciousCrumb, mockOperatorHanSolo, mockOperatorBobaFett],
+};
+
+/**
+ * "Cloud City Evac Planner" from API spec
+ */
+export const mockApplicationCloudCityEvacPlanner: Application = {
+  name: "Cloud City Evac Planner",
+  description: "Application for planning an emergency evacuation",
+  environments: [mockEnvironmentCcepProd],
+};
+
+/**
+ * "Jabba's Palace Expansion App" from API spec
+ */
+export const mockApplicationJabbasPalaceExpansionApp: Application = {
+  name: "Jabba's Palace Expansion App",
+  description: "Planning application for palace expansion",
+  environments: [mockEnvironmentJpeaDev],
+};
+
+/**
+ * ApplicationStepEx from API spec
+ * @returns a complete ApplicationStep with good data
+ */
+export const mockApplicationStep: ApplicationStep = {
+  applications: [mockApplicationCloudCityEvacPlanner, mockApplicationJabbasPalaceExpansionApp],
+};
+
+/** ABOVE THIS LINE ARE VALID OBJECTS WITH GOOD DATA **/
+/** BELOW THIS LINE ARE INVALID OBJECTS WITH MISSING FIELDS AND BAD DATA **/
+
+/**
+ * An array of Environment-looking objects with missing fields
+ * that should be rejected by isEnvironment()
+ */
+export const mockEnvironmentsMissingFields = [
+  {
+    // name: "production",
+    operators: [mockOperatorDarthVader, mockOperatorLandonisCalrissian, mockOperatorLukeSkywalker],
+  },
+  {
+    name: "production",
+    // operators: [mockOperatorDarthVader, mockOperatorLandonisCalrissian, mockOperatorLukeSkywalker],
+  },
+];
+
+/**
+ * An array of Application-looking objects with missing fields
+ * that should be rejected by isApplication()
+ */
+export const mockApplicationsMissingFields = [
+  {
+    // name: "Cloud City Evac Planner",
+    description: "Application for planning an emergency evacuation",
+    environments: [mockEnvironmentCcepProd],
+  },
+  {
+    name: "Cloud City Evac Planner",
+    // description: "Application for planning an emergency evacuation",
+    environments: [mockEnvironmentCcepProd],
+  },
+  {
+    name: "Cloud City Evac Planner",
+    description: "Application for planning an emergency evacuation",
+    // environments: [mockEnvironmentCcepProd],
+  },
+];
+
+/**
+ * An array of ApplicationStep-looking objects with missing fields
+ * that should be rejected by isApplicationStep()
+ */
+export const mockApplicationStepsMissingFields = [
+  {
+    // applications: [],
+  },
+];
+
+/**
+ * An array of ApplicationStep objects with bad data
+ * that should cause input validation errors
+ */
+export const mockApplicationStepsBadData: Array<ApplicationStep> = [
+  {
+    ...mockApplicationStep,
+    applications: [{ ...mockApplicationCloudCityEvacPlanner, name: "abc" }], // too short
+  },
+  {
+    ...mockApplicationStep,
+    applications: [
+      {
+        ...mockApplicationCloudCityEvacPlanner,
+        // too long
+        name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eleifend lectus ut luctus ultricies nisi.",
+      },
+    ],
+  },
+  {
+    ...mockApplicationStep,
+    applications: [
+      {
+        ...mockApplicationCloudCityEvacPlanner,
+        environments: [
+          {
+            ...mockEnvironmentCcepProd,
+            // too short
+            name: "abc",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    ...mockApplicationStep,
+    applications: [
+      {
+        ...mockApplicationCloudCityEvacPlanner,
+        environments: [
+          {
+            ...mockEnvironmentCcepProd,
+            // too long
+            name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eleifend lectus ut luctus ultricies nisi.",
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/packages/api/portfolioDrafts/application/createApplicationStep.test.ts
+++ b/packages/api/portfolioDrafts/application/createApplicationStep.test.ts
@@ -1,0 +1,136 @@
+import { DynamoDBDocumentClient, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { mockClient } from "aws-sdk-client-mock";
+import { ApplicationStep } from "../../models/ApplicationStep";
+import { AccessLevel } from "../../models/AccessLevel";
+import { handler } from "./createApplicationStep";
+import { ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
+import { isApplicationStep } from "../../utils/validation";
+import { NO_SUCH_PORTFOLIO_DRAFT, REQUEST_BODY_INVALID } from "../../utils/errors";
+import { ErrorCodes } from "../../models/Error";
+import cloneDeep from "lodash.clonedeep";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+// NOTE: consider moving this to a shared location so that other tests can use it
+const emptyEvent: APIGatewayProxyEvent = {
+  body: "",
+  headers: {},
+  httpMethod: "",
+  isBase64Encoded: false,
+  path: "",
+  pathParameters: {},
+  queryStringParameters: null,
+  stageVariables: {},
+  requestContext: {} as never,
+  resource: "",
+  multiValueHeaders: {},
+  multiValueQueryStringParameters: {},
+};
+
+const mockPortfolioDraftId = "12345a67-b89c-01d2-ef34-5678901ab234";
+
+const applicationStepMinimal: ApplicationStep = {
+  name: "app name",
+  description: "app desc",
+  environments: [
+    {
+      name: "env 1 name",
+      operators: [
+        {
+          access: AccessLevel.ADMINISTRATOR,
+          email: "valid.email@foo.com",
+          first_name: "Homer",
+          last_name: "Simpson",
+        },
+      ],
+    },
+  ],
+};
+
+describe("Successful operation tests", () => {
+  const validRequest = cloneDeep(emptyEvent);
+  validRequest.pathParameters = { portfolioDraftId: mockPortfolioDraftId };
+  validRequest.body = JSON.stringify(applicationStepMinimal);
+
+  beforeEach(() => {
+    ddbMock.on(UpdateCommand).resolves({ Attributes: applicationStepMinimal });
+  });
+
+  it("should return HTTP response status code 201 Created", async () => {
+    const result = await handler(validRequest);
+    expect(result.statusCode).toEqual(SuccessStatusCode.CREATED);
+  });
+  it("should return a response body that looks like a ApplicationStep", async () => {
+    const result = await handler(validRequest);
+    expect(isApplicationStep(JSON.parse(result.body))).toBeTruthy();
+  });
+});
+
+describe("Invalid input tests", () => {
+  it("should return status code 400 if body is not JSON", async () => {
+    const request = cloneDeep(emptyEvent);
+    request.pathParameters = { portfolioDraftId: mockPortfolioDraftId };
+    request.body = "a string that is not JSON";
+    expect(await handler(request)).toEqual(REQUEST_BODY_INVALID);
+  });
+  it("should return status code 400 if app name is too few characters", async () => {
+    await doStringLengthTest("name", null, "a", /application name invalid/);
+  });
+  it("should return status code 400 if app name is too many characters", async () => {
+    await doStringLengthTest(
+      "name",
+      null,
+      "this is tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo long",
+      /application name invalid/
+    );
+  });
+  it("should return status code 400 if environment name is too few characters", async () => {
+    await doStringLengthTest("environments", "name", "a", /environment name invalid/);
+  });
+  it("should return status code 400 if environment name is too many characters", async () => {
+    await doStringLengthTest(
+      "environments",
+      "name",
+      "this is tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo long",
+      /environment name invalid/
+    );
+  });
+
+  async function doStringLengthTest(appProperty: string, envProperty: string | null, value: string, message: RegExp) {
+    const body = JSON.parse(JSON.stringify(applicationStepMinimal));
+    if (envProperty) {
+      body[appProperty][0][envProperty] = value;
+    } else {
+      body[appProperty] = value;
+    }
+    const request = cloneDeep(emptyEvent);
+    request.pathParameters = { portfolioDraftId: mockPortfolioDraftId };
+    request.body = JSON.stringify(body);
+
+    const result = await handler(request);
+    expect(result).toBeInstanceOf(ErrorResponse);
+    expect(result.statusCode).toEqual(ErrorStatusCode.BAD_REQUEST);
+    expect(JSON.parse(result.body).code).toEqual(ErrorCodes.INVALID_INPUT);
+    expect(JSON.parse(result.body).message).toMatch(message);
+  }
+});
+
+describe("Portfolio Draft DNE tests", () => {
+  it.todo("should return PATH_PARAMETER_REQUIRED_BUT_MISSING if no path param");
+
+  it("should return status code 404 & error body with message 'Portfolio Draft with the given ID does not exist'", async () => {
+    ddbMock.on(UpdateCommand).rejects({
+      name: "ConditionalCheckFailedException",
+    });
+    const request = cloneDeep(emptyEvent);
+    request.pathParameters = { portfolioDraftId: "invalid" };
+    request.body = JSON.stringify(applicationStepMinimal);
+
+    const result = await handler(request);
+    expect(result).toEqual(NO_SUCH_PORTFOLIO_DRAFT);
+  });
+});

--- a/packages/api/portfolioDrafts/application/createApplicationStep.test.ts
+++ b/packages/api/portfolioDrafts/application/createApplicationStep.test.ts
@@ -1,136 +1,213 @@
-import { DynamoDBDocumentClient, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent } from "aws-lambda";
-import { mockClient } from "aws-sdk-client-mock";
-import { ApplicationStep } from "../../models/ApplicationStep";
-import { AccessLevel } from "../../models/AccessLevel";
-import { handler } from "./createApplicationStep";
-import { ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
+import { ApiSuccessResponse, ErrorStatusCode, OtherErrorResponse, SuccessStatusCode } from "../../utils/response";
+import { DynamoDBDocumentClient, UpdateCommand, UpdateCommandOutput } from "@aws-sdk/lib-dynamodb";
+import { handler, validateApplication, validateEnvironment } from "./createApplicationStep";
 import { isApplicationStep } from "../../utils/validation";
-import { NO_SUCH_PORTFOLIO_DRAFT, REQUEST_BODY_INVALID } from "../../utils/errors";
-import { ErrorCodes } from "../../models/Error";
-import cloneDeep from "lodash.clonedeep";
+import { mockApplicationStep, mockApplicationStepsBadData } from "./commonMockData";
+import { mockClient } from "aws-sdk-client-mock";
+import { ProvisioningStatus } from "../../models/ProvisioningStatus";
+import { v4 as uuidv4 } from "uuid";
+import {
+  DATABASE_ERROR,
+  NO_SUCH_PORTFOLIO_DRAFT,
+  PATH_PARAMETER_REQUIRED_BUT_MISSING,
+  REQUEST_BODY_EMPTY,
+  REQUEST_BODY_INVALID,
+} from "../../utils/errors";
+import { ValidationMessage } from "../../models/ApplicationStep";
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 beforeEach(() => {
   ddbMock.reset();
 });
 
-// NOTE: consider moving this to a shared location so that other tests can use it
-const emptyEvent: APIGatewayProxyEvent = {
-  body: "",
-  headers: {},
-  httpMethod: "",
-  isBase64Encoded: false,
-  path: "",
-  pathParameters: {},
-  queryStringParameters: null,
-  stageVariables: {},
-  requestContext: {} as never,
-  resource: "",
-  multiValueHeaders: {},
-  multiValueQueryStringParameters: {},
-};
+const validRequest: APIGatewayProxyEvent = {
+  body: JSON.stringify(mockApplicationStep),
+  pathParameters: { portfolioDraftId: uuidv4() },
+} as any;
 
-const mockPortfolioDraftId = "12345a67-b89c-01d2-ef34-5678901ab234";
-
-const applicationStepMinimal: ApplicationStep = {
-  name: "app name",
-  description: "app desc",
-  environments: [
-    {
-      name: "env 1 name",
-      operators: [
-        {
-          access: AccessLevel.ADMINISTRATOR,
-          email: "valid.email@foo.com",
-          first_name: "Homer",
-          last_name: "Simpson",
-        },
-      ],
-    },
-  ],
-};
-
-describe("Successful operation tests", () => {
-  const validRequest = cloneDeep(emptyEvent);
-  validRequest.pathParameters = { portfolioDraftId: mockPortfolioDraftId };
-  validRequest.body = JSON.stringify(applicationStepMinimal);
-
-  beforeEach(() => {
-    ddbMock.on(UpdateCommand).resolves({ Attributes: applicationStepMinimal });
-  });
-
-  it("should return HTTP response status code 201 Created", async () => {
+describe("Handle service level error", function () {
+  it("should return generic Error if exception caught", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => jest.fn()); // suppress output
+    ddbMock.on(UpdateCommand).rejects("Some error occurred");
     const result = await handler(validRequest);
-    expect(result.statusCode).toEqual(SuccessStatusCode.CREATED);
-  });
-  it("should return a response body that looks like a ApplicationStep", async () => {
-    const result = await handler(validRequest);
-    expect(isApplicationStep(JSON.parse(result.body))).toBeTruthy();
+    expect(result).toBeInstanceOf(OtherErrorResponse);
+    expect(result).toEqual(DATABASE_ERROR);
+    expect(result.statusCode).toEqual(ErrorStatusCode.INTERNAL_SERVER_ERROR);
   });
 });
 
-describe("Invalid input tests", () => {
-  it("should return status code 400 if body is not JSON", async () => {
-    const request = cloneDeep(emptyEvent);
-    request.pathParameters = { portfolioDraftId: mockPortfolioDraftId };
-    request.body = "a string that is not JSON";
-    expect(await handler(request)).toEqual(REQUEST_BODY_INVALID);
-  });
-  it("should return status code 400 if app name is too few characters", async () => {
-    await doStringLengthTest("name", null, "a", /application name invalid/);
-  });
-  it("should return status code 400 if app name is too many characters", async () => {
-    await doStringLengthTest(
-      "name",
-      null,
-      "this is tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo long",
-      /application name invalid/
-    );
-  });
-  it("should return status code 400 if environment name is too few characters", async () => {
-    await doStringLengthTest("environments", "name", "a", /environment name invalid/);
-  });
-  it("should return status code 400 if environment name is too many characters", async () => {
-    await doStringLengthTest(
-      "environments",
-      "name",
-      "this is tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo long",
-      /environment name invalid/
-    );
-  });
-
-  async function doStringLengthTest(appProperty: string, envProperty: string | null, value: string, message: RegExp) {
-    const body = JSON.parse(JSON.stringify(applicationStepMinimal));
-    if (envProperty) {
-      body[appProperty][0][envProperty] = value;
-    } else {
-      body[appProperty] = value;
-    }
-    const request = cloneDeep(emptyEvent);
-    request.pathParameters = { portfolioDraftId: mockPortfolioDraftId };
-    request.body = JSON.stringify(body);
-
-    const result = await handler(request);
-    expect(result).toBeInstanceOf(ErrorResponse);
+describe("Path parameter tests", function () {
+  it("should require path param", async () => {
+    const emptyRequest: APIGatewayProxyEvent = {} as any; // no pathParameters
+    const result = await handler(emptyRequest);
+    expect(result).toBeInstanceOf(OtherErrorResponse);
+    expect(result).toEqual(PATH_PARAMETER_REQUIRED_BUT_MISSING);
     expect(result.statusCode).toEqual(ErrorStatusCode.BAD_REQUEST);
-    expect(JSON.parse(result.body).code).toEqual(ErrorCodes.INVALID_INPUT);
-    expect(JSON.parse(result.body).message).toMatch(message);
-  }
-});
-
-describe("Portfolio Draft DNE tests", () => {
-  it.todo("should return PATH_PARAMETER_REQUIRED_BUT_MISSING if no path param");
-
-  it("should return status code 404 & error body with message 'Portfolio Draft with the given ID does not exist'", async () => {
-    ddbMock.on(UpdateCommand).rejects({
-      name: "ConditionalCheckFailedException",
-    });
-    const request = cloneDeep(emptyEvent);
-    request.pathParameters = { portfolioDraftId: "invalid" };
-    request.body = JSON.stringify(applicationStepMinimal);
-
-    const result = await handler(request);
+  });
+  it("should return error when path param not UUIDv4 (to avoid attempting update)", async () => {
+    const invalidRequest: APIGatewayProxyEvent = {
+      pathParameters: { portfolioDraftId: "invalid" }, // not UUIDv4
+    } as any;
+    const result = await handler(invalidRequest);
+    expect(result).toBeInstanceOf(OtherErrorResponse);
     expect(result).toEqual(NO_SUCH_PORTFOLIO_DRAFT);
+    expect(result.statusCode).toEqual(ErrorStatusCode.NOT_FOUND);
+    expect(JSON.parse(result.body).message).toMatch(/Portfolio Draft with the given ID does not exist/);
   });
 });
+
+describe("Request body tests", function () {
+  it("should return error when request body is empty", async () => {
+    const emptyRequest: APIGatewayProxyEvent = {
+      body: "", // empty body
+      pathParameters: { portfolioDraftId: uuidv4() },
+    } as any;
+    const result = await handler(emptyRequest);
+    expect(result).toBeInstanceOf(OtherErrorResponse);
+    expect(result).toEqual(REQUEST_BODY_EMPTY);
+    expect(result.statusCode).toEqual(ErrorStatusCode.BAD_REQUEST);
+    expect(JSON.parse(result.body).message).toMatch(/Request body must not be empty/);
+  });
+  it("should return error when request body is invalid json", async () => {
+    const invalidBodyRequest: APIGatewayProxyEvent = {
+      body: JSON.stringify({ foo: "bar" }) + "}", // invalid json
+      pathParameters: { portfolioDraftId: uuidv4() },
+    } as any;
+    const result = await handler(invalidBodyRequest);
+    expect(result).toBeInstanceOf(OtherErrorResponse);
+    expect(result).toEqual(REQUEST_BODY_INVALID);
+    expect(result.statusCode).toEqual(ErrorStatusCode.BAD_REQUEST);
+    expect(JSON.parse(result.body).message).toMatch(/A valid request body must be provided/);
+  });
+  it("should return error when request body is not a application step", async () => {
+    const notApplicationStepRequest: APIGatewayProxyEvent = {
+      body: JSON.stringify({ foo: "bar" }), // valid json, but not ApplicationStep
+      pathParameters: { portfolioDraftId: uuidv4() },
+    } as any;
+    expect(isApplicationStep(mockApplicationStep)).toEqual(true); // control
+    expect(isApplicationStep(notApplicationStepRequest)).toEqual(false);
+    const result = await handler(notApplicationStepRequest);
+    expect(result).toBeInstanceOf(OtherErrorResponse);
+    expect(result).toEqual(REQUEST_BODY_INVALID);
+    expect(result.statusCode).toEqual(ErrorStatusCode.BAD_REQUEST);
+    expect(JSON.parse(result.body).message).toMatch(/A valid request body must be provided/);
+  });
+});
+
+describe("Successful operation tests", function () {
+  it("should return application step and http status code 201", async () => {
+    const now = new Date().toISOString();
+    const mockResponse = {
+      updated_at: now,
+      created_at: now,
+      application_step: mockApplicationStep,
+      num_portfolio_managers: 0,
+      status: ProvisioningStatus.NOT_STARTED,
+      id: uuidv4(),
+    };
+    ddbMock.on(UpdateCommand).resolves({
+      Attributes: mockResponse,
+    });
+    const applicationStepOutput: UpdateCommandOutput = {
+      Attributes: { application_step: JSON.stringify(mockApplicationStep) },
+    } as any;
+    ddbMock.on(UpdateCommand).resolves(applicationStepOutput);
+    const result = await handler(validRequest);
+    expect(result).toBeInstanceOf(ApiSuccessResponse);
+    expect(result.statusCode).toEqual(SuccessStatusCode.CREATED);
+    expect(result.body).toStrictEqual(JSON.stringify(mockApplicationStep));
+  });
+});
+
+describe("Individual Application input validation tests", function () {
+  it("should throw error if input does not look like an Application", () => {
+    expect(() => {
+      validateApplication({});
+    }).toThrow(Error("Input must be an Application object"));
+  });
+  it("should return no error map entries when given Application has good data", () => {
+    const allerrors = mockApplicationStep.applications
+      .map(validateApplication)
+      .reduce((accumulator, validationErrors) => accumulator.concat(validationErrors), []);
+    expect(allerrors).toStrictEqual([]);
+  });
+  it("should return error map entries when given Application has a name that is too short", () => {
+    const errors = validateApplication(mockApplicationStepsBadData[0].applications[0]);
+    expect(errors.length).toEqual(1);
+    const tooShortName = "abc";
+    expect(errors).toContainEqual({
+      applicationName: tooShortName,
+      invalidParameterName: "name",
+      invalidParameterValue: tooShortName,
+      validationMessage: ValidationMessage.INVALID_APPLICATION_NAME,
+    });
+  });
+  it("should return error map entries when given Application has a name that is too long", () => {
+    const errors = validateApplication(mockApplicationStepsBadData[1].applications[0]);
+    expect(errors.length).toEqual(1);
+    const tooLongName =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eleifend lectus ut luctus ultricies nisi.";
+    expect(errors).toContainEqual({
+      applicationName: tooLongName,
+      invalidParameterName: "name",
+      invalidParameterValue: tooLongName,
+      validationMessage: ValidationMessage.INVALID_APPLICATION_NAME,
+    });
+  });
+  it("should return error map entries when given Application has an Environment with a name that is too short", () => {
+    const errors = validateEnvironment(mockApplicationStepsBadData[2].applications[0].environments[0]);
+    expect(errors.length).toEqual(1);
+    const tooShortName = "abc";
+    expect(errors).toContainEqual({
+      applicationName: tooShortName,
+      invalidParameterName: "name",
+      invalidParameterValue: tooShortName,
+      validationMessage: ValidationMessage.INVALID_ENVIRONMENT_NAME,
+    });
+  });
+  it("should return error map entries when given Application has an Environment with a name that is too long", () => {
+    const errors = validateEnvironment(mockApplicationStepsBadData[3].applications[0].environments[0]);
+    expect(errors.length).toEqual(1);
+    const tooLongName =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eleifend lectus ut luctus ultricies nisi.";
+    expect(errors).toContainEqual({
+      applicationName: tooLongName,
+      invalidParameterName: "name",
+      invalidParameterValue: tooLongName,
+      validationMessage: ValidationMessage.INVALID_ENVIRONMENT_NAME,
+    });
+  });
+});
+
+// // NOTE: consider moving this to a shared location so that other tests can use it
+// const emptyEvent: APIGatewayProxyEvent = {
+//   body: "",
+//   headers: {},
+//   httpMethod: "",
+//   isBase64Encoded: false,
+//   path: "",
+//   pathParameters: {},
+//   queryStringParameters: null,
+//   stageVariables: {},
+//   requestContext: {} as never,
+//   resource: "",
+//   multiValueHeaders: {},
+//   multiValueQueryStringParameters: {},
+// };
+
+// describe("Portfolio Draft DNE tests", () => {
+//   it.todo("should return PATH_PARAMETER_REQUIRED_BUT_MISSING if no path param");
+
+//   it("should return status code 404 & error body with message 'Portfolio Draft with the given ID does not exist'", async () => {
+//     ddbMock.on(UpdateCommand).rejects({
+//       name: "ConditionalCheckFailedException",
+//     });
+//     const request = cloneDeep(emptyEvent);
+//     request.pathParameters = { portfolioDraftId: "invalid" };
+//     request.body = JSON.stringify(applicationStepMinimal);
+
+//     const result = await handler(request);
+//     expect(result).toEqual(NO_SUCH_PORTFOLIO_DRAFT);
+//   });
+// });

--- a/packages/api/portfolioDrafts/application/createApplicationStep.test.ts
+++ b/packages/api/portfolioDrafts/application/createApplicationStep.test.ts
@@ -14,8 +14,8 @@ import {
 import {
   createValidationErrorResponse,
   handler,
-  validateApplication,
-  validateEnvironment,
+  performDataValidationOnApplication,
+  performDataValidationOnEnvironment,
 } from "./createApplicationStep";
 import {
   DATABASE_ERROR,
@@ -114,7 +114,7 @@ describe("Successful operation tests", function () {
 describe("Individual Application input validation tests", function () {
   it("should return no error map entries when given Application has good data", () => {
     const allerrors = mockApplicationStep.applications
-      .map(validateApplication)
+      .map(performDataValidationOnApplication)
       .reduce((accumulator, validationErrors) => accumulator.concat(validationErrors), []);
     expect(allerrors).toStrictEqual([]);
   });
@@ -122,7 +122,7 @@ describe("Individual Application input validation tests", function () {
   const tooLongName =
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eleifend lectus ut luctus ultricies nisi.";
   it("should return error map entries when given Application has a name that is too short", () => {
-    const errors = validateApplication(mockApplicationStepsBadData[0].applications[0]);
+    const errors = performDataValidationOnApplication(mockApplicationStepsBadData[0].applications[0]);
     expect(errors.length).toEqual(1);
     expect(errors).toContainEqual({
       applicationName: tooShortName,
@@ -132,7 +132,7 @@ describe("Individual Application input validation tests", function () {
     });
   });
   it("should return error map entries when given Application has a name that is too long", () => {
-    const errors = validateApplication(mockApplicationStepsBadData[1].applications[0]);
+    const errors = performDataValidationOnApplication(mockApplicationStepsBadData[1].applications[0]);
     expect(errors.length).toEqual(1);
     expect(errors).toContainEqual({
       applicationName: tooLongName,
@@ -142,7 +142,7 @@ describe("Individual Application input validation tests", function () {
     });
   });
   it("should return error map entries when given Application has an Environment with a name that is too short", () => {
-    const errors = validateEnvironment(mockApplicationStepsBadData[2].applications[0].environments[0]);
+    const errors = performDataValidationOnEnvironment(mockApplicationStepsBadData[2].applications[0].environments[0]);
     expect(errors.length).toEqual(1);
     expect(errors).toContainEqual({
       applicationName: tooShortName,
@@ -152,7 +152,7 @@ describe("Individual Application input validation tests", function () {
     });
   });
   it("should return error map entries when given Application has an Environment with a name that is too long", () => {
-    const errors = validateEnvironment(mockApplicationStepsBadData[3].applications[0].environments[0]);
+    const errors = performDataValidationOnEnvironment(mockApplicationStepsBadData[3].applications[0].environments[0]);
     expect(errors.length).toEqual(1);
     expect(errors).toContainEqual({
       applicationName: tooLongName,

--- a/packages/api/portfolioDrafts/application/createApplicationStep.ts
+++ b/packages/api/portfolioDrafts/application/createApplicationStep.ts
@@ -1,0 +1,104 @@
+import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { ApplicationStep } from "../../models/ApplicationStep";
+import { APPLICATION_STEP } from "../../models/PortfolioDraft";
+import { dynamodbDocumentClient as client } from "../../utils/dynamodb";
+import {
+  DATABASE_ERROR,
+  NO_SUCH_PORTFOLIO_DRAFT,
+  PATH_PARAMETER_REQUIRED_BUT_MISSING,
+  REQUEST_BODY_EMPTY,
+  REQUEST_BODY_INVALID,
+} from "../../utils/errors";
+import { ApiSuccessResponse, ErrorResponse, ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
+import { isApplicationStep, isValidJson } from "../../utils/validation";
+import { ErrorCodes, ValidationError } from "../../models/Error";
+
+/**
+ * Submits the Application Step of the Portfolio Draft Wizard
+ *
+ * @param event - The POST request from API Gateway
+ */
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  if (!event.body) {
+    return REQUEST_BODY_EMPTY;
+  }
+
+  const portfolioDraftId = event.pathParameters?.portfolioDraftId;
+
+  if (!portfolioDraftId) {
+    return PATH_PARAMETER_REQUIRED_BUT_MISSING;
+  }
+
+  if (!isValidJson(event.body)) {
+    return REQUEST_BODY_INVALID;
+  }
+  const requestBody = JSON.parse(event.body);
+
+  // remove this, and function?
+  if (!isApplicationStep(requestBody)) {
+    return REQUEST_BODY_INVALID;
+  }
+  const now = new Date().toISOString();
+  const applicationStep: ApplicationStep = requestBody;
+
+  // NOTE This is absolutely not want we want to do long term but I am just trying to meet the ACs as simply as possible
+  const error = validate(applicationStep);
+  if (error) {
+    return new ErrorResponse({ code: error.code, message: error.message }, ErrorStatusCode.BAD_REQUEST);
+  }
+
+  const command = new UpdateCommand({
+    TableName: process.env.ATAT_TABLE_NAME ?? "",
+    Key: {
+      id: portfolioDraftId,
+    },
+    UpdateExpression: "set #portfolioVariable = :application, updated_at = :now",
+    ExpressionAttributeNames: {
+      "#portfolioVariable": APPLICATION_STEP,
+    },
+    ExpressionAttributeValues: {
+      ":application": applicationStep,
+      ":now": now,
+    },
+    ConditionExpression: "attribute_exists(created_at)",
+  });
+
+  try {
+    await client.send(command);
+  } catch (error) {
+    if (error.name === "ConditionalCheckFailedException") {
+      return NO_SUCH_PORTFOLIO_DRAFT;
+    }
+    console.error("Database error: " + error);
+    return DATABASE_ERROR;
+  }
+  return new ApiSuccessResponse<ApplicationStep>(applicationStep, SuccessStatusCode.CREATED);
+}
+
+function validate(applicationStep: ApplicationStep): ValidationError | null {
+  // NOTE: this is a quick and dirty validation attempt that will likely be replaced by a full-featured solution in AT-6549
+  // It will not provide an error map because of the complexity involved.
+  if (applicationStep.name.length < 4 || applicationStep.name.length > 100) {
+    return {
+      code: ErrorCodes.INVALID_INPUT,
+      message: "application name invalid",
+    } as ValidationError;
+  }
+  if (!applicationStep.environments || applicationStep.environments?.length === 0) {
+    return {
+      code: ErrorCodes.INVALID_INPUT,
+      message: "environments must be included",
+    } as ValidationError;
+  }
+  for (const environment of applicationStep.environments) {
+    if (environment.name.length < 4 || environment.name.length > 100) {
+      return {
+        code: ErrorCodes.INVALID_INPUT,
+        message: "environment name invalid",
+      } as ValidationError;
+    }
+  }
+
+  return null;
+}

--- a/packages/api/portfolioDrafts/application/createApplicationStep.ts
+++ b/packages/api/portfolioDrafts/application/createApplicationStep.ts
@@ -45,7 +45,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     return REQUEST_BODY_INVALID;
   }
   const applicationStep: ApplicationStep = requestBody;
-  const errors: Array<ApplicationValidationError> = validateApplicationStep(applicationStep);
+  const errors: Array<ApplicationValidationError> = performDataValidation(applicationStep);
   if (errors.length) {
     return createValidationErrorResponse({ input_validation_errors: errors });
   }
@@ -79,23 +79,23 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
 }
 
 /**
- * Validates the given ApplicationStep
- * Performs input validation on all Applications and Environments contained therein
- * @param applicationStep the object to validate
+ * Performs data validation on the given ApplicationStep object
+ * Also performs data validation on all Applications and Environments contained therein
+ * @param applicationStep the object containing data to validate
  * @returns a collection of application validation errors
  */
-export function validateApplicationStep(applicationStep: ApplicationStep): Array<ApplicationValidationError> {
+export function performDataValidation(applicationStep: ApplicationStep): Array<ApplicationValidationError> {
   return applicationStep.applications
-    .map(validateApplication)
+    .map(performDataValidationOnApplication)
     .reduce((accumulator, validationErrors) => accumulator.concat(validationErrors), []);
 }
 
 /**
- * Validates the given Application object
- * @param application the object to validate
+ * Performs data validation on the given Application object
+ * @param application the object containing data to validate
  * @returns a collection of application validation errors
  */
-export function validateApplication(application: Application): Array<ApplicationValidationError> {
+export function performDataValidationOnApplication(application: Application): Array<ApplicationValidationError> {
   const errors = Array<ApplicationValidationError>();
   if (application.name.length < 4 || application.name.length > 100) {
     errors.push({
@@ -106,18 +106,18 @@ export function validateApplication(application: Application): Array<Application
     });
   }
   const environmentErrors = application.environments
-    .map(validateEnvironment)
+    .map(performDataValidationOnEnvironment)
     .reduce((accumulator, validationErrors) => accumulator.concat(validationErrors), []);
 
   return errors.concat(environmentErrors);
 }
 
 /**
- * Validates the given Environment object
- * @param environment the object to validate
+ * Performs data validation on the given Environment object
+ * @param environment the object containing data to validate
  * @returns a collection of application validation errors
  */
-export function validateEnvironment(environment: Environment): Array<ApplicationValidationError> {
+export function performDataValidationOnEnvironment(environment: Environment): Array<ApplicationValidationError> {
   const errors = Array<ApplicationValidationError>();
   if (environment.name.length < 4 || environment.name.length > 100) {
     errors.push({

--- a/packages/api/portfolioDrafts/application/createApplicationStep.ts
+++ b/packages/api/portfolioDrafts/application/createApplicationStep.ts
@@ -13,7 +13,7 @@ import {
   REQUEST_BODY_INVALID,
 } from "../../utils/errors";
 import { ApiSuccessResponse, SuccessStatusCode, ValidationErrorResponse } from "../../utils/response";
-import { isApplicationStep, isValidJson, isValidUuidV4 } from "../../utils/validation";
+import { isApplicationStep, isBodyPresent, isValidJson, isValidUuidV4 } from "../../utils/validation";
 export interface ApplicationValidationError {
   applicationName: string;
   invalidParameterName: string;
@@ -34,7 +34,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   if (!isValidUuidV4(portfolioDraftId)) {
     return NO_SUCH_PORTFOLIO_DRAFT;
   }
-  if (!event.body) {
+  if (!isBodyPresent(event.body)) {
     return REQUEST_BODY_EMPTY;
   }
   if (!isValidJson(event.body)) {

--- a/packages/api/portfolioDrafts/application/createApplicationStep.ts
+++ b/packages/api/portfolioDrafts/application/createApplicationStep.ts
@@ -45,7 +45,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     return REQUEST_BODY_INVALID;
   }
   const applicationStep: ApplicationStep = requestBody;
-  const errors: Array<ApplicationValidationError> = validateApplications(applicationStep);
+  const errors: Array<ApplicationValidationError> = validateApplicationStep(applicationStep);
   if (errors.length) {
     return createValidationErrorResponse({ input_validation_errors: errors });
   }
@@ -79,11 +79,12 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
 }
 
 /**
- * Accepts an Application Step and performs input validation
- * on all Applications contained therein.
+ * Validates the given ApplicationStep
+ * Performs input validation on all Applications and Environments contained therein
+ * @param applicationStep the object to validate
  * @returns a collection of application validation errors
  */
-export function validateApplications(applicationStep: ApplicationStep): Array<ApplicationValidationError> {
+export function validateApplicationStep(applicationStep: ApplicationStep): Array<ApplicationValidationError> {
   return applicationStep.applications
     .map(validateApplication)
     .reduce((accumulator, validationErrors) => accumulator.concat(validationErrors), []);
@@ -91,7 +92,7 @@ export function validateApplications(applicationStep: ApplicationStep): Array<Ap
 
 /**
  * Validates the given Application object
- * @param application an object that looks like an Application
+ * @param application the object to validate
  * @returns a collection of application validation errors
  */
 export function validateApplication(application: Application): Array<ApplicationValidationError> {
@@ -111,6 +112,11 @@ export function validateApplication(application: Application): Array<Application
   return errors.concat(environmentErrors);
 }
 
+/**
+ * Validates the given Environment object
+ * @param environment the object to validate
+ * @returns a collection of application validation errors
+ */
 export function validateEnvironment(environment: Environment): Array<ApplicationValidationError> {
   const errors = Array<ApplicationValidationError>();
   if (environment.name.length < 4 || environment.name.length > 100) {

--- a/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
@@ -1,15 +1,11 @@
-import { DynamoDBDocumentClient, GetCommand, GetCommandOutput } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent } from "aws-lambda";
+import { ApiSuccessResponse, ErrorStatusCode, OtherErrorResponse, SuccessStatusCode } from "../../utils/response";
+import { DATABASE_ERROR, NO_SUCH_APPLICATION_STEP, PATH_PARAMETER_REQUIRED_BUT_MISSING } from "../../utils/errors";
+import { DynamoDBDocumentClient, GetCommand, GetCommandOutput } from "@aws-sdk/lib-dynamodb";
+import { handler, NO_SUCH_PORTFOLIO_DRAFT } from "./getApplicationStep";
+import { mockApplicationStep } from "./commonMockData";
 import { mockClient } from "aws-sdk-client-mock";
 import { v4 as uuidv4 } from "uuid";
-import { AccessLevel } from "../../models/AccessLevel";
-import { ApplicationStep } from "../../models/ApplicationStep";
-import { Environment } from "../../models/Environment";
-import { ErrorCode } from "../../models/Error";
-import { Operator } from "../../models/Operator";
-import { DATABASE_ERROR, NO_SUCH_APPLICATION_STEP, PATH_PARAMETER_REQUIRED_BUT_MISSING } from "../../utils/errors";
-import { ApiSuccessResponse, ErrorStatusCode, OtherErrorResponse, SuccessStatusCode } from "../../utils/response";
-import { handler, NO_SUCH_PORTFOLIO_DRAFT } from "./getApplicationStep";
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 beforeEach(() => {
@@ -27,7 +23,6 @@ it("should return generic Error if exception caught", async () => {
   expect(result).toBeInstanceOf(OtherErrorResponse);
   expect(result).toEqual(DATABASE_ERROR);
   expect(result.statusCode).toEqual(ErrorStatusCode.INTERNAL_SERVER_ERROR);
-  expect(JSON.parse(result.body).code).toEqual(ErrorCode.OTHER);
 });
 it("should require path param", async () => {
   const emptyRequest: APIGatewayProxyEvent = {} as any;
@@ -35,7 +30,6 @@ it("should require path param", async () => {
   expect(result).toBeInstanceOf(OtherErrorResponse);
   expect(result).toEqual(PATH_PARAMETER_REQUIRED_BUT_MISSING);
   expect(result.statusCode).toEqual(ErrorStatusCode.BAD_REQUEST);
-  expect(JSON.parse(result.body).code).toEqual(ErrorCode.OTHER);
 });
 it("should return error when path param not UUIDv4 (to avoid performing query)", async () => {
   const invalidRequest: APIGatewayProxyEvent = {
@@ -45,7 +39,6 @@ it("should return error when path param not UUIDv4 (to avoid performing query)",
   expect(result).toBeInstanceOf(OtherErrorResponse);
   expect(result).toEqual(NO_SUCH_PORTFOLIO_DRAFT);
   expect(result.statusCode).toEqual(ErrorStatusCode.BAD_REQUEST);
-  expect(JSON.parse(result.body).code).toEqual(ErrorCode.OTHER);
   expect(JSON.parse(result.body).message).toMatch(/The given Portfolio Draft does not exist/);
 });
 it("should return error if portfolio draft does not exist", async () => {
@@ -55,7 +48,6 @@ it("should return error if portfolio draft does not exist", async () => {
   expect(result).toBeInstanceOf(OtherErrorResponse);
   expect(result).toEqual(NO_SUCH_PORTFOLIO_DRAFT);
   expect(result.statusCode).toEqual(ErrorStatusCode.BAD_REQUEST);
-  expect(JSON.parse(result.body).code).toEqual(ErrorCode.OTHER);
   expect(JSON.parse(result.body).message).toMatch(/The given Portfolio Draft does not exist/);
 });
 it("should return error if application step does not exist in portfolio draft", async () => {
@@ -65,7 +57,6 @@ it("should return error if application step does not exist in portfolio draft", 
   expect(result).toBeInstanceOf(OtherErrorResponse);
   expect(result).toEqual(NO_SUCH_APPLICATION_STEP);
   expect(result.statusCode).toEqual(ErrorStatusCode.NOT_FOUND);
-  expect(JSON.parse(result.body).code).toEqual(ErrorCode.OTHER);
   expect(JSON.parse(result.body).message).toMatch(/Application Step not found for this Portfolio Draft/);
 });
 it("should return application step", async () => {
@@ -77,58 +68,8 @@ it("should return application step", async () => {
   expect(result.body).toEqual(JSON.stringify({}));
 });
 it("should return application step with sample data", async () => {
-  const fullAppStepOutput: GetCommandOutput = { Item: { application_step: mockApplicationStep() } } as any;
+  const fullAppStepOutput: GetCommandOutput = { Item: { application_step: mockApplicationStep } } as any;
   ddbMock.on(GetCommand).resolves(fullAppStepOutput);
   const result = await handler(validRequest);
-  expect(result.body).toStrictEqual(JSON.stringify(mockApplicationStep()));
+  expect(result.body).toStrictEqual(JSON.stringify(mockApplicationStep));
 });
-
-/**
- * PortfolioDraftSummaryEx from API spec
- * @returns a complete ApplicationStep
- */
-function mockApplicationStep(): ApplicationStep {
-  const mockOperatorDarthVader: Operator = {
-    first_name: "Darth",
-    last_name: "Vader",
-    email: "iam@yourfather.com",
-    access: AccessLevel.ADMINISTRATOR,
-  };
-  const mockOperatorHanSolo: Operator = {
-    first_name: "Han",
-    last_name: "Solo",
-    email: "frozen@carbonite.com",
-    access: AccessLevel.READ_ONLY,
-  };
-  const mockOperatorLukeSkywalker: Operator = {
-    first_name: "Luke",
-    last_name: "Skywalker",
-    email: "lostmy@hand.com",
-    access: AccessLevel.READ_ONLY,
-  };
-  const mockOperatorSalaciousCrumb: Operator = {
-    first_name: "Salacious",
-    last_name: "Crumb",
-    email: "monkey@lizard.com",
-    access: AccessLevel.ADMINISTRATOR,
-  };
-  const mockOperatorBobaFett: Operator = {
-    first_name: "Boba",
-    last_name: "Fett",
-    email: "original@mandalorian.com",
-    access: AccessLevel.READ_ONLY,
-  };
-  const mockEnvironmentCloudCity: Environment = {
-    name: "Cloud City",
-    operators: [mockOperatorDarthVader, mockOperatorHanSolo, mockOperatorLukeSkywalker],
-  };
-  const mockEnvironmentJabbasPalace: Environment = {
-    name: "Jabba's Palace",
-    operators: [mockOperatorSalaciousCrumb, mockOperatorHanSolo, mockOperatorBobaFett],
-  };
-  return {
-    name: "Mock Application",
-    description: "The description of the Mock Application",
-    environments: [mockEnvironmentCloudCity, mockEnvironmentJabbasPalace],
-  };
-}

--- a/packages/api/utils/validation.test.ts
+++ b/packages/api/utils/validation.test.ts
@@ -1,4 +1,11 @@
 import {
+  mockApplicationStep,
+  mockApplicationStepsMissingFields,
+  mockApplicationsMissingFields,
+  mockApplicationCloudCityEvacPlanner,
+  mockEnvironmentsMissingFields,
+} from "../portfolioDrafts/application/commonMockData";
+import {
   isBodyPresent,
   isFundingStep,
   isPathParameterPresent,
@@ -8,6 +15,9 @@ import {
   isClin,
   isClinNumber,
   isFundingAmount,
+  isApplicationStep,
+  isApplication,
+  isEnvironment,
 } from "./validation";
 
 describe("Testing validation of request body", function () {
@@ -130,6 +140,40 @@ describe("Testing validation of fundingStep objects", () => {
   });
   it.each(badFundingSteps)("should reject a FundingStep missing any field", async (badStep) => {
     expect(isFundingStep(badStep)).toEqual(false);
+  });
+});
+
+describe("isApplicationStep()", () => {
+  it.each([true, 1, undefined, null])("should reject non-objects", async (item) => {
+    expect(isApplicationStep(item)).toEqual(false);
+  });
+  it("should accept an ApplicationStep object", async () => {
+    expect(isApplicationStep(mockApplicationStep)).toEqual(true);
+  });
+  it("should reject an ApplicationStep missing any field", async () => {
+    expect(isApplicationStep(mockApplicationStepsMissingFields)).toEqual(false);
+  });
+});
+describe("isApplication()", () => {
+  it.each([true, 1, undefined, null])("should reject non-objects", async (item) => {
+    expect(isApplication(item)).toEqual(false);
+  });
+  it.each(mockApplicationStep.applications)("should accept an Application object", async (item) => {
+    expect(isApplication(item)).toEqual(true);
+  });
+  it("should reject an Application missing any field", async () => {
+    expect(isApplication(mockApplicationsMissingFields)).toEqual(false);
+  });
+});
+describe("isEnvironment()", () => {
+  it.each([true, 1, undefined, null])("should reject non-objects", async (item) => {
+    expect(isEnvironment(item)).toEqual(false);
+  });
+  it.each(mockApplicationCloudCityEvacPlanner.environments)("should accept an Environment object", async (item) => {
+    expect(isEnvironment(item)).toEqual(true);
+  });
+  it("should reject an Environment missing any field", async () => {
+    expect(isEnvironment(mockEnvironmentsMissingFields)).toEqual(false);
   });
 });
 

--- a/packages/api/utils/validation.ts
+++ b/packages/api/utils/validation.ts
@@ -3,6 +3,8 @@ import { Clin } from "../models/Clin";
 import { FundingStep } from "../models/FundingStep";
 import { PortfolioStep } from "../models/PortfolioStep";
 import { validate as uuidValidate, version as uuidVersion } from "uuid";
+import { Application } from "../models/Application";
+import { Environment } from "../models/Environment";
 
 /**
  * Check whether a given string is valid JSON.
@@ -85,7 +87,38 @@ export function isApplicationStep(object: unknown): object is ApplicationStep {
   if (!isValidObject(object)) {
     return false;
   }
+  return ["applications"].every((item) => item in object);
+}
+
+/**
+ * Check whether a given object is a {@link Application}.
+ *
+ * Note that this only asserts that the given object meets the interface. It does not validate
+ * that the object is a valid {@link Application}.
+ *
+ * @param object - The object to check
+ * @returns true if the object has all the attributes of a {@link Application}
+ */
+export function isApplication(object: unknown): object is Application {
+  if (!isValidObject(object)) {
+    return false;
+  }
   return ["name", "description", "environments"].every((item) => item in object);
+}
+/**
+ * Check whether a given object is an {@link Environment}.
+ *
+ * Note that this only asserts that the given object meets the interface. It does not validate
+ * that the object is a valid {@link Environment}.
+ *
+ * @param object - The object to check
+ * @returns true if the object has all the attributes of an {@link Environment}
+ */
+export function isEnvironment(object: unknown): object is Environment {
+  if (!isValidObject(object)) {
+    return false;
+  }
+  return ["name", "operators"].every((item) => item in object);
 }
 
 /**


### PR DESCRIPTION
Change model `ApplicationStep` to contain array _applications_

Add model `Application`

Relocate and organize mock data into a common location `application/commonMockData.ts `
 - includes valid objects with good data (above demarcation)
 - includes invalid objects with missing fields and bad data (below demarcation)

Change references in unit tests for GET function to use common mock data
 - remove tests for `ErrorCode.OTHER` due to recent error response improvements in e51344485bbab60be35f3e665f0299e6c4ca1314 and 9497c9b422933bdece3b424e4a9dbbc9e5fc45c6

Apply TDD and lessons from unit testing funding step to function impl and unit tests

Decompose input validation functions for increased testability

Add unit tests for individual input validation

Define enum for validation messages in `ApplicationStep.ts`

Add isApplicationStep(), isApplication(), isEnvironment() to validation module, plus unit tests for each

Create appropriate `ValidationErrorResponse` with `error_map` containing input validation errors

Ticket: AT-6467