### PR TITLE
Add pattern for PoP dates to API spec

### DIFF
--- a/atat_provisioning_wizard_api.yaml
+++ b/atat_provisioning_wizard_api.yaml
@@ -1020,10 +1020,12 @@ components:
         pop_start_date:
           description: Start of period of performance
           type: string
+          pattern: '^\d{4}-((0[1-9])|(1[012]))-((0[1-9])|([12]\d)|(3[01]))$'
           example: "2021-10-01"
         pop_end_date:
           description: End of period of performance
           type: string
+          pattern: '^\d{4}-((0[1-9])|(1[012]))-((0[1-9])|([12]\d)|(3[01]))$'
           example: "2022-09-30"
       required:
         - clin_number


### PR DESCRIPTION
Roughly enforces the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) `Date` format of YYYY-MM-DD for Period of Performance start and end dates.
Not every edge case is handled, but most places accept only possible digits.