### PR TITLE
Enable API Gateway Cache & Execution Logging

### DIFF
--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -144,9 +144,6 @@ export class AtatWebApiStack extends cdk.Stack {
     // This will get used as the `Body:` parameter in the underlying CloudFormation resource.
     const restApi = new SecureRestApi(this, "AtatSpecTest", {
       apiDefinition: apigw.ApiDefinition.fromInline(apiSpecAsTemplateInclude),
-      deployOptions: {
-        cacheTtl: cdk.Duration.minutes(2),
-      },
     });
     this.addTaskOrderRoutes(props);
   }

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -7,7 +7,7 @@ import * as cdk from "@aws-cdk/core";
 import { ApiDynamoDBFunction } from "./constructs/api-dynamodb-function";
 import { ApiS3Function } from "./constructs/api-s3-function";
 import { CognitoAuthentication } from "./constructs/authentication";
-import { SecureBucket, SecureTable } from "./constructs/compliant-resources";
+import { SecureBucket, SecureTable, SecureAPIGateway } from "./constructs/compliant-resources";
 import { TaskOrderLifecycle } from "./constructs/task-order-lifecycle";
 import { HttpMethod } from "./http";
 import { packageRoot } from "./util";
@@ -142,15 +142,20 @@ export class AtatWebApiStack extends cdk.Stack {
     // And with the data now loaded from the template, we can use ApiDefinition.fromInline to parse it as real
     // OpenAPI spec (because it was!) and now we've got all our special AWS values and variables interpolated.
     // This will get used as the `Body:` parameter in the underlying CloudFormation resource.
-    const restApi = new apigw.SpecRestApi(this, "AtatSpecTest", {
-      apiDefinition: apigw.ApiDefinition.fromInline(apiSpecAsTemplateInclude),
-      // This is slightly repetitive between endpointTypes and parameters.endpointConfigurationTypes; however, due
-      // to underlying CloudFormation behaviors, endpointTypes is not evaluated entirely correctly when a
-      // parameter specification is given. Specifying both ensures that we truly have a regional endpoint rather than
-      // edge.
-      endpointTypes: [apigw.EndpointType.REGIONAL],
-      parameters: {
-        endpointConfigurationTypes: apigw.EndpointType.REGIONAL,
+    const restApi = new SecureAPIGateway(this, "AtatSpecTest", {
+      apiGatewayProps: {
+        apiDefinition: apigw.ApiDefinition.fromInline(apiSpecAsTemplateInclude),
+        // This is slightly repetitive between endpointTypes and parameters.endpointConfigurationTypes; however, due
+        // to underlying CloudFormation behaviors, endpointTypes is not evaluated entirely correctly when a
+        // parameter specification is given. Specifying both ensures that we truly have a regional endpoint rather than
+        // edge.
+        endpointTypes: [apigw.EndpointType.REGIONAL],
+        parameters: {
+          endpointConfigurationTypes: apigw.EndpointType.REGIONAL,
+        },
+        deployOptions: {
+          cacheTtl: cdk.Duration.minutes(2),
+        },
       },
     });
     this.addTaskOrderRoutes(props);

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -7,7 +7,7 @@ import * as cdk from "@aws-cdk/core";
 import { ApiDynamoDBFunction } from "./constructs/api-dynamodb-function";
 import { ApiS3Function } from "./constructs/api-s3-function";
 import { CognitoAuthentication } from "./constructs/authentication";
-import { SecureBucket, SecureTable, SecureAPIGateway } from "./constructs/compliant-resources";
+import { SecureBucket, SecureTable, SecureRestApi } from "./constructs/compliant-resources";
 import { TaskOrderLifecycle } from "./constructs/task-order-lifecycle";
 import { HttpMethod } from "./http";
 import { packageRoot } from "./util";
@@ -142,20 +142,10 @@ export class AtatWebApiStack extends cdk.Stack {
     // And with the data now loaded from the template, we can use ApiDefinition.fromInline to parse it as real
     // OpenAPI spec (because it was!) and now we've got all our special AWS values and variables interpolated.
     // This will get used as the `Body:` parameter in the underlying CloudFormation resource.
-    const restApi = new SecureAPIGateway(this, "AtatSpecTest", {
-      apiGatewayProps: {
-        apiDefinition: apigw.ApiDefinition.fromInline(apiSpecAsTemplateInclude),
-        // This is slightly repetitive between endpointTypes and parameters.endpointConfigurationTypes; however, due
-        // to underlying CloudFormation behaviors, endpointTypes is not evaluated entirely correctly when a
-        // parameter specification is given. Specifying both ensures that we truly have a regional endpoint rather than
-        // edge.
-        endpointTypes: [apigw.EndpointType.REGIONAL],
-        parameters: {
-          endpointConfigurationTypes: apigw.EndpointType.REGIONAL,
-        },
-        deployOptions: {
-          cacheTtl: cdk.Duration.minutes(2),
-        },
+    const restApi = new SecureRestApi(this, "AtatSpecTest", {
+      apiDefinition: apigw.ApiDefinition.fromInline(apiSpecAsTemplateInclude),
+      deployOptions: {
+        cacheTtl: cdk.Duration.minutes(2),
       },
     });
     this.addTaskOrderRoutes(props);

--- a/infrastructure/lib/constructs/compliant-resources.ts
+++ b/infrastructure/lib/constructs/compliant-resources.ts
@@ -79,7 +79,7 @@ export interface SecureRestApiProps extends apigw.RestApiBaseProps {
  *  - execution logs enabled by default
  */
 export class SecureRestApi extends cdk.Construct {
-  readonly restApi: apigw.SpecRestApi;
+  readonly restApi: apigw.RestApiBase;
 
   constructor(scope: cdk.Construct, id: string, props: SecureRestApiProps) {
     super(scope, id);

--- a/infrastructure/lib/constructs/compliant-resources.ts
+++ b/infrastructure/lib/constructs/compliant-resources.ts
@@ -93,13 +93,12 @@ export class SecureRestApi extends cdk.Construct {
         endpointConfigurationTypes: apigw.EndpointType.REGIONAL,
       },
       deployOptions: {
-        // sensible defaults allowed to be overridden
-        cacheTtl: cdk.Duration.minutes(15),
         // passed in API Gateway configurations
         ...props?.deployOptions,
         // secure defaults that cannot be overridden
         cachingEnabled: true,
         cacheDataEncrypted: true,
+        cacheTtl: cdk.Duration.minutes(0),
         loggingLevel: apigw.MethodLoggingLevel.INFO, // execution logging
       },
     };


### PR DESCRIPTION
Create SecureAPIGateway construct with encrypted cache and
execution logging enabled by default for NIST SP 800-53.

Replace apigateway with SecureAPIGateway to remove cdk-nag errors.
- [x] no cdk-nag error for `APIGWCacheEnabledAndEncrypted`
- [x] no cdk-nag error for `APIGWExecutionLoggingEnabled` 

Ticket: AT-6556