### PR TITLE
Update cdk-nag to 0.0.119

### DIFF
--- a/infrastructure/package-lock.json
+++ b/infrastructure/package-lock.json
@@ -4243,9 +4243,9 @@
       "dev": true
     },
     "cdk-nag": {
-      "version": "0.0.116",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-0.0.116.tgz",
-      "integrity": "sha512-dqU+tTzWqWSDp7Xu+CCbl62rvTlUPsVv5Ml/bZFHo7o1N7Tbvf8awn8F6PXfk4KqXrNFJZSYZsHlGvNqKkK9OA==",
+      "version": "0.0.119",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-0.0.119.tgz",
+      "integrity": "sha512-y5it5pDVwkHz6bYVpe2pqx2SGjXPN2qh6d1sbFvC4Vhxv7z4xDLhFnF0YiW8pBUuX6QjkYgbdOXy4WZoTru84Q==",
       "requires": {
         "@aws-cdk/aws-apigateway": "^1.110.0",
         "@aws-cdk/aws-apigatewayv2": "^1.110.0",

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -52,7 +52,7 @@
     "@aws-cdk/aws-ssm": "1.126.0",
     "@aws-cdk/core": "1.126.0",
     "@aws-cdk/custom-resources": "1.126.0",
-    "cdk-nag": "0.0.116",
+    "cdk-nag": "0.0.119",
     "eslint": "^7.31.0",
     "source-map-support": "^0.5.16",
     "uuid": "^8.3.2"


### PR DESCRIPTION
This contains fixes for the bug we were experiencing that caused
failures on parsing intrinsic functions. Dependabot would likely have
opened this later today but I'm tracking this now so it felt just as
easy to open the PR.