### PR TITLE
Update Date handling logic

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -1006,10 +1006,8 @@ components:
           type: number
         pop_start_date:
           type: string
-          format: date
         pop_end_date:
           type: string
-          format: date
       required:
         - clin_number
         - idiq_clin

--- a/packages/api/utils/validation.test.ts
+++ b/packages/api/utils/validation.test.ts
@@ -203,14 +203,55 @@ describe("Testing validation of path parameter", function () {
 });
 
 describe("isValidDate()", function () {
-  it("should validate these strings", () => {
-    expect(isValidDate("1970-01-01")).toEqual(true);
-    expect(isValidDate(new Date().toISOString())).toEqual(true);
+  it.each([
+    "1970-01-01",
+    "2021-10-12",
+    "2000-02-29",
+    "2032-12-31",
+    "2019-10-02",
+    "1969-07-20",
+    "1977-05-25",
+    "2006-03-14",
+  ])("should accept valid dates", async (date) => {
+    expect(isValidDate(date)).toEqual(true);
   });
-  it("should not validate these strings", () => {
-    expect(isValidDate("")).toEqual(false);
-    expect(isValidDate("not an ISO date")).toEqual(false);
-    expect(isValidDate(NaN.toString())).toEqual(false);
+  it.each([
+    "",
+    "not an ISO date",
+    NaN.toString(),
+    "7",
+    "undefined",
+    "null",
+    "tomorrow",
+    "yesterday",
+    "today",
+    "Friday",
+    "0-14-7",
+    "not-a-date",
+    "2341-23-67",
+  ])("should not accept non-date values", async (date) => {
+    expect(isValidDate(date)).toEqual(false);
+  });
+  it.each(["2021-09-31", "2021-04-31", "2021-06-31", "2021-11-31"])(
+    "reject the 31st of months with 30 days",
+    async (date) => {
+      expect(isValidDate(date)).toEqual(false);
+    }
+  );
+  it.each(["2020-02-30", "2020-02-31", "2021-02-30", "2021-02-31", "2000-02-31", "3000-02-31"])(
+    "should reject the 30th and 31st of February every year",
+    async (date) => {
+      expect(isValidDate(date)).toEqual(false);
+    }
+  );
+  it.each(["1900-02-29", "2100-02-29", "2021-02-29", "2019-02-29", "3000-02-29"])(
+    "should reject the 29th in non-leap-years",
+    async (date) => {
+      expect(isValidDate(date)).toEqual(false);
+    }
+  );
+  it.each(["2020-02-29", "2000-02-29", "2024-02-29"])("should accept the 29th in leap years", async (date) => {
+    expect(isValidDate(date)).toEqual(true);
   });
 });
 

--- a/packages/api/utils/validation.ts
+++ b/packages/api/utils/validation.ts
@@ -156,15 +156,25 @@ export function isBodyPresent(body: string | null): body is string {
 }
 
 /**
- * Check whether a given string is a valid date.
- * The expected format is YYYY-MM-DD (ISO 8601).
+ * Checks whether the given string is a valid date.
  *
- * @param str - The string to check
- * @returns true if the string is a valid date; false otherwise
+ * This overcomes limitations in JSON Schema Draft 4 around the lack
+ * of a `date` `format` specifier.
+ *
+ * @param possibleDate - The string to check for formatting as a date
+ * @returns
  */
-export function isValidDate(str: string): boolean {
-  const date: Date = new Date(str);
-  return date instanceof Date && !isNaN(date.getTime());
+export function isValidDate(possibleDate: string): boolean {
+  const resultingDate = new Date(possibleDate);
+  if (!(resultingDate instanceof Date) || isNaN(resultingDate.getTime())) {
+    return false;
+  }
+  // Date does weird things like converting February 31st to a date in March.
+  // Because of that, we need to check that the resulting ISO String's date
+  // portion (the stuff before the T) is the same as the input. Otherwise,
+  // we might accept YYYY-02-31 as valid.
+  // TODO: Migrate to a reputable date-handling library.
+  return resultingDate.toISOString().split("T")[0] === possibleDate;
 }
 
 /**


### PR DESCRIPTION
The AWS API Gateway service only supports JSON Schema Draft 4 for object
schemas (not the OpenAPI schemas). This means that `date`, which was not
available as a `format` until later drafts, is not available in API
Gateway. Instead, we need to rely on our ability to parse regular
strings as dates. Because we were using an invalid format, request
validation was failing. It is unfortunate that this error wasn't caught
during the import of the spec into API Gateway.

This also fixes some potential bugs around invalid dates in our
implementation of `isValidDate` and adds some more tests to handle those
edge cases. It very well may introduce more bugs or also leave behind
some subtle ones. Because of that, I have added a TODO to switch to a
trusted and reputable library for this; however, performing that
evaluation was somewhat out-of-scope for this change, which is intended
to be a quick fix to unblock the UI team.