### PR TITLE
Add CORS workaround

### DIFF
--- a/packages/api/utils/response.test.ts
+++ b/packages/api/utils/response.test.ts
@@ -44,13 +44,21 @@ describe("Validate parsing results in the same object", () => {
 });
 
 describe("Validate header handling", () => {
-  it("should not modify headers", async () => {
+  it("should not delete headers", async () => {
     const successObject = { test: "object" };
     const headers = {
       "Content-Type": "application/json",
       "X-Test-Header": "testing code",
     };
     const successResponse = new response.ApiSuccessResponse(successObject, response.SuccessStatusCode.OK, headers);
-    expect(successResponse.headers).toEqual(headers);
+    expect(successResponse.headers).not.toEqual(undefined);
+    expect(successResponse.headers).not.toEqual(null);
+    // This assertion is safe because we've already asserted through the previous
+    // tests that the input is not undefined/null (which is an assumption of this
+    // class that should hold). If this turns out to not be valid, then the test
+    // should fail regardless.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const responseHeaderKeys = Object.keys(successResponse.headers!);
+    Object.keys(headers).forEach((header) => expect(responseHeaderKeys).toContain(header));
   });
 });

--- a/packages/api/utils/response.ts
+++ b/packages/api/utils/response.ts
@@ -86,6 +86,10 @@ abstract class SuccessResponse extends Response {
     headers?: Headers,
     multiValueHeaders?: MultiValueHeaders
   ) {
+    const temporaryIncompleteCorsHeaderWorkaround = {
+      "Access-Control-Allow-Origin": "*",
+    };
+    headers = { ...headers, ...temporaryIncompleteCorsHeaderWorkaround };
     super(response, statusCode, headers, multiValueHeaders, false);
   }
 }


### PR DESCRIPTION
In the long-term, we need a more complete solution here. And this may
not necessarily be enough. But we're going to want to limit the actual
origins that can interact with ATAT (it should not be \*); however, today
it could be any number of sandbox, local, or "real" environments with
different names so we don't have a true static list of allowed
environments nor a convenient way to dynamically build a list. The
Access-Control-Allow-Origin header also _only_ accepts "none", "*", or a
single origin so we'd need some logic to handle dynamically setting the
header based on the `Origin` header.

We probably want to look into a pattern where this is built based on a
reaction to the event. Or we even want to see if we can push this down
into the API Spec document.

This is added as an inline function with a name to clearly represent
what its purpose is.