### PR TITLE
Make handler setup more generic

### DIFF
--- a/packages/api/portfolioDrafts/portfolio/createPortfolioStep.ts
+++ b/packages/api/portfolioDrafts/portfolio/createPortfolioStep.ts
@@ -1,29 +1,62 @@
 import { UpdateCommand, UpdateCommandOutput } from "@aws-sdk/lib-dynamodb";
-import { dynamodbDocumentClient as client } from "../../utils/dynamodb";
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
 import { PORTFOLIO_STEP } from "../../models/PortfolioDraft";
 import { PortfolioStep } from "../../models/PortfolioStep";
-import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
+import { dynamodbDocumentClient as client } from "../../utils/dynamodb";
+import { DATABASE_ERROR, NO_SUCH_PORTFOLIO_DRAFT, REQUEST_BODY_INVALID } from "../../utils/errors";
+import { baseHandler } from "../../utils/handler";
+import { ApiSuccessResponse, ErrorResponse, SuccessStatusCode } from "../../utils/response";
 import { isValidJson, isValidUuidV4 } from "../../utils/validation";
-import { NO_SUCH_PORTFOLIO_DRAFT, REQUEST_BODY_INVALID, DATABASE_ERROR } from "../../utils/errors";
+
+class SetupError {
+  public readonly errorResponse: ErrorResponse;
+  constructor(errorResponse: ErrorResponse) {
+    this.errorResponse = errorResponse;
+  }
+}
+
+class SetupSuccess<T> {
+  public readonly path: { [key: string]: string };
+  public readonly bodyObject: T;
+  constructor(path: { [key: string]: string }, bodyObject: T) {
+    this.path = path;
+    this.bodyObject = bodyObject;
+  }
+}
+
+type SetupResult<T> = SetupError | SetupSuccess<T>;
+
+export async function handler(event: APIGatewayProxyEvent, context?: Context): Promise<APIGatewayProxyResult> {
+  return baseHandler(createPortfolioStep, event, context);
+}
+
+function preValidation(event: APIGatewayProxyEvent): SetupResult<PortfolioStep> {
+  if (!isValidUuidV4(event.pathParameters?.portfolioDraftId)) {
+    return new SetupError(NO_SUCH_PORTFOLIO_DRAFT);
+  }
+  const portfolioDraftId = event.pathParameters!.portfolioDraftId!;
+  const bodyResult = isValidJson<PortfolioStep>(event.body);
+  if (bodyResult === undefined) {
+    return new SetupError(REQUEST_BODY_INVALID);
+  }
+  return new SetupSuccess<PortfolioStep>({ portfolioDraftId }, bodyResult);
+}
 
 /**
  * Submits the Portfolio Step of the Portfolio Draft Wizard
  *
  * @param event - The POST request from API Gateway
  */
-export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
-  const portfolioDraftId = event.pathParameters?.portfolioDraftId;
-  if (!isValidUuidV4(portfolioDraftId!)) {
-    return NO_SUCH_PORTFOLIO_DRAFT;
+export async function createPortfolioStep(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const setupResult = preValidation(event);
+  if (setupResult instanceof SetupError) {
+    return setupResult.errorResponse;
   }
-  if (!isValidJson(event.body!)) {
-    return REQUEST_BODY_INVALID;
-  }
-  const portfolioStep: PortfolioStep = JSON.parse(event.body!);
+  const portfolioDraftId = setupResult.path.portfolioDraftId;
+  const portfolioStep = setupResult.bodyObject;
 
   try {
-    await createPortfolioStepCommand(portfolioDraftId!, portfolioStep);
+    await createPortfolioStepCommand(portfolioDraftId, portfolioStep);
   } catch (error) {
     if (error.name === "ConditionalCheckFailedException") {
       return NO_SUCH_PORTFOLIO_DRAFT;

--- a/packages/api/utils/errors.ts
+++ b/packages/api/utils/errors.ts
@@ -6,6 +6,15 @@ import { ErrorStatusCode, OtherErrorResponse } from "./response";
 export const DATABASE_ERROR = new OtherErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);
 
 /**
+ * A "last-resort" error, to be used when it is unknown what caused a particular
+ * error (or to entirely mask error details)
+ */
+export const UNKNOWN_ERROR = new OtherErrorResponse(
+  "An unexpected error occurred",
+  ErrorStatusCode.INTERNAL_SERVER_ERROR
+);
+
+/**
  * To be used when a request body is required but was not provided
  */
 export const REQUEST_BODY_EMPTY = new OtherErrorResponse("Request body must not be empty", ErrorStatusCode.BAD_REQUEST);

--- a/packages/api/utils/handler.ts
+++ b/packages/api/utils/handler.ts
@@ -1,0 +1,37 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
+import { UNKNOWN_ERROR } from "./errors";
+
+type Handler = (event: APIGatewayProxyEvent, context?: Context) => Promise<APIGatewayProxyResult>;
+
+/**
+ * A wrapper for handlers to ensure that any unhandled errors get returned
+ * as a 500 error, rather than resulting in an API Gateway default 502
+ * error message.
+ *
+ * @param handler The underlying handler function
+ * @param event The API Gateway event object
+ * @param context The Lambda Context object
+ * @returns The result from invoking the underlying handler, unless an
+ * unhandled error occurs, then a 500 error is logged and returned.
+ */
+export async function baseHandler(
+  handler: Handler,
+  event: APIGatewayProxyEvent,
+  context?: Context
+): Promise<APIGatewayProxyResult> {
+  try {
+    return handler(event, context);
+  } catch (err: unknown) {
+    // TODO?: Send data point to CloudWatch Metrics to trigger an alarm? Or
+    // see if we can use X-Ray here?
+    console.error("An unexpected error occurred on event", err, event);
+    if (err instanceof Error) {
+      console.error(err.stack);
+    } else {
+      console.error("Error is not an Error type. Falling back to console.trace");
+      console.trace();
+    }
+    console.error("User will receive a 500 response.");
+    return UNKNOWN_ERROR;
+  }
+}

--- a/packages/api/utils/response.ts
+++ b/packages/api/utils/response.ts
@@ -125,7 +125,7 @@ export class ApiSuccessResponse<T> extends SuccessResponse {
   }
 }
 
-abstract class ErrorResponse extends Response {
+export abstract class ErrorResponse extends Response {
   /**
    * Create an error response.
    *

--- a/packages/api/utils/validation.ts
+++ b/packages/api/utils/validation.ts
@@ -1,11 +1,11 @@
+import { validate as uuidValidate, version as uuidVersion } from "uuid";
+import { Application } from "../models/Application";
 import { ApplicationStep } from "../models/ApplicationStep";
 import { Clin } from "../models/Clin";
+import { Environment } from "../models/Environment";
 import { FundingStep } from "../models/FundingStep";
 import { PortfolioStep } from "../models/PortfolioStep";
 import { TaskOrder } from "../models/TaskOrder";
-import { validate as uuidValidate, version as uuidVersion } from "uuid";
-import { Application } from "../models/Application";
-import { Environment } from "../models/Environment";
 
 /**
  * Check whether a given string is valid JSON.
@@ -13,13 +13,15 @@ import { Environment } from "../models/Environment";
  * @param str - The string to check
  * @returns true if the string is valid JSON and false otherwise
  */
-export function isValidJson(str: string): boolean {
-  try {
-    JSON.parse(str);
-  } catch (e) {
-    return false;
+export function isValidJson<T>(str?: string | null): T | undefined {
+  if (!str) {
+    return undefined;
   }
-  return true;
+  try {
+    return JSON.parse(str) as T;
+  } catch (e) {
+    return undefined;
+  }
 }
 
 /**
@@ -27,8 +29,8 @@ export function isValidJson(str: string): boolean {
  * @param str - The string to check
  * @returns true if the string is valid v4 UUID and false otherwise
  */
-export function isValidUuidV4(str: string): boolean {
-  return uuidValidate(str) && uuidVersion(str) === 4;
+export function isValidUuidV4(str?: string): boolean {
+  return !!str && uuidValidate(str) && uuidVersion(str) === 4;
 }
 
 /**


### PR DESCRIPTION
⚠️This PR exists as an easy diff to @zachclark-ccpo's branch⚠️

This moves the initial setup logic into it's own generic set of handlers. A lot of this was kept purely in the `createPortfolioStep` file just because I was lazy while writing. Maybe this exposes a possible path for additional refactoring? The `SetupResult` type is somewhat inspired by Rust's `Result` enum but doesn't quite replicate that functionality.

This probably breaks `isValidJson` literally everywhere else, but having the validators return valid objects feels cool. I mean, checking for `undefined` isn't much different than checking for `False`. 

Oh and `baseHandler` tries to make sure literally everything that we don't handle explicitly implicitly gets cleanly handled with a 500. We really, really, really never want to hit that code. But it's there if we need it.