### PR TITLE
Add local typeorm config to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ tags-private.json
 .scannerwork
 
 # typeorm local config
-packages/api/ormconfig.json
+ormconfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ tags-private.json
 # Sonar Scanner
 *.ucfg
 .scannerwork
+
+# typeorm local config
+packages/api/ormconfig.json


### PR DESCRIPTION
Add file `ormconfig.json` to `.gitignore`

This file is for configuration of typeorm for local development.
Reference: https://typeorm.io/#/using-ormconfig/using-ormconfigjson 
