### PR TITLE
Require Authentication for all API operations

### DIFF
--- a/packages/api/authorizer.test.ts
+++ b/packages/api/authorizer.test.ts
@@ -1,0 +1,85 @@
+import { APIGatewayAuthorizerResultContext, APIGatewayTokenAuthorizerEvent } from "aws-lambda";
+import { generatePolicyDocument, handler, PolicyEffect } from "./authorizer";
+
+describe("handler()", function () {
+  const event: APIGatewayTokenAuthorizerEvent = {
+    type: "TOKEN",
+    authorizationToken: "allow",
+    methodArn: "arn:aws:execute-api:us-gov-west-1:123456789012:5046p4ua74/prod/GET/",
+  };
+  const context: APIGatewayAuthorizerResultContext = {};
+  it("should accept a well-formed authorizer lambda event", async () => {
+    expect(event).toHaveProperty("type");
+    expect(event).toHaveProperty("authorizationToken");
+    expect(event).toHaveProperty("methodArn");
+    expect(() => {
+      handler(event, context);
+    }).not.toThrow(Error());
+  });
+  it("should return result with properties 'principalId' and 'policyDocument'", async () => {
+    const result = await handler(event, context);
+    expect(result).toHaveProperty("principalId");
+    expect(result).toHaveProperty("policyDocument");
+  });
+  it("should return result with Allow effect when caller-supplied-token is 'allow'", async () => {
+    const result = await handler(event, context);
+    expect(result.policyDocument.Statement[0].Effect).toBe(PolicyEffect.ALLOW);
+  });
+  it("should return result with Deny effect when caller-supplied-token is 'deny'", async () => {
+    const denyEvent: APIGatewayTokenAuthorizerEvent = {
+      ...event,
+      authorizationToken: "deny",
+    };
+    const result = await handler(denyEvent, context);
+    expect(result.policyDocument.Statement[0].Effect).toBe(PolicyEffect.DENY);
+  });
+  it("should return result with Deny effect when caller-supplied-token is 'unauthorized'", async () => {
+    const unauthorizedEvent: APIGatewayTokenAuthorizerEvent = {
+      ...event,
+      authorizationToken: "unauthorized",
+    };
+    const result = await handler(unauthorizedEvent, context);
+    expect(result.policyDocument.Statement[0].Effect).toBe(PolicyEffect.DENY);
+  });
+  it("should return result with Deny effect when caller-supplied-token is invalid", async () => {
+    const invalidTokenEvent: APIGatewayTokenAuthorizerEvent = {
+      ...event,
+      authorizationToken: "invalid token",
+    };
+    const result = await handler(invalidTokenEvent, context);
+    expect(result.policyDocument.Statement[0].Effect).toBe(PolicyEffect.DENY);
+  });
+  it("should return result with Deny effect when caller-supplied-token is empty string", async () => {
+    const emptyStringTokenEvent: APIGatewayTokenAuthorizerEvent = {
+      ...event,
+      authorizationToken: "",
+    };
+    const result = await handler(emptyStringTokenEvent, context);
+    expect(result.policyDocument.Statement[0].Effect).toBe(PolicyEffect.DENY);
+  });
+});
+
+describe("generatePolicyDocument()", function () {
+  const resourceArn = "arn:aws:execute-api:us-gov-west-1:123456789012:5046p4ua74/prod/GET/";
+  const allowDoc = generatePolicyDocument(PolicyEffect.ALLOW, resourceArn);
+  it("should return policy document with a specific version", () => {
+    expect(allowDoc.Version).toEqual("2012-10-17");
+  });
+  it("should return policy document with a statement array with a single entry", () => {
+    expect(allowDoc.Statement.length).toEqual(1);
+  });
+  it("should return policy document w/ Effect of 'Allow' when appropriate", async () => {
+    expect(allowDoc.Statement[0].Effect).toBe(PolicyEffect.ALLOW);
+  });
+  it("should return policy document w/ Effect of 'Deny' when appropriate", async () => {
+    const denyDoc = generatePolicyDocument(PolicyEffect.DENY, resourceArn);
+    expect(denyDoc.Statement[0].Effect).toBe(PolicyEffect.DENY);
+  });
+  // TODO: Need help with the Types here
+  // it("should return policy document w/ Action allowing invokation", async () => {
+  //   expect(allowDoc.Statement[0].Action).toBe("execute-api:Invoke");
+  // });
+  // it("should return policy document w/ Resource equal to ARN", async () => {
+  //   expect(allowDoc.Statement[0].Resource).toBe(resourceArn);
+  // });
+});

--- a/packages/api/authorizer.ts
+++ b/packages/api/authorizer.ts
@@ -1,3 +1,4 @@
+import jwtDecode, { JwtDecodeOptions, JwtHeader, JwtPayload } from "jwt-decode";
 import {
   APIGatewayAuthorizerResult,
   APIGatewayAuthorizerResultContext,
@@ -20,16 +21,15 @@ export async function handler(
   context: APIGatewayAuthorizerResultContext
 ): Promise<APIGatewayAuthorizerResult> {
   let effect: PolicyEffect;
-  switch (event.authorizationToken.toLowerCase()) {
-    case "allow":
-      effect = PolicyEffect.ALLOW;
-      break;
-    case "deny":
-    case "unauthorized":
-    default:
-      // Return 401 Unauthorized
-      effect = PolicyEffect.DENY;
+  try {
+    validateToken(event.authorizationToken);
+  } catch (e) {
+    console.warn("Token failed validation: " + e);
+    // Return 401 Unauthorized
+    effect = PolicyEffect.DENY;
   }
+  effect = PolicyEffect.ALLOW;
+
   return {
     principalId: "janemanager",
     policyDocument: generatePolicyDocument(effect, event.methodArn),
@@ -54,4 +54,41 @@ export function generatePolicyDocument(effect: PolicyEffect, resourceArn: string
       },
     ],
   };
+}
+
+/**
+ * Validates given JWT.  Throws error if invalid.
+ *
+ * Authorizing API requests
+ * - Check the identitySource for a token. The identitySource can include only the token, or the token prefixed with Bearer.
+ * - Decode the token.
+ * - Check the token's algorithm and signature by using the public key that is fetched from the issuer's jwks_uri.
+ *   https://cognito-idp.us-gov-west-1.amazonaws.com/us-gov-west-1_aOkFERvad/.well-known/jwks.json
+ * - Validate claims. API Gateway evaluates the following token claims:
+ *   - kid – The token must have a header claim that matches the key in the jwks_uri that signed the token.
+ *   - iss – Must match the issuer that is configured for the authorizer.
+ *   - aud or client_id – Must match one of the audience entries that is configured for the authorizer.
+ *   - exp – Must be after the current time in UTC.
+ *   - nbf – Must be before the current time in UTC.
+ *   - iat – Must be before the current time in UTC.
+ *   - scope or scp – The token must include at least one of the scopes in the route's authorizationScopes.
+ *
+ * If any of these steps fail, deny the API request.
+ */
+export function validateToken(token: string): void {
+  // JwtHeader has 'type' not 'typ'
+  interface MyJwtHeader extends JwtHeader {
+    typ: string;
+  }
+  const options: JwtDecodeOptions = { header: true };
+  const tokenHeader = jwtDecode<MyJwtHeader>(token, options);
+  if (tokenHeader.typ !== "JWT") {
+    throw Error("Unexpected type");
+  }
+  if (tokenHeader.alg !== "RS256") {
+    throw Error("Unexpected algorithm");
+  }
+  const tokenPayload = jwtDecode<JwtPayload>(token);
+  // TODO: check signature
+  // TODO: check all claims
 }

--- a/packages/api/authorizer.ts
+++ b/packages/api/authorizer.ts
@@ -1,0 +1,57 @@
+import {
+  APIGatewayAuthorizerResult,
+  APIGatewayAuthorizerResultContext,
+  APIGatewayTokenAuthorizerEvent,
+  PolicyDocument,
+} from "aws-lambda";
+
+export enum PolicyEffect {
+  ALLOW = "Allow",
+  DENY = "Deny",
+}
+/**
+ * Reference: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-input.html
+ * @param event an authorizer event that contains, among other things, a caller-supplied-token in property 'authorizationToken'
+ * @param context the context
+ * @returns a resource-based JSON policy document either allowing or denying the principal to invoke a specific resource
+ */
+export async function handler(
+  event: APIGatewayTokenAuthorizerEvent,
+  context: APIGatewayAuthorizerResultContext
+): Promise<APIGatewayAuthorizerResult> {
+  let effect: PolicyEffect;
+  switch (event.authorizationToken.toLowerCase()) {
+    case "allow":
+      effect = PolicyEffect.ALLOW;
+      break;
+    case "deny":
+    case "unauthorized":
+    default:
+      // Return 401 Unauthorized
+      effect = PolicyEffect.DENY;
+  }
+  return {
+    principalId: "janemanager",
+    policyDocument: generatePolicyDocument(effect, event.methodArn),
+  };
+}
+
+/**
+ * Generates JSON policy documents which are resource-based policies attached to a resource.
+ * Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_resource-based
+ * @param effect either 'Allow' or 'Deny'
+ * @param resourceArn the ARN of a specific resource
+ * @returns a JSON policy document either allowing or denying the invokation of the specified resource
+ */
+export function generatePolicyDocument(effect: PolicyEffect, resourceArn: string): PolicyDocument {
+  return {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Action: "execute-api:Invoke",
+        Effect: effect,
+        Resource: resourceArn,
+      },
+    ],
+  };
+}

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -4577,6 +4577,11 @@
 				}
 			}
 		},
+		"jose": {
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-3.19.0.tgz",
+			"integrity": "sha512-G5imz/7oSe8Ohg4EMEhGhMhN+yzACMw7NC7ZrEYSoJekQXHPf+TPQNc/XJkYRm6TFWIbf3HA4OHZhdRv8KsskA=="
+		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -4674,6 +4674,11 @@
 			"integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
 			"dev": true
 		},
+		"jwt-decode": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+			"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+		},
 		"kleur": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,6 +13,7 @@
     "@aws-sdk/lib-dynamodb": "^3.33.0",
     "@types/aws-lambda": "^8.10.83",
     "jose": "^3.19.0",
+    "jwt-decode": "^3.1.2",
     "lambda-multipart-parser": "^1.0.1",
     "uuid": "^8.3.2"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,6 +12,7 @@
     "@aws-sdk/client-s3": "^3.33.0",
     "@aws-sdk/lib-dynamodb": "^3.33.0",
     "@types/aws-lambda": "^8.10.83",
+    "jose": "^3.19.0",
     "lambda-multipart-parser": "^1.0.1",
     "uuid": "^8.3.2"
   },


### PR DESCRIPTION
Adds an API Gateway token-based lambda authorizer function `authorizer.ts` and unit tests

TODO
- [x] create the lambda function (API GW dev guide p.297)
- [x] create unit tests
- [ ] parse token to get principal identifier in function
- [x] select [a package](https://openid.net/developers/jwt/) for token parsing - added [jwt-decode](https://www.npmjs.com/package/jwt-decode).  Also added [jose](https://www.npmjs.com/package/jose) but may remove.
- [ ] configure function as API GW authorizer in CDK stack (API GW dev guide p.302)
- [ ] configure initial API operation `getPortfolioDrafts` to require authorizer (API GW dev guide p.304)
- [ ] configure remaining API operations
- [ ] make configurable.  `On` by default.

Ticket: AT-6533