### PR TITLE
Update buckets removal policy

### DIFF
--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -141,6 +141,10 @@ export class AtatWebApiStack extends cdk.Stack {
     const taskOrdersAccessLogsBucket = new SecureBucket(this, "taskOrdersLogBucket", {
       logTargetBucket: "self", // access control set to LOG_DELIVERY_WRITE when "self"
       logTargetPrefix: "logs/logbucket/",
+      bucketProps: {
+        removalPolicy: props?.removalPolicy,
+        autoDeleteObjects: props?.removalPolicy === cdk.RemovalPolicy.DESTROY,
+      },
     });
     const taskOrderManagement = new TaskOrderLifecycle(this, "TaskOrders", {
       // enables server access logs for task order buckets (NIST SP 800-53 controls)

--- a/infrastructure/lib/constructs/compliant-resources.ts
+++ b/infrastructure/lib/constructs/compliant-resources.ts
@@ -24,7 +24,8 @@ export class SecureBucket extends cdk.Construct {
       // secure defaults that cannot be overridden
       publicReadAccess: false,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      autoDeleteObjects: false,
+      // NOTE: removed for dev purposes only, once envs are differentiated this will be fixed
+      // autoDeleteObjects: false,
       serverAccessLogsBucket: props.logTargetBucket === "self" ? undefined : props.logTargetBucket,
       serverAccessLogsPrefix: props.logTargetPrefix,
     });

--- a/infrastructure/lib/constructs/compliant-resources.ts
+++ b/infrastructure/lib/constructs/compliant-resources.ts
@@ -24,7 +24,8 @@ export class SecureBucket extends cdk.Construct {
       // secure defaults that cannot be overridden
       publicReadAccess: false,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      // NOTE: removed for dev purposes only, once envs are differentiated this will be fixed
+      // TODO: Prevent auto-delete when we properly handle differences between dev and
+      // higher environments
       // autoDeleteObjects: false,
       serverAccessLogsBucket: props.logTargetBucket === "self" ? undefined : props.logTargetBucket,
       serverAccessLogsPrefix: props.logTargetPrefix,


### PR DESCRIPTION
This is only temporary for dev purposes to ensure that deployed
buckets can be destroyed after the completion of tickets.

Ticket: AT-6557