### PR TITLE
Share the names of the created IdPs in SSM

### DIFF
--- a/infrastructure/lib/atat-auth-stack.ts
+++ b/infrastructure/lib/atat-auth-stack.ts
@@ -35,10 +35,15 @@ export class AtatAuthStack extends cdk.Stack {
         },
       ],
     });
-    const ssmParam = new ssm.StringParameter(this, "UserPoolIdParameter", {
+    const poolIdParam = new ssm.StringParameter(this, "UserPoolIdParameter", {
       description: "Cognito User Pool ID",
       stringValue: cognitoAuthentication.userPool.userPoolId,
       parameterName: `/atat/${props.environmentId}/cognito/userpool/id`,
+    });
+    const idpNamesParam = new ssm.StringListParameter(this, "CognitoIdPNamesParameter", {
+      description: "Names of configured identity providers",
+      parameterName: `/atat/${props.environmentId}/cognito/idps`,
+      stringListValue: cognitoAuthentication.idps.map((idp) => idp.providerName),
     });
   }
 }


### PR DESCRIPTION
This is required because the UI repo's stack needs to be able to query
the list of IdPs so that the Cognito User Pool Client can configure them
as the supported IdPs.

This will unblock AT-6532.