### PR TITLE
Configure dependabot to add PR reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    reviewers:
+      - dod-ccpo/platform-team
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
+    reviewers:
+      - dod-ccpo/platform-team


### PR DESCRIPTION
This adds the full platform team to the Dependabot PRs as reviewers so
that it will show up in folks review queues.