### PR TITLE
Replace a less-than-optimal regex

### DIFF
--- a/packages/cognito/preTokenGeneration/groups.ts
+++ b/packages/cognito/preTokenGeneration/groups.ts
@@ -10,7 +10,9 @@ export function processSamlGroupData(groups: string[]): string[] {
     allGroups.push(
       ...groupString
         .trim()
-        .split(/\s*,\s*/)
+        .split(",")
+        .map((groupName) => groupName.trim())
+        // keep all non-empty values
         .filter((groupName) => groupName)
     );
   }


### PR DESCRIPTION
This was picked up by SonarCloud as a potential issue. The regex matches
one of the known problematic patterns. Replacing the regex with a
split-then-trim actually makes the intent of the code more clear anyway.