### PR TITLE
Update AWS SDK JS v3 dependencies

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -134,13 +134,13 @@
 			}
 		},
 		"@aws-sdk/client-dynamodb": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.42.0.tgz",
-			"integrity": "sha512-JYeigFvLOHa7yCWJqH7jlEFzGlWQnvRuFzryrEPNmVB7ga+wBJUithjRADmfuGY8VDduWoG4s0Mx0yGK+8rZ0A==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.43.0.tgz",
+			"integrity": "sha512-7Itr8i0MibjyOM2a7/ARuJcKS8MPNmaxMZgN4d/NWZWG9Thf8FVVnliFuGLOQWcz0VFgA9ACTCv3jQQ73NmtOA==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.42.0",
+				"@aws-sdk/client-sts": "3.43.0",
 				"@aws-sdk/config-resolver": "3.40.0",
 				"@aws-sdk/credential-provider-node": "3.41.0",
 				"@aws-sdk/fetch-http-handler": "3.40.0",
@@ -172,58 +172,16 @@
 				"@aws-sdk/util-waiter": "3.40.0",
 				"tslib": "^2.3.0",
 				"uuid": "^8.3.2"
-			},
-			"dependencies": {
-				"@aws-sdk/client-sts": {
-					"version": "3.42.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.42.0.tgz",
-					"integrity": "sha512-jDklT7MoD8RxaPzUqEuCYmwhkSPpkVzLbmbMaR1oc95REuiAljVzgmEHBX/5Rk6xsFxAv2xk2P07DDmECv9fTg==",
-					"requires": {
-						"@aws-crypto/sha256-browser": "2.0.0",
-						"@aws-crypto/sha256-js": "2.0.0",
-						"@aws-sdk/config-resolver": "3.40.0",
-						"@aws-sdk/credential-provider-node": "3.41.0",
-						"@aws-sdk/fetch-http-handler": "3.40.0",
-						"@aws-sdk/hash-node": "3.40.0",
-						"@aws-sdk/invalid-dependency": "3.40.0",
-						"@aws-sdk/middleware-content-length": "3.40.0",
-						"@aws-sdk/middleware-host-header": "3.40.0",
-						"@aws-sdk/middleware-logger": "3.40.0",
-						"@aws-sdk/middleware-retry": "3.40.0",
-						"@aws-sdk/middleware-sdk-sts": "3.40.0",
-						"@aws-sdk/middleware-serde": "3.40.0",
-						"@aws-sdk/middleware-signing": "3.40.0",
-						"@aws-sdk/middleware-stack": "3.40.0",
-						"@aws-sdk/middleware-user-agent": "3.40.0",
-						"@aws-sdk/node-config-provider": "3.40.0",
-						"@aws-sdk/node-http-handler": "3.40.0",
-						"@aws-sdk/protocol-http": "3.40.0",
-						"@aws-sdk/smithy-client": "3.41.0",
-						"@aws-sdk/types": "3.40.0",
-						"@aws-sdk/url-parser": "3.40.0",
-						"@aws-sdk/util-base64-browser": "3.37.0",
-						"@aws-sdk/util-base64-node": "3.37.0",
-						"@aws-sdk/util-body-length-browser": "3.37.0",
-						"@aws-sdk/util-body-length-node": "3.37.0",
-						"@aws-sdk/util-user-agent-browser": "3.40.0",
-						"@aws-sdk/util-user-agent-node": "3.40.0",
-						"@aws-sdk/util-utf8-browser": "3.37.0",
-						"@aws-sdk/util-utf8-node": "3.37.0",
-						"entities": "2.2.0",
-						"fast-xml-parser": "3.19.0",
-						"tslib": "^2.3.0"
-					}
-				}
 			}
 		},
 		"@aws-sdk/client-s3": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.42.0.tgz",
-			"integrity": "sha512-y/MyfTr2uF/M8zidHn5T85Bz7p0gIewPtGeDg2rWVCtfRiG2hNgKGB5+wcFAN91ObFde7VCM+/zMDJ7XPXyTmg==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.43.0.tgz",
+			"integrity": "sha512-RwO5aaeg920USk5mEjHvZvWixAOmz8BUXutb0jP6f8Eg5BCnf94AZ0sIRHyQ7Agw+V1A/tMhM0zfs26bsAfKUw==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.42.0",
+				"@aws-sdk/client-sts": "3.43.0",
 				"@aws-sdk/config-resolver": "3.40.0",
 				"@aws-sdk/credential-provider-node": "3.41.0",
 				"@aws-sdk/eventstream-serde-browser": "3.40.0",
@@ -268,58 +226,16 @@
 				"entities": "2.2.0",
 				"fast-xml-parser": "3.19.0",
 				"tslib": "^2.3.0"
-			},
-			"dependencies": {
-				"@aws-sdk/client-sts": {
-					"version": "3.42.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.42.0.tgz",
-					"integrity": "sha512-jDklT7MoD8RxaPzUqEuCYmwhkSPpkVzLbmbMaR1oc95REuiAljVzgmEHBX/5Rk6xsFxAv2xk2P07DDmECv9fTg==",
-					"requires": {
-						"@aws-crypto/sha256-browser": "2.0.0",
-						"@aws-crypto/sha256-js": "2.0.0",
-						"@aws-sdk/config-resolver": "3.40.0",
-						"@aws-sdk/credential-provider-node": "3.41.0",
-						"@aws-sdk/fetch-http-handler": "3.40.0",
-						"@aws-sdk/hash-node": "3.40.0",
-						"@aws-sdk/invalid-dependency": "3.40.0",
-						"@aws-sdk/middleware-content-length": "3.40.0",
-						"@aws-sdk/middleware-host-header": "3.40.0",
-						"@aws-sdk/middleware-logger": "3.40.0",
-						"@aws-sdk/middleware-retry": "3.40.0",
-						"@aws-sdk/middleware-sdk-sts": "3.40.0",
-						"@aws-sdk/middleware-serde": "3.40.0",
-						"@aws-sdk/middleware-signing": "3.40.0",
-						"@aws-sdk/middleware-stack": "3.40.0",
-						"@aws-sdk/middleware-user-agent": "3.40.0",
-						"@aws-sdk/node-config-provider": "3.40.0",
-						"@aws-sdk/node-http-handler": "3.40.0",
-						"@aws-sdk/protocol-http": "3.40.0",
-						"@aws-sdk/smithy-client": "3.41.0",
-						"@aws-sdk/types": "3.40.0",
-						"@aws-sdk/url-parser": "3.40.0",
-						"@aws-sdk/util-base64-browser": "3.37.0",
-						"@aws-sdk/util-base64-node": "3.37.0",
-						"@aws-sdk/util-body-length-browser": "3.37.0",
-						"@aws-sdk/util-body-length-node": "3.37.0",
-						"@aws-sdk/util-user-agent-browser": "3.40.0",
-						"@aws-sdk/util-user-agent-node": "3.40.0",
-						"@aws-sdk/util-utf8-browser": "3.37.0",
-						"@aws-sdk/util-utf8-node": "3.37.0",
-						"entities": "2.2.0",
-						"fast-xml-parser": "3.19.0",
-						"tslib": "^2.3.0"
-					}
-				}
 			}
 		},
 		"@aws-sdk/client-secrets-manager": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.42.0.tgz",
-			"integrity": "sha512-rtviJZKy2L5IHlVNNjKklGePeS81ucRCxzpvwaPktrYbljVGzGa/eCbzEOy7bdGdHGaeQXFvA3DoUYg0nwV7tg==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.43.0.tgz",
+			"integrity": "sha512-0EHsbZqLziWmZ75PyNh92+SX+7a+h/spOWlS9vmpRrqbHASAPbij8HcPf2ITw7woivgKD2dqh42+nMhutsLmlg==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.42.0",
+				"@aws-sdk/client-sts": "3.43.0",
 				"@aws-sdk/config-resolver": "3.40.0",
 				"@aws-sdk/credential-provider-node": "3.41.0",
 				"@aws-sdk/fetch-http-handler": "3.40.0",
@@ -352,13 +268,13 @@
 			}
 		},
 		"@aws-sdk/client-sfn": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.42.0.tgz",
-			"integrity": "sha512-N9cPFYg1eIJ3VuV1PQ+xqrrcSP3qgJocGNfqyWj0i/VeTXJCJlfVSgZwbvz/FW1qnenImfurKevwsnvrO+zMbA==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.43.0.tgz",
+			"integrity": "sha512-QbkYSv56B+wrHtzYp2aR1jcE1Awc5rXy2McXKTZa8UDzqrRhSYbcPiFQrQefsalL3YR7iD1q1XqgdsDh+928dA==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.42.0",
+				"@aws-sdk/client-sts": "3.43.0",
 				"@aws-sdk/config-resolver": "3.40.0",
 				"@aws-sdk/credential-provider-node": "3.41.0",
 				"@aws-sdk/fetch-http-handler": "3.40.0",
@@ -387,58 +303,16 @@
 				"@aws-sdk/util-utf8-browser": "3.37.0",
 				"@aws-sdk/util-utf8-node": "3.37.0",
 				"tslib": "^2.3.0"
-			},
-			"dependencies": {
-				"@aws-sdk/client-sts": {
-					"version": "3.42.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.42.0.tgz",
-					"integrity": "sha512-jDklT7MoD8RxaPzUqEuCYmwhkSPpkVzLbmbMaR1oc95REuiAljVzgmEHBX/5Rk6xsFxAv2xk2P07DDmECv9fTg==",
-					"requires": {
-						"@aws-crypto/sha256-browser": "2.0.0",
-						"@aws-crypto/sha256-js": "2.0.0",
-						"@aws-sdk/config-resolver": "3.40.0",
-						"@aws-sdk/credential-provider-node": "3.41.0",
-						"@aws-sdk/fetch-http-handler": "3.40.0",
-						"@aws-sdk/hash-node": "3.40.0",
-						"@aws-sdk/invalid-dependency": "3.40.0",
-						"@aws-sdk/middleware-content-length": "3.40.0",
-						"@aws-sdk/middleware-host-header": "3.40.0",
-						"@aws-sdk/middleware-logger": "3.40.0",
-						"@aws-sdk/middleware-retry": "3.40.0",
-						"@aws-sdk/middleware-sdk-sts": "3.40.0",
-						"@aws-sdk/middleware-serde": "3.40.0",
-						"@aws-sdk/middleware-signing": "3.40.0",
-						"@aws-sdk/middleware-stack": "3.40.0",
-						"@aws-sdk/middleware-user-agent": "3.40.0",
-						"@aws-sdk/node-config-provider": "3.40.0",
-						"@aws-sdk/node-http-handler": "3.40.0",
-						"@aws-sdk/protocol-http": "3.40.0",
-						"@aws-sdk/smithy-client": "3.41.0",
-						"@aws-sdk/types": "3.40.0",
-						"@aws-sdk/url-parser": "3.40.0",
-						"@aws-sdk/util-base64-browser": "3.37.0",
-						"@aws-sdk/util-base64-node": "3.37.0",
-						"@aws-sdk/util-body-length-browser": "3.37.0",
-						"@aws-sdk/util-body-length-node": "3.37.0",
-						"@aws-sdk/util-user-agent-browser": "3.40.0",
-						"@aws-sdk/util-user-agent-node": "3.40.0",
-						"@aws-sdk/util-utf8-browser": "3.37.0",
-						"@aws-sdk/util-utf8-node": "3.37.0",
-						"entities": "2.2.0",
-						"fast-xml-parser": "3.19.0",
-						"tslib": "^2.3.0"
-					}
-				}
 			}
 		},
 		"@aws-sdk/client-sqs": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.42.0.tgz",
-			"integrity": "sha512-X+VtDABMRRlTo7eC/X1xHx6KwFfoQXJGcnoIDiDUCTRY5pdSl8ETNk4AB72ZI7Z5W3vNJ37Xnb00HmMCSsCeXQ==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.43.0.tgz",
+			"integrity": "sha512-FRLxT0p/nfU26AOwBfKSKGFbXz6oU0pIjl8tvCjfudgKmzLz4zL+coTL5UsGmxDfEyyb99LtLimN6UGe5KFVZA==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.42.0",
+				"@aws-sdk/client-sts": "3.43.0",
 				"@aws-sdk/config-resolver": "3.40.0",
 				"@aws-sdk/credential-provider-node": "3.41.0",
 				"@aws-sdk/fetch-http-handler": "3.40.0",
@@ -471,48 +345,6 @@
 				"entities": "2.2.0",
 				"fast-xml-parser": "3.19.0",
 				"tslib": "^2.3.0"
-			},
-			"dependencies": {
-				"@aws-sdk/client-sts": {
-					"version": "3.42.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.42.0.tgz",
-					"integrity": "sha512-jDklT7MoD8RxaPzUqEuCYmwhkSPpkVzLbmbMaR1oc95REuiAljVzgmEHBX/5Rk6xsFxAv2xk2P07DDmECv9fTg==",
-					"requires": {
-						"@aws-crypto/sha256-browser": "2.0.0",
-						"@aws-crypto/sha256-js": "2.0.0",
-						"@aws-sdk/config-resolver": "3.40.0",
-						"@aws-sdk/credential-provider-node": "3.41.0",
-						"@aws-sdk/fetch-http-handler": "3.40.0",
-						"@aws-sdk/hash-node": "3.40.0",
-						"@aws-sdk/invalid-dependency": "3.40.0",
-						"@aws-sdk/middleware-content-length": "3.40.0",
-						"@aws-sdk/middleware-host-header": "3.40.0",
-						"@aws-sdk/middleware-logger": "3.40.0",
-						"@aws-sdk/middleware-retry": "3.40.0",
-						"@aws-sdk/middleware-sdk-sts": "3.40.0",
-						"@aws-sdk/middleware-serde": "3.40.0",
-						"@aws-sdk/middleware-signing": "3.40.0",
-						"@aws-sdk/middleware-stack": "3.40.0",
-						"@aws-sdk/middleware-user-agent": "3.40.0",
-						"@aws-sdk/node-config-provider": "3.40.0",
-						"@aws-sdk/node-http-handler": "3.40.0",
-						"@aws-sdk/protocol-http": "3.40.0",
-						"@aws-sdk/smithy-client": "3.41.0",
-						"@aws-sdk/types": "3.40.0",
-						"@aws-sdk/url-parser": "3.40.0",
-						"@aws-sdk/util-base64-browser": "3.37.0",
-						"@aws-sdk/util-base64-node": "3.37.0",
-						"@aws-sdk/util-body-length-browser": "3.37.0",
-						"@aws-sdk/util-body-length-node": "3.37.0",
-						"@aws-sdk/util-user-agent-browser": "3.40.0",
-						"@aws-sdk/util-user-agent-node": "3.40.0",
-						"@aws-sdk/util-utf8-browser": "3.37.0",
-						"@aws-sdk/util-utf8-node": "3.37.0",
-						"entities": "2.2.0",
-						"fast-xml-parser": "3.19.0",
-						"tslib": "^2.3.0"
-					}
-				}
 			}
 		},
 		"@aws-sdk/client-sso": {
@@ -551,9 +383,9 @@
 			}
 		},
 		"@aws-sdk/client-sts": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.42.0.tgz",
-			"integrity": "sha512-jDklT7MoD8RxaPzUqEuCYmwhkSPpkVzLbmbMaR1oc95REuiAljVzgmEHBX/5Rk6xsFxAv2xk2P07DDmECv9fTg==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.43.0.tgz",
+			"integrity": "sha512-4CKYimjhIEixVtJH0Y8FR5FXc7zIepZtfScy8QHgH+DERXm/YL5cuUbkJiL6ZRTpek0vztVvE+mNSQU0z1eXag==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
@@ -813,11 +645,11 @@
 			}
 		},
 		"@aws-sdk/lib-dynamodb": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.42.0.tgz",
-			"integrity": "sha512-uxJqwSCrPrHU8ystBYldTYQ022Xxdry5cPBTTzeVIgFObRlftzOAzWXF5kmTjhHriyjx4MW+87AVu3b6Skt/zA==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.43.0.tgz",
+			"integrity": "sha512-V4OY7Dj831ZdN12MIN4jChWR/1fEM8qGczxHxBTKAE493j65ep4EIrOozJT2GFT3O5REbRVGgO4zQggSfqq+mA==",
 			"requires": {
-				"@aws-sdk/util-dynamodb": "3.42.0",
+				"@aws-sdk/util-dynamodb": "3.43.0",
 				"tslib": "^2.3.0"
 			}
 		},
@@ -1199,9 +1031,9 @@
 			}
 		},
 		"@aws-sdk/util-dynamodb": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.42.0.tgz",
-			"integrity": "sha512-71lJrdSouu4yHmLFjZM+8LYlQbGrZ940XC4Qv5qmp+pAEn/SzOkLJ48PxcIa8A0ibfhULfUgju+d7tok/gHanA==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.43.0.tgz",
+			"integrity": "sha512-hluGFIH0W6F9nVhGmk/VcT3Y3riGCE75Z0Zej8a9A9q9F07n0ytmdMAXBttnJgG8jCf2YdCEI5ybP1BVoTkLRw==",
 			"requires": {
 				"tslib": "^2.3.0"
 			}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,12 +8,12 @@
     "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.42.0",
-    "@aws-sdk/client-s3": "^3.42.0",
-    "@aws-sdk/client-secrets-manager": "^3.42.0",
-    "@aws-sdk/client-sfn": "^3.42.0",
-    "@aws-sdk/client-sqs": "^3.42.0",
-    "@aws-sdk/lib-dynamodb": "^3.42.0",
+    "@aws-sdk/client-dynamodb": "^3.43.0",
+    "@aws-sdk/client-s3": "^3.43.0",
+    "@aws-sdk/client-secrets-manager": "^3.43.0",
+    "@aws-sdk/client-sfn": "^3.43.0",
+    "@aws-sdk/client-sqs": "^3.43.0",
+    "@aws-sdk/lib-dynamodb": "^3.43.0",
     "@middy/core": "^2.5.2",
     "@middy/http-cors": "^2.5.2",
     "@middy/http-event-normalizer": "^2.5.2",

--- a/packages/email/package-lock.json
+++ b/packages/email/package-lock.json
@@ -100,13 +100,13 @@
 			}
 		},
 		"@aws-sdk/client-secrets-manager": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.42.0.tgz",
-			"integrity": "sha512-rtviJZKy2L5IHlVNNjKklGePeS81ucRCxzpvwaPktrYbljVGzGa/eCbzEOy7bdGdHGaeQXFvA3DoUYg0nwV7tg==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.43.0.tgz",
+			"integrity": "sha512-0EHsbZqLziWmZ75PyNh92+SX+7a+h/spOWlS9vmpRrqbHASAPbij8HcPf2ITw7woivgKD2dqh42+nMhutsLmlg==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.42.0",
+				"@aws-sdk/client-sts": "3.43.0",
 				"@aws-sdk/config-resolver": "3.40.0",
 				"@aws-sdk/credential-provider-node": "3.41.0",
 				"@aws-sdk/fetch-http-handler": "3.40.0",
@@ -139,13 +139,13 @@
 			}
 		},
 		"@aws-sdk/client-sqs": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.42.0.tgz",
-			"integrity": "sha512-X+VtDABMRRlTo7eC/X1xHx6KwFfoQXJGcnoIDiDUCTRY5pdSl8ETNk4AB72ZI7Z5W3vNJ37Xnb00HmMCSsCeXQ==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.43.0.tgz",
+			"integrity": "sha512-FRLxT0p/nfU26AOwBfKSKGFbXz6oU0pIjl8tvCjfudgKmzLz4zL+coTL5UsGmxDfEyyb99LtLimN6UGe5KFVZA==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.42.0",
+				"@aws-sdk/client-sts": "3.43.0",
 				"@aws-sdk/config-resolver": "3.40.0",
 				"@aws-sdk/credential-provider-node": "3.41.0",
 				"@aws-sdk/fetch-http-handler": "3.40.0",
@@ -178,48 +178,6 @@
 				"entities": "2.2.0",
 				"fast-xml-parser": "3.19.0",
 				"tslib": "^2.3.0"
-			},
-			"dependencies": {
-				"@aws-sdk/client-sts": {
-					"version": "3.42.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.42.0.tgz",
-					"integrity": "sha512-jDklT7MoD8RxaPzUqEuCYmwhkSPpkVzLbmbMaR1oc95REuiAljVzgmEHBX/5Rk6xsFxAv2xk2P07DDmECv9fTg==",
-					"requires": {
-						"@aws-crypto/sha256-browser": "2.0.0",
-						"@aws-crypto/sha256-js": "2.0.0",
-						"@aws-sdk/config-resolver": "3.40.0",
-						"@aws-sdk/credential-provider-node": "3.41.0",
-						"@aws-sdk/fetch-http-handler": "3.40.0",
-						"@aws-sdk/hash-node": "3.40.0",
-						"@aws-sdk/invalid-dependency": "3.40.0",
-						"@aws-sdk/middleware-content-length": "3.40.0",
-						"@aws-sdk/middleware-host-header": "3.40.0",
-						"@aws-sdk/middleware-logger": "3.40.0",
-						"@aws-sdk/middleware-retry": "3.40.0",
-						"@aws-sdk/middleware-sdk-sts": "3.40.0",
-						"@aws-sdk/middleware-serde": "3.40.0",
-						"@aws-sdk/middleware-signing": "3.40.0",
-						"@aws-sdk/middleware-stack": "3.40.0",
-						"@aws-sdk/middleware-user-agent": "3.40.0",
-						"@aws-sdk/node-config-provider": "3.40.0",
-						"@aws-sdk/node-http-handler": "3.40.0",
-						"@aws-sdk/protocol-http": "3.40.0",
-						"@aws-sdk/smithy-client": "3.41.0",
-						"@aws-sdk/types": "3.40.0",
-						"@aws-sdk/url-parser": "3.40.0",
-						"@aws-sdk/util-base64-browser": "3.37.0",
-						"@aws-sdk/util-base64-node": "3.37.0",
-						"@aws-sdk/util-body-length-browser": "3.37.0",
-						"@aws-sdk/util-body-length-node": "3.37.0",
-						"@aws-sdk/util-user-agent-browser": "3.40.0",
-						"@aws-sdk/util-user-agent-node": "3.40.0",
-						"@aws-sdk/util-utf8-browser": "3.37.0",
-						"@aws-sdk/util-utf8-node": "3.37.0",
-						"entities": "2.2.0",
-						"fast-xml-parser": "3.19.0",
-						"tslib": "^2.3.0"
-					}
-				}
 			}
 		},
 		"@aws-sdk/client-sso": {
@@ -258,9 +216,9 @@
 			}
 		},
 		"@aws-sdk/client-sts": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.42.0.tgz",
-			"integrity": "sha512-jDklT7MoD8RxaPzUqEuCYmwhkSPpkVzLbmbMaR1oc95REuiAljVzgmEHBX/5Rk6xsFxAv2xk2P07DDmECv9fTg==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.43.0.tgz",
+			"integrity": "sha512-4CKYimjhIEixVtJH0Y8FR5FXc7zIepZtfScy8QHgH+DERXm/YL5cuUbkJiL6ZRTpek0vztVvE+mNSQU0z1eXag==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -8,8 +8,8 @@
     "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "3.42.0",
-    "@aws-sdk/client-sqs": "3.42.0",
+    "@aws-sdk/client-secrets-manager": "3.43.0",
+    "@aws-sdk/client-sqs": "3.43.0",
     "@middy/core": "^2.5.2",
     "@middy/http-cors": "^2.5.2",
     "@middy/http-event-normalizer": "^2.5.2",

--- a/packages/rds/package-lock.json
+++ b/packages/rds/package-lock.json
@@ -99,52 +99,14 @@
         "tslib": "^2.3.0"
       }
     },
-    "@aws-sdk/client-cognito-identity": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.41.0.tgz",
-      "integrity": "sha512-rmlVJi75hLTeUoflafkyINSGD58du7XxxICbT2LGUkkqptfp/y0MViX8kgbymBMs7PdNcyDvevUCzGW6Zdhu0A==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.41.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
-        "@aws-sdk/fetch-http-handler": "3.40.0",
-        "@aws-sdk/hash-node": "3.40.0",
-        "@aws-sdk/invalid-dependency": "3.40.0",
-        "@aws-sdk/middleware-content-length": "3.40.0",
-        "@aws-sdk/middleware-host-header": "3.40.0",
-        "@aws-sdk/middleware-logger": "3.40.0",
-        "@aws-sdk/middleware-retry": "3.40.0",
-        "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/middleware-user-agent": "3.40.0",
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/node-http-handler": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/smithy-client": "3.41.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/url-parser": "3.40.0",
-        "@aws-sdk/util-base64-browser": "3.37.0",
-        "@aws-sdk/util-base64-node": "3.37.0",
-        "@aws-sdk/util-body-length-browser": "3.37.0",
-        "@aws-sdk/util-body-length-node": "3.37.0",
-        "@aws-sdk/util-user-agent-browser": "3.40.0",
-        "@aws-sdk/util-user-agent-node": "3.40.0",
-        "@aws-sdk/util-utf8-browser": "3.37.0",
-        "@aws-sdk/util-utf8-node": "3.37.0",
-        "tslib": "^2.3.0"
-      }
-    },
     "@aws-sdk/client-secrets-manager": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.41.0.tgz",
-      "integrity": "sha512-QnZCog7souPSWjaJ7Av8kmtkOcBpKA/6RZE0bZ7osYodGv5fI7j/6wf7xXlhjJeLX83rPjeCm28gKVf0WxXW5g==",
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.43.0.tgz",
+      "integrity": "sha512-0EHsbZqLziWmZ75PyNh92+SX+7a+h/spOWlS9vmpRrqbHASAPbij8HcPf2ITw7woivgKD2dqh42+nMhutsLmlg==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.41.0",
+        "@aws-sdk/client-sts": "3.43.0",
         "@aws-sdk/config-resolver": "3.40.0",
         "@aws-sdk/credential-provider-node": "3.41.0",
         "@aws-sdk/fetch-http-handler": "3.40.0",
@@ -212,9 +174,9 @@
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.41.0.tgz",
-      "integrity": "sha512-XTjmr53kMbXuVhH3B+g2jEYuhNralptsMSd4RcSHCB7BX1NmAMnMFKKTmVlmc5NizWi4x1CzExu86Q0YSqp0og==",
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.43.0.tgz",
+      "integrity": "sha512-4CKYimjhIEixVtJH0Y8FR5FXc7zIepZtfScy8QHgH+DERXm/YL5cuUbkJiL6ZRTpek0vztVvE+mNSQU0z1eXag==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -259,17 +221,6 @@
         "@aws-sdk/signature-v4": "3.40.0",
         "@aws-sdk/types": "3.40.0",
         "@aws-sdk/util-config-provider": "3.40.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.41.0.tgz",
-      "integrity": "sha512-cwndWlbO2GJrnqHXQqekVmC7oZw6ELfaivaVtk4zd7iA94B5SjNIm9qGzUKcwvNCM1lezSWn8bluvRMX+jlk4w==",
-      "requires": {
-        "@aws-sdk/client-cognito-identity": "3.41.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
         "tslib": "^2.3.0"
       }
     },
@@ -361,28 +312,6 @@
       "requires": {
         "@aws-sdk/property-provider": "3.40.0",
         "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/credential-providers": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.41.0.tgz",
-      "integrity": "sha512-D4mGPg+j7lP6QMzshwhj/DaOKV6f337VhldzNvdlc1oWmE/n33Ru+iBIThhbaeCXYVTCTEAknrKRUgYuYZAhKQ==",
-      "requires": {
-        "@aws-sdk/client-cognito-identity": "3.41.0",
-        "@aws-sdk/client-sso": "3.41.0",
-        "@aws-sdk/client-sts": "3.41.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.41.0",
-        "@aws-sdk/credential-provider-env": "3.40.0",
-        "@aws-sdk/credential-provider-imds": "3.40.0",
-        "@aws-sdk/credential-provider-ini": "3.41.0",
-        "@aws-sdk/credential-provider-process": "3.40.0",
-        "@aws-sdk/credential-provider-sso": "3.41.0",
-        "@aws-sdk/credential-provider-web-identity": "3.41.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-credentials": "3.37.0",
         "tslib": "^2.3.0"
       }
     },

--- a/packages/rds/package.json
+++ b/packages/rds/package.json
@@ -8,9 +8,8 @@
     "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "3.41.0",
+    "@aws-sdk/client-secrets-manager": "3.43.0",
     "@aws-sdk/credential-provider-node": "3.41.0",
-    "@aws-sdk/credential-providers": "3.41.0",
     "@aws-sdk/hash-node": "3.40.0",
     "@aws-sdk/protocol-http": "3.40.0",
     "@aws-sdk/signature-v4": "3.40.0",


### PR DESCRIPTION
This bumps all packages to the newest version possible. For most clients
this is 3.43.0; for some supporting/util packages, this is 3.41.0 or
3.40.0. Additionally, the unused `@aws-sdk/credential-providers` package
was removed from `atat-web-api-rds`.

Hopefully this will unstick dependabot.