### PR TITLE
Use an Aspect to set Removal Policy

### DIFF
--- a/infrastructure/lib/aspects/removal-policy.ts
+++ b/infrastructure/lib/aspects/removal-policy.ts
@@ -1,0 +1,24 @@
+import * as cdk from "@aws-cdk/core";
+
+export interface RemovalPolicySetterProps {
+  globalRemovalPolicy?: cdk.RemovalPolicy;
+}
+
+/**
+ * Consistently apply a RemovalPolicy to all nodes in the tree.
+ */
+export class RemovalPolicySetter implements cdk.IAspect {
+  private readonly globalRemovalPolicy?: cdk.RemovalPolicy;
+  constructor(props?: RemovalPolicySetterProps) {
+    this.globalRemovalPolicy = props?.globalRemovalPolicy;
+  }
+
+  public visit(node: cdk.IConstruct): void {
+    // Removal policies must be set only (and directly) on CfnResource objects,
+    // the higher level constructs don't support it. We also should not set one
+    // if one was not provided (at the risk of returning it to undefined)
+    if (node instanceof cdk.CfnResource && this.globalRemovalPolicy) {
+      node.applyRemovalPolicy(this.globalRemovalPolicy);
+    }
+  }
+}

--- a/infrastructure/lib/util.test.ts
+++ b/infrastructure/lib/util.test.ts
@@ -131,3 +131,15 @@ describe("Validate function name normalization", () => {
     }
   );
 });
+
+describe("Validate temporary environment", () => {
+  it.each(["dev", "sandbox", "staging", "prod", "development", "production"])(
+    "should return false for real-looking envs",
+    async (env) => {
+      expect(utils.isPossibleTemporaryEnvironment(env)).toBe(false);
+    }
+  );
+  it.each(["at1234", "usertestenv", "username20211108"])("should return true for generic names", async (env) => {
+    expect(utils.isPossibleTemporaryEnvironment(env)).toBe(true);
+  });
+});

--- a/infrastructure/lib/util.ts
+++ b/infrastructure/lib/util.ts
@@ -103,3 +103,18 @@ export function apiSpecOperationMethod(operationId: string): HttpMethod {
   // regularity in naming
   return HttpMethod.POST;
 }
+
+/**
+ * Checks whether the given environment ID may be considered temporary or
+ * not. This is not a complete check and should be understood to be based on
+ * a general guess. Returning true does not necessarily mean the environment is
+ * absolutely temporary.
+ *
+ * @param environmentId the environment id to check
+ * @returns true if the environment ID looks like it is for a temporary environment
+ */
+// TODO: Replace with a more complete means of indicating an environment is not a
+// long-lived environment.
+export function isPossibleTemporaryEnvironment(environmentId: string): boolean {
+  return !/^(sandbox|dev|stag|prod)/.test(environmentId);
+}


### PR DESCRIPTION
Currently, disjoint mechanisms are used to set the removal policy for
constructs across the application. This uses an Aspect to consistently
apply a removal policy whenever we're dealing with a sandbox
environment. For resources in more permanent environments, the default
retention policies are used. In general, the defaults are generally to
retain resources that hold data such as S3 buckets, DynamoDB tables, and
OpenSearch Domains; however, we need to delete those in our Sandbox
environments. This ensures the proper policy is applied to all resources
in those sandboxes while leaving the default for dev/staging/prod, etc.

While this does now special case "dev", "staging", and "prod", which I
am not a fan of, it resolves the issue of "dev" currently having removal
policies set to DESTROY incorrectly. The same TODO of needing to
determine a long-term fix for this still applies; new tech debt is not
added, it's just moved.

This was originally started in #382.