### PR TITLE
Enable server access logs for S3 buckets

### DIFF
--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -139,22 +139,8 @@ export class AtatWebApiStack extends cdk.Stack {
     // Creates a target server access log bucket shared amongst the Task Order Lifecycle buckets
     // server access logs enabled on target bucket
     const taskOrdersAccessLogsBucket = new SecureBucket(this, "taskOrdersLogBucket", {
-      logTargetBucket: "self",
+      logTargetBucket: "self", // access control set to LOG_DELIVERY_WRITE when "self"
       logTargetPrefix: "logs/logbucket/",
-      bucketProps: {
-        accessControl: s3.BucketAccessControl.LOG_DELIVERY_WRITE,
-      },
-    });
-    // Error still shows even though the target bucket server access logs is enabled
-    // this suppresses the related cdk-nag for the target bucket error
-    (taskOrdersAccessLogsBucket.bucket.node.defaultChild as s3.CfnBucket).addMetadata("cdk_nag", {
-      rules_to_suppress: [
-        {
-          id: "NIST.800.53-S3BucketLoggingEnabled",
-          reason:
-            "Task orders server access logs are enabled by using the SecureBucket construct. AWS warns against enabling logs on the log bucket -> https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html",
-        },
-      ],
     });
     const taskOrderManagement = new TaskOrderLifecycle(this, "TaskOrders", {
       // enables server access logs for task order buckets (NIST SP 800-53 controls)

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -136,7 +136,7 @@ export class AtatWebApiStack extends cdk.Stack {
   }
 
   private addTaskOrderRoutes(props?: AtatWebApiStackProps) {
-    // Creates a target server access log bucket shared amongst the Task Order Lifecycle buckets
+    // Creates a server access log target bucket shared amongst the Task Order Lifecycle buckets
     // server access logs enabled on target bucket
     const taskOrdersAccessLogsBucket = new SecureBucket(this, "taskOrdersLogBucket", {
       logTargetBucket: "self", // access control set to LOG_DELIVERY_WRITE when "self"

--- a/infrastructure/lib/constructs/api-s3-function.ts
+++ b/infrastructure/lib/constructs/api-s3-function.ts
@@ -3,10 +3,10 @@ import * as s3 from "@aws-cdk/aws-s3";
 import * as cdk from "@aws-cdk/core";
 import { HttpMethod } from "../http";
 import { ApiFunction, ApiFunctionProps } from "./api-function";
-import { PrivateBucket } from "./compliant-resources";
+import { SecureBucket } from "./compliant-resources";
 
 export interface ApiS3FunctionProps extends ApiFunctionProps {
-  readonly bucket: PrivateBucket;
+  readonly bucket: SecureBucket;
 }
 
 export class ApiS3Function extends ApiFunction {
@@ -14,7 +14,7 @@ export class ApiS3Function extends ApiFunction {
 
   constructor(scope: cdk.Construct, id: string, props: ApiS3FunctionProps) {
     super(scope, id, props);
-    this.bucket = props.bucket;
+    this.bucket = props.bucket.bucket;
     this.fn.addEnvironment("DATA_BUCKET", this.bucket.bucketName);
     this.grantRequiredBucketPermissions();
   }

--- a/infrastructure/lib/constructs/compliant-resources.ts
+++ b/infrastructure/lib/constructs/compliant-resources.ts
@@ -7,6 +7,9 @@ export interface SecureBucketProps {
   bucketProps?: s3.BucketProps;
 }
 
+/**
+ * Creates a secure bucket with enabled server access logs.
+ */
 export class SecureBucket extends cdk.Construct {
   public readonly bucket: s3.IBucket;
 
@@ -14,16 +17,17 @@ export class SecureBucket extends cdk.Construct {
     super(scope, id);
 
     const bucket = new s3.Bucket(this, id, {
+      // sensible defaults allowed to be overridden
+      accessControl: props.logTargetBucket === "self" ? s3.BucketAccessControl.LOG_DELIVERY_WRITE : undefined,
+      // passed in configuration options
       ...props.bucketProps,
+      // secure defaults that cannot be overridden
       publicReadAccess: false,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       autoDeleteObjects: false,
+      serverAccessLogsBucket: props.logTargetBucket === "self" ? undefined : props.logTargetBucket,
+      serverAccessLogsPrefix: props.logTargetPrefix,
     });
-    // low level (L1) construct modifications for server access logs
-    (bucket.node.defaultChild as s3.CfnBucket).loggingConfiguration = {
-      logFilePrefix: props.logTargetPrefix,
-      destinationBucketName: props.logTargetBucket === "self" ? undefined : props.logTargetBucket.bucketName,
-    };
     this.bucket = bucket;
   }
 }

--- a/infrastructure/lib/constructs/compliant-resources.ts
+++ b/infrastructure/lib/constructs/compliant-resources.ts
@@ -19,9 +19,10 @@ export class SecureBucket extends cdk.Construct {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       autoDeleteObjects: false,
     });
+    // low level (L1) construct modifications for server access logs
     (bucket.node.defaultChild as s3.CfnBucket).loggingConfiguration = {
       logFilePrefix: props.logTargetPrefix,
-      destinationBucketName: props.logTargetBucket === "self" ? bucket.bucketName : props.logTargetBucket.bucketName,
+      destinationBucketName: props.logTargetBucket === "self" ? undefined : props.logTargetBucket.bucketName,
     };
     this.bucket = bucket;
   }

--- a/infrastructure/lib/constructs/task-order-lifecycle.ts
+++ b/infrastructure/lib/constructs/task-order-lifecycle.ts
@@ -1,8 +1,10 @@
 import * as s3 from "@aws-cdk/aws-s3";
 import * as cdk from "@aws-cdk/core";
-import { PrivateBucket } from "./compliant-resources";
+import { SecureBucket } from "./compliant-resources";
 
 export interface TaskOrderLifecycleProps {
+  logTargetBucket: s3.IBucket;
+  logTargetPrefix: string;
   bucketProps?: s3.BucketProps;
 }
 
@@ -13,14 +15,19 @@ export interface TaskOrderLifecycleProps {
  * parts of the architecture.
  */
 export class TaskOrderLifecycle extends cdk.Construct {
-  public readonly pendingBucket: PrivateBucket;
-  public readonly acceptedBucket: PrivateBucket;
-  public readonly rejectedBucket: PrivateBucket;
+  public readonly pendingBucket: SecureBucket;
+  public readonly acceptedBucket: SecureBucket;
+  public readonly rejectedBucket: SecureBucket;
 
-  constructor(scope: cdk.Construct, id: string, props?: TaskOrderLifecycleProps) {
+  constructor(scope: cdk.Construct, id: string, props: TaskOrderLifecycleProps) {
     super(scope, id);
-    this.pendingBucket = new PrivateBucket(this, "PendingBucket", { ...props?.bucketProps });
-    this.acceptedBucket = new PrivateBucket(this, "AcceptedBucket", { ...props?.bucketProps });
-    this.rejectedBucket = new PrivateBucket(this, "RejectedBucket", { ...props?.bucketProps });
+    const taskOrderBucketProps = {
+      logTargetBucket: props.logTargetBucket,
+      logTargetPrefix: props.logTargetPrefix,
+      bucketProps: { ...props?.bucketProps },
+    };
+    this.pendingBucket = new SecureBucket(this, "PendingBucket", { ...taskOrderBucketProps });
+    this.acceptedBucket = new SecureBucket(this, "AcceptedBucket", { ...taskOrderBucketProps });
+    this.rejectedBucket = new SecureBucket(this, "RejectedBucket", { ...taskOrderBucketProps });
   }
 }


### PR DESCRIPTION
Refactor and replace `PrivateBucket` with `SecureBucket`. 
- Enable server access logs on both source and target buckets
- Suppress cdk-nag for target bucket
- All buckets NIST SP 800-53 compliant

Ticket: AT-6557