### PR TITLE
Conditionally create the securityScheme

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -925,17 +925,21 @@ components:
                     email: "original@mandalorian.com"
                     access: "read_only"
   securitySchemes:
-    cognitoAuthorizer:
-      description: >-
-        Authorizes API access by token. Token obtained from custom IdP and provided in subsequent API requests.
-      type: apiKey
-      name: Authorization
-      in: header
-      x-amazon-apigateway-authtype: cognito_user_pools
-      x-amazon-apigateway-authorizer:
-        type: cognito_user_pools
-        providerARNs:
-          - Fn::GetAtt: AtatUserPool.Arn
+    Fn::If:
+      - IsAuthorizationRequired
+      - cognitoAuthorizer:
+          description: >-
+            Authorizes API access by token. Token obtained from custom IdP and provided in subsequent API requests.
+          type: apiKey
+          name: Authorization
+          in: header
+          x-amazon-apigateway-authtype: cognito_user_pools
+          x-amazon-apigateway-authorizer:
+            type: cognito_user_pools
+            providerARNs:
+              - Fn::GetAtt: AtatUserPool.Arn
+      - Ref: AWS::NoValue
+
 x-amazon-apigateway-request-validators:
   full-request-validator:
     validateRequestParameters: true


### PR DESCRIPTION
If we always create the security scheme objects (without the Fn::If),
then the API still returns a 401 Unauthorized response when a token
isn't provided. If we exclude it entirely, then we're able get a 200.