### PR TITLE
Run SonarCloud under pull_request context

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:
@@ -88,10 +90,8 @@ jobs:
         run: npm run build
       - name: Run test suite
         run: npm test
-      - name: Gather test coverage artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: coverage-artifacts
-          path: |
-            packages/*/coverage/lcov.info
-            infrastructure/coverage/lcov.info
+      - name: Trigger SonarCloud
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,8 @@ jobs:
       - name: Run test suite
         run: npm test
       - name: Trigger SonarCloud
+        # This step will fail for external collaborators
+        if: ${{ github.event.sender != 'dependabot[bot]' }}
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Technically, SonarCloud does not support external PRs:
 - https://portal.productboard.com/sonarsource/1-sonarcloud/c/50-sonarcloud-analyzes-external-pull-request
 - https://jira.sonarsource.com/browse/MMF-1371

We are intentionally skipping the SonarCloud step for Dependabot (which are external) PRs.