### PR TITLE
Add table construct with PITR enabled

### DIFF
--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -1,11 +1,10 @@
 import * as apigw from "@aws-cdk/aws-apigateway";
 import * as dynamodb from "@aws-cdk/aws-dynamodb";
-import * as s3 from "@aws-cdk/aws-s3";
 import * as s3asset from "@aws-cdk/aws-s3-assets";
 import * as cdk from "@aws-cdk/core";
 import { ApiDynamoDBFunction } from "./constructs/api-dynamodb-function";
 import { ApiS3Function } from "./constructs/api-s3-function";
-import { SecureBucket } from "./constructs/compliant-resources";
+import { SecureBucket, PITRTable } from "./constructs/compliant-resources";
 import { TaskOrderLifecycle } from "./constructs/task-order-lifecycle";
 import { HttpMethod } from "./http";
 import { packageRoot } from "./util";
@@ -21,12 +20,14 @@ export class AtatWebApiStack extends cdk.Stack {
     this.templateOptions.description = "Resources to support the ATAT application API";
 
     // Create a shared DynamoDB table that will be used by all the functions in the project.
-    const table = new dynamodb.Table(this, "AtatTable", {
-      partitionKey: { name: "id", type: dynamodb.AttributeType.STRING },
-      billingMode: dynamodb.BillingMode.PROVISIONED,
-      readCapacity: 1,
-      writeCapacity: 1,
-      removalPolicy: props?.removalPolicy,
+    const { table } = new PITRTable(this, "AtatTable", {
+      tableProps: {
+        partitionKey: { name: "id", type: dynamodb.AttributeType.STRING },
+        billingMode: dynamodb.BillingMode.PROVISIONED,
+        readCapacity: 1,
+        writeCapacity: 1,
+        removalPolicy: props?.removalPolicy,
+      },
     });
     const tableOutput = new cdk.CfnOutput(this, "TableName", {
       value: table.tableName,

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -4,7 +4,7 @@ import * as s3asset from "@aws-cdk/aws-s3-assets";
 import * as cdk from "@aws-cdk/core";
 import { ApiDynamoDBFunction } from "./constructs/api-dynamodb-function";
 import { ApiS3Function } from "./constructs/api-s3-function";
-import { SecureBucket, PITRTable } from "./constructs/compliant-resources";
+import { SecureBucket, SecureTable } from "./constructs/compliant-resources";
 import { TaskOrderLifecycle } from "./constructs/task-order-lifecycle";
 import { HttpMethod } from "./http";
 import { packageRoot } from "./util";
@@ -20,12 +20,10 @@ export class AtatWebApiStack extends cdk.Stack {
     this.templateOptions.description = "Resources to support the ATAT application API";
 
     // Create a shared DynamoDB table that will be used by all the functions in the project.
-    const { table } = new PITRTable(this, "AtatTable", {
+    const { table } = new SecureTable(this, "AtatTable", {
       tableProps: {
         partitionKey: { name: "id", type: dynamodb.AttributeType.STRING },
-        billingMode: dynamodb.BillingMode.PROVISIONED,
-        readCapacity: 1,
-        writeCapacity: 1,
+        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
         removalPolicy: props?.removalPolicy,
       },
     });

--- a/infrastructure/lib/constructs/compliant-resources.ts
+++ b/infrastructure/lib/constructs/compliant-resources.ts
@@ -33,23 +33,23 @@ export class SecureBucket extends cdk.Construct {
   }
 }
 
-export interface PITRTableProps {
+export interface SecureTableProps {
   /**
    * The properties to configure the DynamoDB table
    */
-  tableProps: dynamodb.TableProps;
+  tableProps?: dynamodb.TableProps;
 }
 /**
- * Creates a DynamoDB table with point-in-time recover (PITR)
- * enabled by default.
+ * Creates a secure DynamoDB table with properties enabled for compliance
+ *  - point-in-time recover (PITR) enabled by default
  */
-export class PITRTable extends cdk.Construct {
+export class SecureTable extends cdk.Construct {
   /**
    * The created DynamoDB table
    */
   public readonly table: dynamodb.ITable;
 
-  constructor(scope: cdk.Construct, id: string, props: PITRTableProps) {
+  constructor(scope: cdk.Construct, id: string, props: SecureTableProps) {
     super(scope, id);
 
     const table = new dynamodb.Table(this, id, {
@@ -57,7 +57,7 @@ export class PITRTable extends cdk.Construct {
       ...props.tableProps,
       // secure defaults that cannot be overridden
       pointInTimeRecovery: true,
-    });
+    } as dynamodb.TableProps);
 
     this.table = table;
   }

--- a/infrastructure/lib/constructs/compliant-resources.ts
+++ b/infrastructure/lib/constructs/compliant-resources.ts
@@ -37,7 +37,7 @@ export interface SecureTableProps {
   /**
    * The properties to configure the DynamoDB table
    */
-  tableProps?: dynamodb.TableProps;
+  tableProps: dynamodb.TableProps;
 }
 /**
  * Creates a secure DynamoDB table with properties enabled for compliance
@@ -57,7 +57,7 @@ export class SecureTable extends cdk.Construct {
       ...props.tableProps,
       // secure defaults that cannot be overridden
       pointInTimeRecovery: true,
-    } as dynamodb.TableProps);
+    });
 
     this.table = table;
   }

--- a/infrastructure/lib/constructs/compliant-resources.ts
+++ b/infrastructure/lib/constructs/compliant-resources.ts
@@ -1,4 +1,5 @@
 import * as s3 from "@aws-cdk/aws-s3";
+import * as dynamodb from "@aws-cdk/aws-dynamodb";
 import * as cdk from "@aws-cdk/core";
 
 export interface SecureBucketProps {
@@ -29,5 +30,35 @@ export class SecureBucket extends cdk.Construct {
       serverAccessLogsPrefix: props.logTargetPrefix,
     });
     this.bucket = bucket;
+  }
+}
+
+export interface PITRTableProps {
+  /**
+   * The properties to configure the DynamoDB table
+   */
+  tableProps: dynamodb.TableProps;
+}
+/**
+ * Creates a DynamoDB table with point-in-time recover (PITR)
+ * enabled by default.
+ */
+export class PITRTable extends cdk.Construct {
+  /**
+   * The created DynamoDB table
+   */
+  public readonly table: dynamodb.ITable;
+
+  constructor(scope: cdk.Construct, id: string, props: PITRTableProps) {
+    super(scope, id);
+
+    const table = new dynamodb.Table(this, id, {
+      // passed in table configuration
+      ...props.tableProps,
+      // secure defaults that cannot be overridden
+      pointInTimeRecovery: true,
+    });
+
+    this.table = table;
   }
 }


### PR DESCRIPTION
Create PITRTable construct that defaults to having point-in-time
recovery (PITR) enabled for NIST SP 800-53 controls.

- [x] scans with cdk-nag do not report an error for enabling PITR on DynamoDB tables

Ticket: AT-6555