### PR TITLE
AT-6697: Internal Spec updates

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -1076,8 +1076,7 @@ components:
           type: string
           format: "email"
       required:
-        - first_name
-        - last_name
+        - display_name
         - email
     PortfolioOperator:
       allOf:
@@ -1103,9 +1102,9 @@ components:
       description: Represents a set of Operators who should be granted access to a Portfolio at a specific access level. Uses an enum construct for forward compatibility should other access levels be specified.
       type: string
       enum:
-        - root_administrator
+        - portfolio_administrator
     AppEnvAccess:
-      description: Represents a set of Operators who should be granted access to an Application or Environment at a specific access level. Is a single type because the same access levels are available for both Applications & Environments.
+      description: Represents a set of Operators who should be granted access to an Application or Environment at a specific access level. The same access levels are available for both Applications & Environments.
       type: string
       enum:
         - administrator


### PR DESCRIPTION
Updated spec to accommodate the addition of operators at the Application and Portfolio level. Also customized the available access levels and fixed one tiny bug in the `clins` property of `FundingStep`

Ticket: AT-6697