### PR TITLE
Move CSP data to Portfolio Step

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -704,6 +704,11 @@ components:
       properties:
         name:
           type: string
+        csp:
+          type: string
+          enum:
+            - "aws"
+            - "azure"
         description:
           type: string
         dod_components:
@@ -741,11 +746,6 @@ components:
                 allOf:
                   - $ref: '#/components/schemas/FileMetadataSummary'
                 description: Metadata associated with file which was previously uploaded by POST /taskOrderFiles
-              csp:
-                type: string
-                enum:
-                  - "aws"
-                  - "azure"
               clins:
                 type: array
                 items:
@@ -840,6 +840,8 @@ components:
     PortfolioStepEx:
       value:
         name: "Mock Portfolio"
+        csp:
+          - "aws"
         description: "Mock portfolio description"
         dod_components: 
           - "air_force"
@@ -861,8 +863,6 @@ components:
               size: 694331
               name: "TO_12345678910.pdf"
               status: "accepted"
-            csp:
-              - "aws"
             clins:
               - clin_number: "0001"
                 idiq_clin: "1234"

--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -878,8 +878,6 @@ components:
               size: 2945459
               name: "TaskOrder_98765432101.pdf"
               status: "pending"
-            csp:
-              - "azure"
             clins:
               - clin_number: "0002"
                 idiq_clin: "1234"

--- a/packages/api/models/PortfolioStep.ts
+++ b/packages/api/models/PortfolioStep.ts
@@ -1,5 +1,7 @@
+import { CloudServiceProvider } from "./CloudServiceProvider";
 export interface PortfolioStep {
   name: string;
+  csp: CloudServiceProvider;
   description: string;
   dod_components: Array<string>;
   portfolio_managers: Array<string>;

--- a/packages/api/models/TaskOrder.ts
+++ b/packages/api/models/TaskOrder.ts
@@ -1,12 +1,10 @@
 import { Clin } from "./Clin";
-import { CloudServiceProvider } from "./CloudServiceProvider";
 import { FileMetadataSummary } from "./FileMetadataSummary";
 import { ExhaustiveAttributeMap } from "./TypeFields";
 
 export interface TaskOrder {
   task_order_number: string;
   task_order_file: FileMetadataSummary;
-  csp: CloudServiceProvider;
   clins: Array<Clin>;
 }
 

--- a/packages/api/models/TaskOrder.ts
+++ b/packages/api/models/TaskOrder.ts
@@ -11,6 +11,5 @@ export interface TaskOrder {
 export const taskOrderFields: ExhaustiveAttributeMap<TaskOrder> = {
   task_order_number: null,
   task_order_file: null,
-  csp: null,
   clins: null,
 };

--- a/packages/api/models/TypeFields.test.ts
+++ b/packages/api/models/TypeFields.test.ts
@@ -1,7 +1,8 @@
+import { CloudServiceProvider } from "./CloudServiceProvider";
+import { exhaustivePick } from "./TypeFields";
 import { PortfolioDraft } from "./PortfolioDraft";
 import { portfolioDraftFields } from "./PortfolioDraftSummary";
 import { ProvisioningStatus } from "./ProvisioningStatus";
-import { exhaustivePick } from "./TypeFields";
 
 describe("Test object trimming", () => {
   const portfolioDraft: PortfolioDraft = {
@@ -22,6 +23,7 @@ describe("Test object trimming", () => {
     },
     portfolio_step: {
       name: "test",
+      csp: CloudServiceProvider.AWS,
       description: "test",
       dod_components: [],
       portfolio_managers: [],

--- a/packages/api/portfolioDrafts/funding/createFundingStep.test.ts
+++ b/packages/api/portfolioDrafts/funding/createFundingStep.test.ts
@@ -7,7 +7,6 @@ import {
   ValidationErrorResponse,
 } from "../../utils/response";
 import { Clin } from "../../models/Clin";
-import { CloudServiceProvider } from "../../models/CloudServiceProvider";
 import { createValidationErrorResponse, handler, validateClin, validateFundingStepClins } from "./createFundingStep";
 import { DynamoDBDocumentClient, UpdateCommand, UpdateCommandOutput } from "@aws-sdk/lib-dynamodb";
 import { FileMetadata, FileScanStatus } from "../../models/FileMetadata";
@@ -468,7 +467,6 @@ function mockFundingStepGoodData(): FundingStep {
       {
         task_order_number: "12345678910",
         task_order_file: mockTaskOrderFile,
-        csp: CloudServiceProvider.AWS,
         clins: [mockClin()],
       },
     ],
@@ -492,7 +490,6 @@ function mockFundingStepBadData(): FundingStep {
       {
         task_order_number: "12345678910",
         task_order_file: mockTaskOrderFile,
-        csp: CloudServiceProvider.AWS,
         clins: [
           mockClinInvalidClinNumberTooShort(),
           mockClinInvalidClinNumberTooLong(),

--- a/packages/api/portfolioDrafts/getPortfolioDraft.test.ts
+++ b/packages/api/portfolioDrafts/getPortfolioDraft.test.ts
@@ -4,7 +4,6 @@ import { mockClient } from "aws-sdk-client-mock";
 import { handler, NO_PORTFOLIO_PATH_PARAM, NO_SUCH_PORTFOLIO } from "./getPortfolioDraft";
 import { DATABASE_ERROR } from "../utils/errors";
 import { SuccessStatusCode } from "../utils/response";
-import { PortfolioDraftSummary } from "../models/PortfolioDraftSummary";
 import { ProvisioningStatus } from "../models/ProvisioningStatus";
 import { CloudServiceProvider } from "../models/CloudServiceProvider";
 import { ApplicationStep } from "../models/ApplicationStep";
@@ -165,6 +164,7 @@ function mockPortfolioDraftSummaryBadData(): PortfolioDraft {
 function mockPortfolioStep(): PortfolioStep {
   return {
     name: "Coolest Portfolio",
+    csp: CloudServiceProvider.AWS,
     description: "Description of something cool",
     portfolio_managers: ["coolIdea@example.com", "coolPerson@example.com", "support@example.com", "admin@example.com"],
     dod_components: ["space_force"],
@@ -273,7 +273,6 @@ function mockFundingStep(): FundingStep {
             obligated_funds: 1,
           },
         ],
-        csp: CloudServiceProvider.AWS,
         task_order_number: "1234567890",
       },
       {
@@ -291,7 +290,6 @@ function mockFundingStep(): FundingStep {
             obligated_funds: 100,
           },
         ],
-        csp: CloudServiceProvider.AZURE,
         task_order_number: "0987654321",
       },
     ],

--- a/packages/api/utils/validation.test.ts
+++ b/packages/api/utils/validation.test.ts
@@ -1,3 +1,4 @@
+import { CloudServiceProvider } from "../models/CloudServiceProvider";
 import {
   mockApplicationStep,
   mockApplicationStepsMissingFields,
@@ -75,6 +76,7 @@ describe("Validation tests for createPortfolioStep function", function () {
   it("should map body to portfolioStep object", async () => {
     const requestBody = {
       name: "Zach's portfolio name",
+      csp: CloudServiceProvider.AWS,
       description: "team america",
       dod_components: ["air_force", "army", "marine_corps", "navy", "space_force"],
       portfolio_managers: ["joe.manager@example.com", "jane.manager@example.com"],
@@ -84,6 +86,8 @@ describe("Validation tests for createPortfolioStep function", function () {
   it("should fail to map body to portfolioStep object due to missing attribute", async () => {
     const requestBodyMissingDescription = {
       name: "Zach's portfolio name",
+      csp: CloudServiceProvider.AWS,
+      // description: "team america",
       dod_components: ["air_force", "army", "marine_corps", "navy", "space_force"],
       portfolio_managers: ["joe.manager@example.com", "jane.manager@example.com"],
     };
@@ -119,25 +123,16 @@ describe("Testing validation of fundingStep objects", () => {
     {
       // task_order_number: "1234567890",
       task_order_file: toFile,
-      csp: "aws",
       clins: [fakeClinData],
     },
     {
       task_order_number: "1234567890",
       // task_order_file: toFile,
-      csp: "aws",
       clins: [fakeClinData],
     },
     {
       task_order_number: "1234567890",
       task_order_file: toFile,
-      // csp: "aws",
-      clins: [fakeClinData],
-    },
-    {
-      task_order_number: "1234567890",
-      task_order_file: toFile,
-      csp: "aws",
       // clins: [fakeClinData],
     },
   ];

--- a/packages/api/utils/validation.ts
+++ b/packages/api/utils/validation.ts
@@ -1,12 +1,12 @@
-import { validate as uuidValidate, version as uuidVersion } from "uuid";
 import { Application } from "../models/Application";
 import { ApplicationStep } from "../models/ApplicationStep";
 import { Clin } from "../models/Clin";
+import { containsExactlyFields } from "../models/TypeFields";
 import { Environment } from "../models/Environment";
 import { FundingStep } from "../models/FundingStep";
 import { PortfolioStep } from "../models/PortfolioStep";
 import { TaskOrder, taskOrderFields } from "../models/TaskOrder";
-import { containsExactlyFields } from "../models/TypeFields";
+import { validate as uuidValidate, version as uuidVersion } from "uuid";
 
 /**
  * Check whether a given string is valid JSON.
@@ -59,7 +59,7 @@ export function isPortfolioStep(object: unknown): object is PortfolioStep {
   if (!isValidObject(object)) {
     return false;
   }
-  return ["name", "description", "dod_components", "portfolio_managers"].every((item) => item in object);
+  return ["name", "csp", "description", "dod_components", "portfolio_managers"].every((item) => item in object);
 }
 
 /**


### PR DESCRIPTION
The UI design has evolved and this is closing the gap in the API.

- Updates API spec to move CSP property to Portfolio Step from Funding Step
- Updates API spec examples
- Updates models `TaskOrder` (part of `FundingStep`) and `PortfolioStep`
- Updates impacted unit tests

Ticket: AT-6677