### PR TITLE
Revert admin role business rule

### DIFF
--- a/packages/api/portfolioDrafts/application/createApplicationStep.test.ts
+++ b/packages/api/portfolioDrafts/application/createApplicationStep.test.ts
@@ -348,7 +348,8 @@ describe("Business rules validation tests", () => {
     expect(responseBody.details[0].message).toEqual("must NOT have less than 1 item");
     expect(result?.body).toMatch(/"\/body\/applications\/0\/environments"/);
   });
-  it("should return a validation error when admin roles are not acceptable", async () => {
+  // TODO(AT-?): move to new operation that is implemented for Step 4 with adding operators
+  it.skip("should return a validation error when admin roles are not acceptable", async () => {
     const badAdminRolesRequest: ApiGatewayEventParsed<ApplicationStep> = {
       body: mockApplicationsStepWithBadAdminRoles[0],
       pathParameters: { portfolioDraftId: uuidv4() },

--- a/packages/api/portfolioDrafts/application/createApplicationStep.ts
+++ b/packages/api/portfolioDrafts/application/createApplicationStep.ts
@@ -32,17 +32,23 @@ export async function baseHandler(
   }
   const portfolioDraftId = setupResult.path.portfolioDraftId;
   const applicationStep = event.body;
-  const adminRoles = findAdministrators(applicationStep);
+
+  // TODO(AT-?): add new endpoint for Step 4 that includes this below business rule
+  // This is only a quick fix and is reverting the admin operator role business
+  // rule that was implemented in AT-6723. All other business rules are
+  // are still covered by middy. This will allow the UI team to submit application
+  // in Step 3.
+  // const adminRoles = findAdministrators(applicationStep);
   // TODO(AT-6734): add uniform validation response for business rules
-  if (!adminRoles.acceptableAdministratorRoles) {
-    return new ValidationErrorResponse(
-      `Invalid admin roles. Acceptable admin rules are:
-      - one portfolio admin role
-      - at least one app admin role for each app when no portfolio admin role
-      - at least one env admin role for each env when no app admin role one level up.`,
-      { ...adminRoles }
-    );
-  }
+  // if (!adminRoles.acceptableAdministratorRoles) {
+  //   return new ValidationErrorResponse(
+  //     `Invalid admin roles. Acceptable admin rules are:
+  //     - one portfolio admin role
+  //     - at least one app admin role for each app when no portfolio admin role
+  //     - at least one env admin role for each env when no app admin role one level up.`,
+  //     { ...adminRoles }
+  //   );
+  // }
 
   try {
     await client.send(


### PR DESCRIPTION
Remove admin role business rule validation to allow UI to submit
the `applicationStep` with no operators in Step 3. The operators are
added in Step 4 and a new endpoint will be added that will add
add back in the admin role business rules for when Step 4 is
submitted.

This reverts only the business rules for the admin operators done 
in Ticket: AT-6723