### PR TITLE
Add IAM permissions for each role

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,8 @@ jobs:
         run: npm run build
       - name: Synthesize CDK template
         run: cdk synth -c "EnvironmentId=GITHUBWF"
+        env:
+          ATAT_DEPLOY_IAM: 1
       - name: Synthesize CDK template with CDK Nag
         # Errors are allowed here because if there was a true synthesis problem
         # the previous step would have failed and we would not reach this step.
@@ -58,6 +60,7 @@ jobs:
         run: cdk synth -c "EnvironmentId=GITHUBWF" || exit 0
         env:
           CDK_NAG_ENABLED: 1
+          ATAT_DEPLOY_IAM: 1
       - name: Run test suite
         run: npm test
       - name: Gather artifacts

--- a/infrastructure/lib/atat-iam-stack.ts
+++ b/infrastructure/lib/atat-iam-stack.ts
@@ -52,6 +52,20 @@ export class AtatIamStack extends cdk.Stack {
       ],
     });
 
+    const developerCdkStagingAccess = new iam.ManagedPolicy(this, "DeveloperCdkStagingAccess", {
+      statements: [
+        new iam.PolicyStatement({
+          sid: "AllowModifyingCdkToolBuckets",
+          effect: iam.Effect.ALLOW,
+          actions: ["s3:*"],
+          resources: [
+            `arn:${cdk.Aws.PARTITION}:s3:::cdk-hnb659fds-assets-${cdk.Aws.ACCOUNT_ID}-*`,
+            `arn:${cdk.Aws.PARTITION}:s3:::cdktoolkit-stagingbucket-*`,
+          ],
+        }),
+      ],
+    });
+
     // Eventually, this should be restricted to the specific services in use for the application
     // rather than allowing all IAM actions. This still theoretically will give anyone who can pass
     // the role permission to do almost anything in the account; however, it at least requires that
@@ -106,6 +120,7 @@ export class AtatIamStack extends cdk.Stack {
         generalReadAccess,
         awsManagedLogsReadPolicy,
         awsManagedCfnFullAccessPolicy,
+        developerCdkStagingAccess,
         baseDenies,
       ],
     });

--- a/infrastructure/lib/atat-iam-stack.ts
+++ b/infrastructure/lib/atat-iam-stack.ts
@@ -1,0 +1,169 @@
+import * as iam from "@aws-cdk/aws-iam";
+import * as cdk from "@aws-cdk/core";
+import * as custom from "@aws-cdk/custom-resources";
+
+export class AtatIamStack extends cdk.Stack {
+  private readonly outputs: cdk.CfnOutput[] = [];
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    this.templateOptions.description = "Creates the IAM permissions for ATAT developers, testers, and auditors.";
+
+    // job-function/ReadOnlyAccess is actually a somewhat-dangerous IAM policy that
+    // allows users to view sensitive data (such as Lambda environment variables or
+    // some Secrets Manager Secrets). ViewOnlyAccess is more restrictive.
+    // All roles will have ViewOnly access.
+    const awsManagedViewOnlyPolicy = iam.ManagedPolicy.fromAwsManagedPolicyName("job-function/ViewOnlyAccess");
+    const awsManagedLogsReadPolicy = iam.ManagedPolicy.fromAwsManagedPolicyName("CloudWatchLogsReadOnlyAccess");
+    const awsManagedAuditorPolicy = iam.ManagedPolicy.fromAwsManagedPolicyName("SecurityAudit");
+    const awsManagedAdminAccessPolicy = iam.ManagedPolicy.fromAwsManagedPolicyName("AdministratorAccess");
+    const awsManagedCfnFullAccessPolicy = iam.ManagedPolicy.fromAwsManagedPolicyName("AWSCloudFormationFullAccess");
+
+    // In the future, we may want to consider moving to a mechanism where the various
+    // resources, when created, grant access to these administrative roles rather than
+    // having us globally grant access at this level. For example, at this point, it
+    // is appropriate for our users to have access to read all tables directly but
+    // will it always? Might we eventually store sensitive data there?
+    // Eventually, many of these actions may require access to a KMS Key.
+    const generalReadAccess = new iam.ManagedPolicy(this, "GeneralReadAccess", {
+      statements: [
+        new iam.PolicyStatement({
+          sid: "DynamoDBItemAccess",
+          effect: iam.Effect.ALLOW,
+          actions: ["dynamodb:*GetItem", "dynamodb:PartiQLSelect", "dynamodb:Scan", "dynamodb:Query"],
+          resources: [`arn:${cdk.Aws.PARTITION}:dynamodb:*:${cdk.Aws.ACCOUNT_ID}:table/*`],
+        }),
+        new iam.PolicyStatement({
+          sid: "APIGatewayRestApiReadAccess",
+          effect: iam.Effect.ALLOW,
+          actions: ["apigateway:GET"],
+          resources: [`arn:${cdk.Aws.PARTITION}:apigateway:*::/restapis*`],
+        }),
+      ],
+    });
+
+    const baseDenies = new iam.ManagedPolicy(this, "AtatUserDenyPolicy", {
+      statements: [
+        new iam.PolicyStatement({
+          sid: "DenyAllOrganizations",
+          effect: iam.Effect.DENY,
+          actions: ["organizations:*"],
+          resources: ["*"],
+        }),
+      ],
+    });
+
+    // Eventually, this should be restricted to the specific services in use for the application
+    // rather than allowing all IAM actions. This still theoretically will give anyone who can pass
+    // the role permission to do almost anything in the account; however, it at least requires that
+    // it happen via CloudFormation.
+    const cloudFormationExecutionRole = new iam.Role(this, "CloudFormationExecutionRole", {
+      roleName: "AtatCloudFormation",
+      assumedBy: new iam.ServicePrincipal("cloudformation.amazonaws.com"),
+      managedPolicies: [awsManagedAdminAccessPolicy, baseDenies],
+    });
+
+    const managementAccountId = this.findOrganizationManagementAccount();
+    // This is currently used as the trust principal to assume the various roles. This
+    // means that _any_ IAM principal in the management account could theoretically
+    // assume this role. We can either:
+    //  - limit access to assume this role in the management account by only
+    //    granting groups sts:AssumeRole to the specific role that they need to use
+    //  - change this to trusting a specific role in the Management Account which
+    //    is better would require users to possible "double hop" from their User
+    //    to role in the management account and then to this role.
+    // For now, keeping it where any user can assume any of the roles in dev/sandbox
+    // makes it easier for any user to see what another user sees. This will need to
+    // be totally refactored when we introduce Identity Federation for IAM anyway.
+    const managementAccountPrincipal = new iam.AccountPrincipal(managementAccountId);
+
+    // Allow read access to all "safe" resources from AWS as well as those read-only
+    // APIs that we have considered to be safe.
+    const qaAndTestRole = new iam.Role(this, "QaTestingRole", {
+      roleName: "AtatQa",
+      assumedBy: managementAccountPrincipal,
+      managedPolicies: [awsManagedViewOnlyPolicy, generalReadAccess, baseDenies],
+    });
+    // Allow read access to all things our other users have as well as the permissions
+    // defined in the AWS-managed SecurityAudit policy.
+    const auditorRole = new iam.Role(this, "SecurityAuditorRole", {
+      roleName: "AtatSecurityAuditor",
+      assumedBy: managementAccountPrincipal,
+      managedPolicies: [
+        awsManagedViewOnlyPolicy,
+        generalReadAccess,
+        awsManagedLogsReadPolicy,
+        awsManagedAuditorPolicy,
+        baseDenies,
+      ],
+    });
+    // Developers have all the read access of QA and Testing and the ability to pass
+    // the CloudFormation execution role and read all logs in CloudWatch.
+    const developerRole = new iam.Role(this, "DeveloperRole", {
+      roleName: "AtatDeveloper",
+      assumedBy: managementAccountPrincipal,
+      managedPolicies: [
+        awsManagedViewOnlyPolicy,
+        generalReadAccess,
+        awsManagedLogsReadPolicy,
+        awsManagedCfnFullAccessPolicy,
+        baseDenies,
+      ],
+    });
+    cloudFormationExecutionRole.grantPassRole(developerRole);
+
+    this.outputs.push(
+      new cdk.CfnOutput(this, "QaTestRoleArnOutput", {
+        exportName: "AtatQaTestRoleArn",
+        value: qaAndTestRole.roleArn,
+      }),
+      new cdk.CfnOutput(this, "DeveloperRoleArnOutput", {
+        exportName: "AtatDeveloperRoleArn",
+        value: developerRole.roleArn,
+      }),
+      new cdk.CfnOutput(this, "AuditorRoleArnOutput", {
+        exportName: "AtatAuditorRoleArn",
+        value: auditorRole.roleArn,
+      })
+    );
+  }
+
+  private findOrganizationManagementAccount(): string {
+    // - We could require the management account ID to be made available either through
+    //   a configuration or the context; however, that feels unnecessarily complex and
+    //   may result in account IDs accidentally getting checked in to version control.
+    //   By dynamically querying for it when we build the stack, we also make it so that
+    //   the stack can be re-used in different places onces synthesized.
+    //   Because this ID is not provided via SSM and because the CDK itself doesn't give
+    //   any better way to identify the Organization we're a member of, this custom
+    //   resource to invoke the single organizations:DescribeOrganization API is our best
+    //   bet to find that information.
+    // - The API still refers to the field as the "MasterAccountId"; however, much of
+    //   the AWS Organizations documentation has been updated to use the term
+    //   "management account".
+    const organizationManagementAccountFinderResource = new custom.AwsCustomResource(
+      this,
+      "OrganizationManagementAccount",
+      {
+        onCreate: {
+          // service and action take the form of the client and method from the
+          // AWS SDK for JavaScript v2 (so basically, uppercase name for service
+          // and camelCase names for action)
+          service: "Organizations",
+          action: "describeOrganization",
+          // Mapping to the Organization.MasterAccountId field ensures that the
+          // custom "resource" gets "replaced" if the account changes for any
+          // reason
+          physicalResourceId: custom.PhysicalResourceId.fromResponse("Organization.MasterAccountId"),
+        },
+        policy: custom.AwsCustomResourcePolicy.fromSdkCalls({
+          // Using ANY_RESOURCE is required since we do not know the ID/ARN of the
+          // Organization we are querying (that's the whole reason why we have to
+          // invoke this API in the first place)
+          resources: custom.AwsCustomResourcePolicy.ANY_RESOURCE,
+        }),
+      }
+    );
+
+    return organizationManagementAccountFinderResource.getResponseField("Organization.MasterAccountId");
+  }
+}

--- a/infrastructure/package-lock.json
+++ b/infrastructure/package-lock.json
@@ -2939,6 +2939,148 @@
 						"yargs": "^16.2.0"
 					},
 					"dependencies": {
+						"@aws-cdk/cloud-assembly-schema": {
+							"version": "1.124.0",
+							"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.124.0.tgz",
+							"integrity": "sha512-emrkfHetGoh6lhrT7ato06VAZun1UVYjJueL9avHxFgzX5qiobP4iWk6M0EZpk7yHlDOtJtp86MJalYYMS6Oww==",
+							"dev": true,
+							"requires": {
+								"jsonschema": "^1.4.0",
+								"semver": "^7.3.5"
+							},
+							"dependencies": {
+								"jsonschema": {
+									"version": "1.4.0",
+									"bundled": true,
+									"dev": true
+								},
+								"lru-cache": {
+									"version": "6.0.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"yallist": "^4.0.0"
+									}
+								},
+								"semver": {
+									"version": "7.3.5",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"lru-cache": "^6.0.0"
+									}
+								},
+								"yallist": {
+									"version": "4.0.0",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"@aws-cdk/cx-api": {
+							"version": "1.124.0",
+							"resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.124.0.tgz",
+							"integrity": "sha512-InBcAoFJ0Ail7/IhJhhw2OwGyWgBv4HShRA20/czxvlQ2pOezcUxQOCJr5USM6dGvTOlDL38XVrw469m9boUzw==",
+							"dev": true,
+							"requires": {
+								"@aws-cdk/cloud-assembly-schema": "1.124.0",
+								"semver": "^7.3.5"
+							},
+							"dependencies": {
+								"lru-cache": {
+									"version": "6.0.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"yallist": "^4.0.0"
+									}
+								},
+								"semver": {
+									"version": "7.3.5",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"lru-cache": "^6.0.0"
+									}
+								},
+								"yallist": {
+									"version": "4.0.0",
+									"bundled": true,
+									"dev": true
+								}
+							}
+						},
+						"ansi-regex": {
+							"version": "5.0.0",
+							"resolved": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75",
+							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+							"dev": true
+						},
+						"ansi-styles": {
+							"version": "4.3.0",
+							"resolved": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937",
+							"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+							"dev": true,
+							"requires": {
+								"color-convert": "^2.0.1"
+							}
+						},
+						"archiver": {
+							"version": "5.3.0",
+							"resolved": "https://registry.yarnpkg.com/archiver/-/archiver-5.3.0.tgz#dd3e097624481741df626267564f7dd8640a45ba",
+							"integrity": "sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==",
+							"dev": true,
+							"requires": {
+								"archiver-utils": "^2.1.0",
+								"async": "^3.2.0",
+								"buffer-crc32": "^0.2.1",
+								"readable-stream": "^3.6.0",
+								"readdir-glob": "^1.0.0",
+								"tar-stream": "^2.2.0",
+								"zip-stream": "^4.1.0"
+							}
+						},
+						"archiver-utils": {
+							"version": "2.1.0",
+							"resolved": "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-2.1.0.tgz#e8a460e94b693c3e3da182a098ca6285ba9249e2",
+							"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+							"dev": true,
+							"requires": {
+								"glob": "^7.1.4",
+								"graceful-fs": "^4.2.0",
+								"lazystream": "^1.0.0",
+								"lodash.defaults": "^4.2.0",
+								"lodash.difference": "^4.5.0",
+								"lodash.flatten": "^4.4.0",
+								"lodash.isplainobject": "^4.0.6",
+								"lodash.union": "^4.6.0",
+								"normalize-path": "^3.0.0",
+								"readable-stream": "^2.0.0"
+							},
+							"dependencies": {
+								"readable-stream": {
+									"version": "2.3.7",
+									"resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57",
+									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+									"dev": true,
+									"requires": {
+										"core-util-is": "~1.0.0",
+										"inherits": "~2.0.3",
+										"isarray": "~1.0.0",
+										"process-nextick-args": "~2.0.0",
+										"safe-buffer": "~5.1.1",
+										"string_decoder": "~1.1.1",
+										"util-deprecate": "~1.0.1"
+									}
+								}
+							}
+						},
+						"async": {
+							"version": "3.2.0",
+							"resolved": "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720",
+							"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+							"dev": true
+						},
 						"aws-sdk": {
 							"version": "2.950.0",
 							"resolved": "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.950.0.tgz#cffb65590c50de9479c87ed04df57d355d1d8a22",
@@ -2983,11 +3125,549 @@
 								}
 							}
 						},
+						"balanced-match": {
+							"version": "1.0.2",
+							"resolved": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
+							"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+							"dev": true
+						},
+						"base64-js": {
+							"version": "1.5.1",
+							"resolved": "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a",
+							"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+							"dev": true
+						},
+						"bl": {
+							"version": "4.1.0",
+							"resolved": "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a",
+							"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+							"dev": true,
+							"requires": {
+								"buffer": "^5.5.0",
+								"inherits": "^2.0.4",
+								"readable-stream": "^3.4.0"
+							}
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"resolved": "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+							"dev": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"buffer": {
+							"version": "5.7.1",
+							"resolved": "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0",
+							"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+							"dev": true,
+							"requires": {
+								"base64-js": "^1.3.1",
+								"ieee754": "^1.1.13"
+							}
+						},
+						"buffer-crc32": {
+							"version": "0.2.13",
+							"resolved": "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242",
+							"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+							"dev": true
+						},
+						"cliui": {
+							"version": "7.0.4",
+							"resolved": "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f",
+							"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+							"dev": true,
+							"requires": {
+								"string-width": "^4.2.0",
+								"strip-ansi": "^6.0.0",
+								"wrap-ansi": "^7.0.0"
+							}
+						},
+						"color-convert": {
+							"version": "2.0.1",
+							"resolved": "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
+							"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+							"dev": true,
+							"requires": {
+								"color-name": "~1.1.4"
+							}
+						},
+						"color-name": {
+							"version": "1.1.4",
+							"resolved": "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2",
+							"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+							"dev": true
+						},
+						"compress-commons": {
+							"version": "4.1.1",
+							"resolved": "https://registry.yarnpkg.com/compress-commons/-/compress-commons-4.1.1.tgz#df2a09a7ed17447642bad10a85cc9a19e5c42a7d",
+							"integrity": "sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==",
+							"dev": true,
+							"requires": {
+								"buffer-crc32": "^0.2.13",
+								"crc32-stream": "^4.0.2",
+								"normalize-path": "^3.0.0",
+								"readable-stream": "^3.6.0"
+							}
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"resolved": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+							"dev": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"resolved": "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7",
+							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+							"dev": true
+						},
+						"crc-32": {
+							"version": "1.2.0",
+							"resolved": "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208",
+							"integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+							"dev": true,
+							"requires": {
+								"exit-on-epipe": "~1.0.1",
+								"printj": "~1.1.0"
+							}
+						},
+						"crc32-stream": {
+							"version": "4.0.2",
+							"resolved": "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-4.0.2.tgz#c922ad22b38395abe9d3870f02fa8134ed709007",
+							"integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
+							"dev": true,
+							"requires": {
+								"crc-32": "^1.2.0",
+								"readable-stream": "^3.4.0"
+							}
+						},
+						"emoji-regex": {
+							"version": "8.0.0",
+							"resolved": "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37",
+							"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+							"dev": true
+						},
+						"end-of-stream": {
+							"version": "1.4.4",
+							"resolved": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0",
+							"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+							"dev": true,
+							"requires": {
+								"once": "^1.4.0"
+							}
+						},
+						"escalade": {
+							"version": "3.1.1",
+							"resolved": "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40",
+							"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+							"dev": true
+						},
+						"events": {
+							"version": "1.1.1",
+							"resolved": "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924",
+							"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+							"dev": true
+						},
+						"exit-on-epipe": {
+							"version": "1.0.1",
+							"resolved": "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692",
+							"integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
+							"dev": true
+						},
+						"fs-constants": {
+							"version": "1.0.0",
+							"resolved": "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad",
+							"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+							"dev": true
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"resolved": "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f",
+							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+							"dev": true
+						},
+						"get-caller-file": {
+							"version": "2.0.5",
+							"resolved": "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e",
+							"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+							"dev": true
+						},
+						"glob": {
+							"version": "7.1.7",
+							"resolved": "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90",
+							"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+							"dev": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"graceful-fs": {
+							"version": "4.2.6",
+							"resolved": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee",
+							"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+							"dev": true
+						},
+						"ieee754": {
+							"version": "1.2.1",
+							"resolved": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352",
+							"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+							"dev": true
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"resolved": "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+							"dev": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.4",
+							"resolved": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c",
+							"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "3.0.0",
+							"resolved": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d",
+							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+							"dev": true
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"dev": true
+						},
+						"jmespath": {
+							"version": "0.15.0",
+							"resolved": "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217",
+							"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+							"dev": true
+						},
+						"lazystream": {
+							"version": "1.0.0",
+							"resolved": "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4",
+							"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+							"dev": true,
+							"requires": {
+								"readable-stream": "^2.0.5"
+							},
+							"dependencies": {
+								"readable-stream": {
+									"version": "2.3.7",
+									"resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57",
+									"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+									"dev": true,
+									"requires": {
+										"core-util-is": "~1.0.0",
+										"inherits": "~2.0.3",
+										"isarray": "~1.0.0",
+										"process-nextick-args": "~2.0.0",
+										"safe-buffer": "~5.1.1",
+										"string_decoder": "~1.1.1",
+										"util-deprecate": "~1.0.1"
+									}
+								}
+							}
+						},
+						"lodash.defaults": {
+							"version": "4.2.0",
+							"resolved": "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c",
+							"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+							"dev": true
+						},
+						"lodash.difference": {
+							"version": "4.5.0",
+							"resolved": "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c",
+							"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+							"dev": true
+						},
+						"lodash.flatten": {
+							"version": "4.4.0",
+							"resolved": "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f",
+							"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+							"dev": true
+						},
+						"lodash.isplainobject": {
+							"version": "4.0.6",
+							"resolved": "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb",
+							"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+							"dev": true
+						},
+						"lodash.union": {
+							"version": "4.6.0",
+							"resolved": "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88",
+							"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+							"dev": true
+						},
+						"mime": {
+							"version": "2.5.2",
+							"resolved": "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe",
+							"integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+							"dev": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"resolved": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
+							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+							"dev": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"normalize-path": {
+							"version": "3.0.0",
+							"resolved": "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65",
+							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+							"dev": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"resolved": "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+							"dev": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"resolved": "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+							"dev": true
+						},
+						"printj": {
+							"version": "1.1.2",
+							"resolved": "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222",
+							"integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+							"dev": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.1",
+							"resolved": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2",
+							"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+							"dev": true
+						},
+						"punycode": {
+							"version": "1.3.2",
+							"resolved": "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d",
+							"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+							"dev": true
+						},
+						"querystring": {
+							"version": "0.2.0",
+							"resolved": "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620",
+							"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "3.6.0",
+							"resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+							"dev": true,
+							"requires": {
+								"inherits": "^2.0.3",
+								"string_decoder": "^1.1.1",
+								"util-deprecate": "^1.0.1"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.2.1",
+									"resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+									"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+									"dev": true
+								},
+								"string_decoder": {
+									"version": "1.3.0",
+									"resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+									"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+									"dev": true,
+									"requires": {
+										"safe-buffer": "~5.2.0"
+									}
+								}
+							}
+						},
+						"readdir-glob": {
+							"version": "1.1.1",
+							"resolved": "https://registry.yarnpkg.com/readdir-glob/-/readdir-glob-1.1.1.tgz#f0e10bb7bf7bfa7e0add8baffdc54c3f7dbee6c4",
+							"integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
+							"dev": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"require-directory": {
+							"version": "2.1.1",
+							"resolved": "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+							"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+							"dev": true
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+							"dev": true
+						},
+						"sax": {
+							"version": "1.2.1",
+							"resolved": "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a",
+							"integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+							"dev": true
+						},
+						"string-width": {
+							"version": "4.2.2",
+							"resolved": "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5",
+							"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^8.0.0",
+								"is-fullwidth-code-point": "^3.0.0",
+								"strip-ansi": "^6.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "6.0.0",
+							"resolved": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532",
+							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^5.0.0"
+							}
+						},
+						"tar-stream": {
+							"version": "2.2.0",
+							"resolved": "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287",
+							"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+							"dev": true,
+							"requires": {
+								"bl": "^4.0.3",
+								"end-of-stream": "^1.4.1",
+								"fs-constants": "^1.0.0",
+								"inherits": "^2.0.3",
+								"readable-stream": "^3.1.1"
+							}
+						},
+						"url": {
+							"version": "0.10.3",
+							"resolved": "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64",
+							"integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+							"dev": true,
+							"requires": {
+								"punycode": "1.3.2",
+								"querystring": "0.2.0"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"resolved": "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+							"dev": true
+						},
 						"uuid": {
 							"version": "3.3.2",
 							"resolved": "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131",
 							"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 							"dev": true
+						},
+						"wrap-ansi": {
+							"version": "7.0.0",
+							"resolved": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43",
+							"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.0.0",
+								"string-width": "^4.1.0",
+								"strip-ansi": "^6.0.0"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"resolved": "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+							"dev": true
+						},
+						"xml2js": {
+							"version": "0.4.19",
+							"resolved": "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7",
+							"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+							"dev": true,
+							"requires": {
+								"sax": ">=0.6.0",
+								"xmlbuilder": "~9.0.1"
+							},
+							"dependencies": {
+								"sax": {
+									"version": "1.2.4",
+									"resolved": "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9",
+									"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+									"dev": true
+								}
+							}
+						},
+						"xmlbuilder": {
+							"version": "9.0.7",
+							"resolved": "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d",
+							"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+							"dev": true
+						},
+						"y18n": {
+							"version": "5.0.8",
+							"resolved": "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55",
+							"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+							"dev": true
+						},
+						"yargs": {
+							"version": "16.2.0",
+							"resolved": "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66",
+							"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+							"dev": true,
+							"requires": {
+								"cliui": "^7.0.2",
+								"escalade": "^3.1.1",
+								"get-caller-file": "^2.0.5",
+								"require-directory": "^2.1.1",
+								"string-width": "^4.2.0",
+								"y18n": "^5.0.5",
+								"yargs-parser": "^20.2.2"
+							}
+						},
+						"yargs-parser": {
+							"version": "20.2.9",
+							"resolved": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee",
+							"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+							"dev": true
+						},
+						"zip-stream": {
+							"version": "4.1.0",
+							"resolved": "https://registry.yarnpkg.com/zip-stream/-/zip-stream-4.1.0.tgz#51dd326571544e36aa3f756430b313576dc8fc79",
+							"integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
+							"dev": true,
+							"requires": {
+								"archiver-utils": "^2.1.0",
+								"compress-commons": "^4.1.0",
+								"readable-stream": "^3.6.0"
+							}
 						}
 					}
 				},
@@ -3624,8 +4304,7 @@
 				"mime": {
 					"version": "2.5.2",
 					"resolved": "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe",
-					"integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
-					"dev": true
+					"integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
 				},
 				"minimatch": {
 					"version": "3.0.4",

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -49,6 +49,7 @@
     "@aws-cdk/aws-ssm": "1.124.0",
     "@aws-cdk/core": "1.124.0",
     "cdk-nag": "0.0.95",
+    "@aws-cdk/custom-resources": "1.124.0",
     "eslint": "^7.31.0",
     "source-map-support": "^0.5.16",
     "uuid": "^8.3.2"


### PR DESCRIPTION
This creates three new roles intended to be used by humans:
1. `AtatQa` for QA/Testing
2. `AtatSecurityAuditor` for Security Auditors
3. `AtatDeveloper` for Developers

This also creates one new role to be passed by developers to CloudFormation
using the `--role-arn` or equivalent flag when building using the CDK:
1. `AtatCloudFormation`

Access is currently granted to the three job function roles to the
entire Central/Management account in AWS Organizations. Long-term, that
is not a good idea and we should find a way to lock it down a bit but
right now this gives us two significant benefits:

  1. Any user can assume any job role and see what those users see,
  which will be especially helpful for developers to help other roles
  troubleshoot other roles' IAM
  2. It simplifies the configuration and steps to assume the job-based
  roles compared to needing to double-hop

Most of the logic around assuming roles is going to need fairly
significant refactoring to support IAM Identity Federation in the near
future anyway (so that we are not relying on IAM Users directly). So
this feels like a pretty good interim solution but we can try to put in
the effort to lock it down if required.

The roles have the following privileges:

 - QA has access to view all "safe" resources, the items in DynamoDB,
   and to GET all API Gateway restapi resources
 - Auditors have all QA access plus access to all CloudWatch Logs, and
   all actions in the SecurityAudit AWS-managed job-function policy
 - Developers have all the access of QA plus read access to all
   CloudWatch Logs, as well as permission to use the CloudFormation
   execution role
 - The CloudFormation execution role has AdministratorAccess

All roles have an explicit Deny for all actions involving AWS
Organizations; however, this is not enforced by an SCP or Permissions
Boundary so we do allow new roles to be created with those permissions
(but it would have to be done with CloudFormation).

The Roles are all made available as CloudFormation stack exports. The
really cool thing about this is that it allows other stacks to grant the
roles access to specific resources that get created later (though there
are not any examples of that added in this PR since there is not really
a need).

We also make use of a pretty basic CloudFormation Custom Resource to get
the Account ID of the AWS Organizations Management Account. We are only
using one field from the output of that API call.

Finally, creation of the IAM stack at all is guarded by an environment
variable. Since we are creating named IAM resources, creating duplicate
stacks would result in failures and folks have gotten accustomed to
using `--all` on the CDK CLI. This adds a warning if the stack gets
created at all to remind users that everything will get wonky if we try
to spin up two if these in the same account (actually, it'll just
totally fail to create but making it sound spookier hopefully encourages
users to pay extra attention to whether it's intentional). The only
environment where multiple stacks being created is probable is the
Sandbox environment but it's also the most commonly-used environment.

So in summary there's a lot of room for improvement here:
 - using federated identity instead of IAM users in the central account
 - limiting the permissions on the CloudFormation role
 - moving to having resources grant access to specific ATAT roles
 - find some more explicit denies
 - improve the trust process

This gets us a good start, likely gives users the majority of access
that they need for day-to-day work, and is a solid base to continue
iterating on.

Ticket: AT-6563