### PR TITLE
Use FIPS endpoints

### DIFF
--- a/packages/api/utils/aws-sdk/dynamodb.ts
+++ b/packages/api/utils/aws-sdk/dynamodb.ts
@@ -1,7 +1,7 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 
-const dynamodbClient = new DynamoDBClient({});
+const dynamodbClient = new DynamoDBClient({ useFipsEndpoint: true });
 
 const marshallOptions = {
   // Whether to automatically convert empty strings, blobs, and sets to `null`.

--- a/packages/api/utils/aws-sdk/s3.ts
+++ b/packages/api/utils/aws-sdk/s3.ts
@@ -1,4 +1,4 @@
 import { S3Client } from "@aws-sdk/client-s3";
 
 // Create SQS service object.
-export const s3Client = new S3Client({});
+export const s3Client = new S3Client({ useFipsEndpoint: true });

--- a/packages/api/utils/aws-sdk/secretsmanager.ts
+++ b/packages/api/utils/aws-sdk/secretsmanager.ts
@@ -1,4 +1,4 @@
 import { SecretsManager } from "@aws-sdk/client-secrets-manager";
 
 // Create a Secrets Manager service object.
-export const smClient = new SecretsManager({});
+export const smClient = new SecretsManager({ useFipsEndpoint: true });

--- a/packages/api/utils/aws-sdk/sqs.ts
+++ b/packages/api/utils/aws-sdk/sqs.ts
@@ -1,4 +1,4 @@
 import { SQSClient } from "@aws-sdk/client-sqs";
 
 // Create SQS service object.
-export const sqsClient = new SQSClient({});
+export const sqsClient = new SQSClient({ useFipsEndpoint: true });

--- a/packages/email/utils/secretsManager.ts
+++ b/packages/email/utils/secretsManager.ts
@@ -1,4 +1,4 @@
 import { SecretsManager } from "@aws-sdk/client-secrets-manager";
 
 // Create a Secrets Manager service object.
-export const smClient = new SecretsManager({});
+export const smClient = new SecretsManager({ useFipsEndpoint: true });

--- a/packages/email/utils/sqs.ts
+++ b/packages/email/utils/sqs.ts
@@ -3,7 +3,7 @@ import { SQSEvent } from "aws-lambda";
 import crypto from "crypto";
 
 // Create SQS service object.
-export const sqsClient = new SQSClient({});
+export const sqsClient = new SQSClient({ useFipsEndpoint: true });
 
 // not sure this is the best place, but placed here to prevent duplication
 export function generateTestSQSEvent(body: string): SQSEvent {


### PR DESCRIPTION
This enables using FIPS endpoints by default. This config option was added in v3.40.0, which we updated to in #400.