### PR TITLE
Refactor models and entities to prevent name collisions

### DIFF
--- a/packages/api/models/Application.ts
+++ b/packages/api/models/Application.ts
@@ -1,8 +1,8 @@
-import { AppEnvOperator } from "./Operator";
-import { Environment } from "./Environment";
-export interface Application {
+import { AppEnvOperatorModel } from "./Operator";
+import { EnvironmentModel } from "./Environment";
+export interface ApplicationModel {
   name: string;
   description?: string;
-  environments: Array<Environment>;
-  operators: Array<AppEnvOperator>;
+  environments: Array<EnvironmentModel>;
+  operators: Array<AppEnvOperatorModel>;
 }

--- a/packages/api/models/ApplicationStep.ts
+++ b/packages/api/models/ApplicationStep.ts
@@ -1,9 +1,9 @@
-import { Application } from "./Application";
-import { PortfolioOperator } from "./Operator";
+import { ApplicationModel } from "./Application";
+import { PortfolioOperatorModel } from "./Operator";
 
-export interface ApplicationStep {
-  applications: Array<Application>;
-  operators: Array<PortfolioOperator>;
+export interface ApplicationStepModel {
+  applications: Array<ApplicationModel>;
+  operators: Array<PortfolioOperatorModel>;
 }
 
 export enum ValidationMessage {

--- a/packages/api/models/BaseDocument.ts
+++ b/packages/api/models/BaseDocument.ts
@@ -1,4 +1,4 @@
-export interface BaseDocument {
+export interface BaseDocumentModel {
   id: string;
   created_at: string;
   updated_at: string;

--- a/packages/api/models/Clin.ts
+++ b/packages/api/models/Clin.ts
@@ -1,4 +1,4 @@
-export interface Clin {
+export interface ClinModel {
   clin_number: string;
   idiq_clin: string;
   total_clin_value: number;

--- a/packages/api/models/Environment.ts
+++ b/packages/api/models/Environment.ts
@@ -1,6 +1,6 @@
-import { AppEnvOperator } from "./Operator";
+import { AppEnvOperatorModel } from "./Operator";
 
-export interface Environment {
+export interface EnvironmentModel {
   name: string;
-  operators: Array<AppEnvOperator>;
+  operators: Array<AppEnvOperatorModel>;
 }

--- a/packages/api/models/Error.ts
+++ b/packages/api/models/Error.ts
@@ -3,12 +3,12 @@ export enum ErrorCode {
   OTHER = "OTHER",
 }
 
-export interface Error {
+export interface ErrorModel {
   code: ErrorCode;
   message: string;
 }
 
-export interface ValidationError extends Error {
+export interface ValidationErrorModel extends ErrorModel {
   code: ErrorCode.INVALID_INPUT;
   error_map: Record<string, unknown>;
 }

--- a/packages/api/models/FileMetadata.ts
+++ b/packages/api/models/FileMetadata.ts
@@ -1,5 +1,5 @@
-import { BaseDocument } from "./BaseDocument";
-import { FileMetadataSummary } from "./FileMetadataSummary";
+import { BaseDocumentModel } from "./BaseDocument";
+import { FileMetadataSummaryModel } from "./FileMetadataSummary";
 
 export enum FileScanStatus {
   PENDING = "pending",
@@ -7,7 +7,7 @@ export enum FileScanStatus {
   REJECTED = "rejected",
 }
 
-export interface FileMetadata extends BaseDocument, FileMetadataSummary {
+export interface FileMetadataModel extends BaseDocumentModel, FileMetadataSummaryModel {
   size: number;
   status: FileScanStatus;
 }

--- a/packages/api/models/FileMetadataSummary.ts
+++ b/packages/api/models/FileMetadataSummary.ts
@@ -1,4 +1,4 @@
-export interface FileMetadataSummary {
+export interface FileMetadataSummaryModel {
   id: string;
   name: string;
 }

--- a/packages/api/models/FundingStep.ts
+++ b/packages/api/models/FundingStep.ts
@@ -1,4 +1,4 @@
-import { TaskOrder } from "./TaskOrder";
+import { TaskOrderModel } from "./TaskOrder";
 
 export enum ValidationMessage {
   START_VALID = "start date must be a valid date",
@@ -10,6 +10,6 @@ export enum ValidationMessage {
   INVALID_CLIN_NUMBER = "clin number must be four numbers and in range 0001 through 9999",
 }
 
-export interface FundingStep {
-  task_orders: Array<TaskOrder>;
+export interface FundingStepModel {
+  task_orders: Array<TaskOrderModel>;
 }

--- a/packages/api/models/Operator.ts
+++ b/packages/api/models/Operator.ts
@@ -10,20 +10,20 @@ export enum AppEnvAccess {
   READ_ONLY = "read_only",
 }
 
-export interface Operator {
+export interface OperatorModel {
   display_name: string;
   email: string;
 }
 
-export interface PortfolioOperator extends Operator {
+export interface PortfolioOperatorModel extends OperatorModel {
   access: PortfolioAccess;
 }
 
-export interface AppEnvOperator extends Operator {
+export interface AppEnvOperatorModel extends OperatorModel {
   access: AppEnvAccess;
 }
 
-export type Operators = PortfolioOperator | AppEnvOperator;
+export type Operators = PortfolioOperatorModel | AppEnvOperatorModel;
 export const operatorFields: ExhaustivePropertyMap<Operators> = {
   display_name: null,
   email: null,

--- a/packages/api/models/PortfolioDraft.ts
+++ b/packages/api/models/PortfolioDraft.ts
@@ -1,20 +1,20 @@
-import { ApplicationStep } from "./ApplicationStep";
+import { ApplicationStepModel } from "./ApplicationStep";
 import { ExhaustivePropertyMap } from "./TypeFields";
-import { FundingStep } from "./FundingStep";
-import { PortfolioDraftSummary } from "./PortfolioDraftSummary";
-import { PortfolioStep } from "./PortfolioStep";
+import { FundingStepModel } from "./FundingStep";
+import { PortfolioDraftSummaryModel } from "./PortfolioDraftSummary";
+import { PortfolioStepModel } from "./PortfolioStep";
 
 export const PORTFOLIO_STEP = "portfolio_step";
 export const FUNDING_STEP = "funding_step";
 export const APPLICATION_STEP = "application_step";
 
-export interface PortfolioDraft extends PortfolioDraftSummary {
-  [PORTFOLIO_STEP]: PortfolioStep;
-  [FUNDING_STEP]: FundingStep;
-  [APPLICATION_STEP]: ApplicationStep;
+export interface PortfolioDraftModel extends PortfolioDraftSummaryModel {
+  [PORTFOLIO_STEP]: PortfolioStepModel;
+  [FUNDING_STEP]: FundingStepModel;
+  [APPLICATION_STEP]: ApplicationStepModel;
 }
 
-export const portfolioDraftProperties: ExhaustivePropertyMap<PortfolioDraft> = {
+export const portfolioDraftProperties: ExhaustivePropertyMap<PortfolioDraftModel> = {
   // BaseDocument properties
   id: null,
   created_at: null,

--- a/packages/api/models/PortfolioDraftSummary.ts
+++ b/packages/api/models/PortfolioDraftSummary.ts
@@ -1,8 +1,8 @@
-import { BaseDocument } from "./BaseDocument";
+import { BaseDocumentModel } from "./BaseDocument";
 import { ProvisioningStatus } from "./ProvisioningStatus";
 import { ExhaustivePropertyMap } from "./TypeFields";
 
-export interface PortfolioDraftSummary extends BaseDocument {
+export interface PortfolioDraftSummaryModel extends BaseDocumentModel {
   status: ProvisioningStatus;
   name: string;
   description: string;
@@ -12,7 +12,7 @@ export interface PortfolioDraftSummary extends BaseDocument {
   num_environments: number;
 }
 
-export const portfolioDraftSummaryProperties: ExhaustivePropertyMap<PortfolioDraftSummary> = {
+export const portfolioDraftSummaryProperties: ExhaustivePropertyMap<PortfolioDraftSummaryModel> = {
   // BaseDocument properties
   id: null,
   created_at: null,

--- a/packages/api/models/PortfolioStep.ts
+++ b/packages/api/models/PortfolioStep.ts
@@ -1,5 +1,5 @@
 import { CloudServiceProvider } from "./CloudServiceProvider";
-export interface PortfolioStep {
+export interface PortfolioStepModel {
   name: string;
   csp: CloudServiceProvider;
   description?: string;

--- a/packages/api/models/ProvisioningStatus.ts
+++ b/packages/api/models/ProvisioningStatus.ts
@@ -1,6 +1,6 @@
-import { PortfolioDraft } from "./PortfolioDraft";
-import { ApplicationStep } from "./ApplicationStep";
-import { FundingStep } from "./FundingStep";
+import { PortfolioDraftModel } from "./PortfolioDraft";
+import { ApplicationStepModel } from "./ApplicationStep";
+import { FundingStepModel } from "./FundingStep";
 import { Operators } from "./Operator";
 import { CloudServiceProvider } from "./CloudServiceProvider";
 
@@ -19,8 +19,8 @@ export enum ProvisioningRequestType {
   OPERATORS = "operators",
 }
 
-type ProvisioningBody = PortfolioDraft | ApplicationStep | FundingStep | Operators;
-export interface ProvisioningTaskInput {
+type ProvisioningBody = PortfolioDraftModel | ApplicationStepModel | FundingStepModel | Operators;
+export interface ProvisioningTaskInputModel {
   body: ProvisioningBody;
   type: ProvisioningRequestType;
   csp: CloudServiceProvider;

--- a/packages/api/models/TaskOrder.ts
+++ b/packages/api/models/TaskOrder.ts
@@ -1,14 +1,14 @@
-import { Clin } from "./Clin";
-import { FileMetadataSummary } from "./FileMetadataSummary";
+import { ClinModel } from "./Clin";
+import { FileMetadataSummaryModel } from "./FileMetadataSummary";
 import { ExhaustivePropertyMap } from "./TypeFields";
 
-export interface TaskOrder {
+export interface TaskOrderModel {
   task_order_number: string;
-  task_order_file: FileMetadataSummary;
-  clins: Array<Clin>;
+  task_order_file: FileMetadataSummaryModel;
+  clins: Array<ClinModel>;
 }
 
-export const taskOrderFields: ExhaustivePropertyMap<TaskOrder> = {
+export const taskOrderFields: ExhaustivePropertyMap<TaskOrderModel> = {
   task_order_number: null,
   task_order_file: null,
   clins: null,

--- a/packages/api/orm/entity/Application.ts
+++ b/packages/api/orm/entity/Application.ts
@@ -1,19 +1,19 @@
 import { Column, Entity, ManyToOne, OneToMany } from "typeorm";
-import { Environment } from "./Environment";
-import { Portfolio } from "./Portfolio";
+import { EnvironmentEntity } from "./Environment";
+import { PortfolioEntity } from "./Portfolio";
 import { ProvisionableEntity } from "./ProvisionableEntity";
 
 @Entity()
-export class Application extends ProvisionableEntity {
+export class ApplicationEntity extends ProvisionableEntity {
   @Column({ length: 100 })
   name: string;
 
   @Column({ nullable: true, length: 300 })
   description: string;
 
-  @ManyToOne(() => Portfolio, (portfolio) => portfolio.applications)
-  portfolio: Portfolio;
+  @ManyToOne(() => PortfolioEntity, (portfolio) => portfolio.applications)
+  portfolio: PortfolioEntity;
 
-  @OneToMany(() => Environment, (environment) => environment.application)
-  environments: Array<Environment>;
+  @OneToMany(() => EnvironmentEntity, (environment) => environment.application)
+  environments: Array<EnvironmentEntity>;
 }

--- a/packages/api/orm/entity/Clin.ts
+++ b/packages/api/orm/entity/Clin.ts
@@ -1,9 +1,9 @@
 import { BaseEntity } from "./BaseEntity";
 import { Column, Entity, ManyToOne } from "typeorm";
-import { TaskOrder } from "./TaskOrder";
+import { TaskOrderEntity } from "./TaskOrder";
 
 @Entity()
-export class Clin extends BaseEntity {
+export class ClinEntity extends BaseEntity {
   @Column({
     length: 4,
     comment: "contract line item number from task order, 0001 through 9999",
@@ -33,6 +33,6 @@ export class Clin extends BaseEntity {
   @Column({ type: "date", comment: "end of POP during which funds can be spent" })
   popEndDate: Date;
 
-  @ManyToOne(() => TaskOrder, (taskOrder) => taskOrder.clins)
-  taskOrder: TaskOrder;
+  @ManyToOne(() => TaskOrderEntity, (taskOrder) => taskOrder.clins)
+  taskOrder: TaskOrderEntity;
 }

--- a/packages/api/orm/entity/Environment.ts
+++ b/packages/api/orm/entity/Environment.ts
@@ -1,12 +1,12 @@
-import { Application } from "./Application";
+import { ApplicationEntity } from "./Application";
 import { Column, Entity, ManyToOne } from "typeorm";
 import { ProvisionableEntity } from "./ProvisionableEntity";
 
 @Entity()
-export class Environment extends ProvisionableEntity {
+export class EnvironmentEntity extends ProvisionableEntity {
   @Column({ length: 100 })
   name: string;
 
-  @ManyToOne(() => Application, (application) => application.environments)
-  application: Application;
+  @ManyToOne(() => ApplicationEntity, (application) => application.environments)
+  application: ApplicationEntity;
 }

--- a/packages/api/orm/entity/Portfolio.ts
+++ b/packages/api/orm/entity/Portfolio.ts
@@ -1,11 +1,11 @@
-import { Application } from "./Application";
+import { ApplicationEntity } from "./Application";
 import { CloudServiceProvider } from "../../models/CloudServiceProvider";
 import { Column, Entity, OneToMany } from "typeorm";
 import { ProvisionableEntity } from "./ProvisionableEntity";
-import { TaskOrder } from "./TaskOrder";
+import { TaskOrderEntity } from "./TaskOrder";
 
 @Entity()
-export class Portfolio extends ProvisionableEntity {
+export class PortfolioEntity extends ProvisionableEntity {
   @Column({ length: 100 })
   name: string;
 
@@ -24,9 +24,9 @@ export class Portfolio extends ProvisionableEntity {
   @Column({ type: "varchar", array: true })
   portfolioManagers: Array<string>;
 
-  @OneToMany(() => TaskOrder, (taskOrder) => taskOrder.portfolio)
-  taskOrders: Array<TaskOrder>;
+  @OneToMany(() => TaskOrderEntity, (taskOrder) => taskOrder.portfolio)
+  taskOrders: Array<TaskOrderEntity>;
 
-  @OneToMany(() => Application, (application) => application.portfolio)
-  applications: Array<Application>;
+  @OneToMany(() => ApplicationEntity, (application) => application.portfolio)
+  applications: Array<ApplicationEntity>;
 }

--- a/packages/api/orm/entity/TaskOrder.ts
+++ b/packages/api/orm/entity/TaskOrder.ts
@@ -1,11 +1,11 @@
 import { BaseEntity } from "./BaseEntity";
-import { Clin } from "./Clin";
+import { ClinEntity } from "./Clin";
 import { Column, Entity, ManyToOne, OneToMany } from "typeorm";
 import { FileScanStatus } from "../../models/FileMetadata";
-import { Portfolio } from "./Portfolio";
+import { PortfolioEntity } from "./Portfolio";
 
 @Entity()
-export class TaskOrder extends BaseEntity {
+export class TaskOrderEntity extends BaseEntity {
   @Column({
     length: 17,
     comment: "TO numbers are 13 characters. TO modifications are 17 characters.",
@@ -24,9 +24,9 @@ export class TaskOrder extends BaseEntity {
   @Column({ type: "enum", enum: FileScanStatus, default: FileScanStatus.PENDING })
   fileScanStatus: FileScanStatus;
 
-  @ManyToOne(() => Portfolio, (portfolio) => portfolio.taskOrders)
-  portfolio: Portfolio;
+  @ManyToOne(() => PortfolioEntity, (portfolio) => portfolio.taskOrders)
+  portfolio: PortfolioEntity;
 
-  @OneToMany(() => Clin, (clin) => clin.taskOrder)
-  clins: Array<Clin>;
+  @OneToMany(() => ClinEntity, (clin) => clin.taskOrder)
+  clins: Array<ClinEntity>;
 }

--- a/packages/api/portfolioDrafts/application/commonApplicationMockData.ts
+++ b/packages/api/portfolioDrafts/application/commonApplicationMockData.ts
@@ -1,57 +1,57 @@
-import { AppEnvAccess, PortfolioAccess, PortfolioOperator, AppEnvOperator } from "../../models/Operator";
-import { Application } from "../../models/Application";
-import { ApplicationStep } from "../../models/ApplicationStep";
-import { Environment } from "../../models/Environment";
+import { AppEnvAccess, PortfolioAccess, PortfolioOperatorModel, AppEnvOperatorModel } from "../../models/Operator";
+import { ApplicationModel } from "../../models/Application";
+import { ApplicationStepModel } from "../../models/ApplicationStep";
+import { EnvironmentModel } from "../../models/Environment";
 import { ProvisioningStatus } from "../../models/ProvisioningStatus";
 import { v4 as uuidv4 } from "uuid";
-import { PortfolioDraftSummary } from "../../models/PortfolioDraftSummary";
-import { PortfolioDraft } from "../../models/PortfolioDraft";
+import { PortfolioDraftSummaryModel } from "../../models/PortfolioDraftSummary";
+import { PortfolioDraftModel } from "../../models/PortfolioDraft";
 
-const mockPortoflioOperatorYoda: PortfolioOperator = {
+const mockPortoflioOperatorYoda: PortfolioOperatorModel = {
   display_name: "Yoda",
   email: "yoda@iam.mil",
   access: PortfolioAccess.PORTFOLIO_ADMINISTRATOR,
 };
-const mockAppEnvOperatorDarthVader: AppEnvOperator = {
+const mockAppEnvOperatorDarthVader: AppEnvOperatorModel = {
   display_name: "Darth Vader",
   email: "iam@yourfather.mil",
   access: AppEnvAccess.ADMINISTRATOR,
 };
-const mockAppEnvOperatorLandonisCalrissian: AppEnvOperator = {
+const mockAppEnvOperatorLandonisCalrissian: AppEnvOperatorModel = {
   display_name: "Landonis Calrissian",
   email: "thegambler@cloudcity.mil",
   access: AppEnvAccess.READ_ONLY,
 };
-const mockAppEnvOperatorLukeSkywalker: AppEnvOperator = {
+const mockAppEnvOperatorLukeSkywalker: AppEnvOperatorModel = {
   display_name: "Luke Skywalker",
   email: "lostmy@hand.mil",
   access: AppEnvAccess.READ_ONLY,
 };
-const mockAppEnvOperatorSalaciousCrumb: AppEnvOperator = {
+const mockAppEnvOperatorSalaciousCrumb: AppEnvOperatorModel = {
   display_name: "Salacious Crumb",
   email: "monkey@lizard.mil",
   access: AppEnvAccess.ADMINISTRATOR,
 };
-const mockAppEnvOperatorHanSolo: AppEnvOperator = {
+const mockAppEnvOperatorHanSolo: AppEnvOperatorModel = {
   display_name: "Han Solo",
   email: "frozen@carbonite.mil",
   access: AppEnvAccess.READ_ONLY,
 };
-const mockAppEnvOperatorBobaFett: AppEnvOperator = {
+const mockAppEnvOperatorBobaFett: AppEnvOperatorModel = {
   display_name: "Boba Fett",
   email: "original@mandalorian.mil",
   access: AppEnvAccess.READ_ONLY,
 };
 
-const mockEnvironmentCcepProd: Environment = {
+const mockEnvironmentCcepProd: EnvironmentModel = {
   name: "production",
   operators: [mockAppEnvOperatorDarthVader, mockAppEnvOperatorLandonisCalrissian, mockAppEnvOperatorLukeSkywalker],
 };
-const mockEnvironmentJpeaStage: Environment = {
+const mockEnvironmentJpeaStage: EnvironmentModel = {
   name: "stage",
   operators: [mockAppEnvOperatorSalaciousCrumb, mockAppEnvOperatorHanSolo, mockAppEnvOperatorBobaFett],
 };
-const mockEnvironmentJpeaDev: Environment = {
+const mockEnvironmentJpeaDev: EnvironmentModel = {
   name: "development",
   operators: [mockAppEnvOperatorSalaciousCrumb, mockAppEnvOperatorHanSolo, mockAppEnvOperatorBobaFett],
 };
@@ -59,7 +59,7 @@ const mockEnvironmentJpeaDev: Environment = {
 /**
  * "Cloud City Evac Planner" from API spec
  */
-export const mockApplicationCloudCityEvacPlanner: Application = {
+export const mockApplicationCloudCityEvacPlanner: ApplicationModel = {
   name: "Cloud City Evac Planner",
   description: "Application for planning an emergency evacuation",
   environments: [mockEnvironmentCcepProd],
@@ -69,7 +69,7 @@ export const mockApplicationCloudCityEvacPlanner: Application = {
 /**
  * "Jabba's Palace Expansion App" from API spec
  */
-export const mockApplicationJabbasPalaceExpansionApp: Application = {
+export const mockApplicationJabbasPalaceExpansionApp: ApplicationModel = {
   name: "Jabba Palace Expansion App",
   description: "Planning application for palace expansion",
   environments: [mockEnvironmentJpeaDev, mockEnvironmentJpeaStage],
@@ -80,7 +80,7 @@ export const mockApplicationJabbasPalaceExpansionApp: Application = {
  * ApplicationStepEx from API spec
  * @returns a complete ApplicationStep with good data
  */
-export const mockApplicationStep: ApplicationStep = {
+export const mockApplicationStep: ApplicationStepModel = {
   applications: [mockApplicationCloudCityEvacPlanner, mockApplicationJabbasPalaceExpansionApp],
   operators: [mockPortoflioOperatorYoda],
 };
@@ -90,7 +90,7 @@ const now = new Date().toISOString();
  * A base Portfolio Draft Summary
  * @returns a base portfolio summary with good data
  */
-export const mockBasePortfolioSummary: PortfolioDraftSummary = {
+export const mockBasePortfolioSummary: PortfolioDraftSummaryModel = {
   id: uuidv4(),
   status: ProvisioningStatus.NOT_STARTED,
   updated_at: now,
@@ -108,19 +108,19 @@ export const mockBasePortfolioSummary: PortfolioDraftSummary = {
  * after a successful DynamoDB update
  * @returns a Portfolio Draft Summary with good data
  */
-export const mockPortfolioDraftSummary: PortfolioDraft = {
+export const mockPortfolioDraftSummary: PortfolioDraftModel = {
   ...mockBasePortfolioSummary,
   application_step: mockApplicationStep,
   num_applications: mockApplicationStep.applications.length,
   num_environments: mockApplicationStep.applications.flatMap((app) => app.environments).length,
-} as PortfolioDraft;
+} as PortfolioDraftModel;
 
 /**
  * An array of good application step items with acceptable admin roles
  * to match business rules
  * @returns an array of good application steps
  */
-export const mockApplicationsStepWithGoodAdminRoles: ApplicationStep[] = [
+export const mockApplicationsStepWithGoodAdminRoles: ApplicationStepModel[] = [
   { ...mockApplicationStep },
   { ...mockApplicationStep, operators: [] },
   {
@@ -253,7 +253,7 @@ export const mockApplicationStepsMissingFields = [
  * An array of ApplicationStep objects with bad data
  * that should cause input validation errors
  */
-export const mockApplicationStepsBadData: Array<ApplicationStep> = [
+export const mockApplicationStepsBadData: Array<ApplicationStepModel> = [
   {
     ...mockApplicationStep,
     applications: [
@@ -474,19 +474,19 @@ export const mockOperatorMissingAccessFields = [
  * A bad Portfolio Draft Summary item with the application step completed
  * @returns a Portfolio Draft Summary with incorrect # of apps and envs
  */
-export const mockBadPortfolioDraftSummary: PortfolioDraft = {
+export const mockBadPortfolioDraftSummary: PortfolioDraftModel = {
   ...mockBasePortfolioSummary,
   application_step: mockApplicationStep,
   num_applications: 77,
   num_environments: 99,
-} as PortfolioDraft;
+} as PortfolioDraftModel;
 
 /**
  * An array of bad application step items with admin roles
  * that do not follow the business rules
  * @returns an array of bad application steps
  */
-export const mockApplicationsStepWithBadAdminRoles: ApplicationStep[] = [
+export const mockApplicationsStepWithBadAdminRoles: ApplicationStepModel[] = [
   {
     ...mockApplicationStep,
     operators: [],

--- a/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.test.ts
@@ -12,14 +12,14 @@ import { mockClient } from "aws-sdk-client-mock";
 import { handler } from "./getApplicationStep";
 import { v4 as uuidv4 } from "uuid";
 import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
-import { ApplicationStep } from "../../models/ApplicationStep";
+import { ApplicationStepModel } from "../../models/ApplicationStep";
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 beforeEach(() => {
   ddbMock.reset();
 });
 
-const validRequest: ApiGatewayEventParsed<ApplicationStep> = {
+const validRequest: ApiGatewayEventParsed<ApplicationStepModel> = {
   body: {},
   pathParameters: { portfolioDraftId: uuidv4() },
 } as any;
@@ -33,14 +33,14 @@ it("should return generic Error if exception caught", async () => {
   expect(result?.statusCode).toEqual(ErrorStatusCode.INTERNAL_SERVER_ERROR);
 });
 it("should require path param", async () => {
-  const emptyRequest: ApiGatewayEventParsed<ApplicationStep> = {} as any;
+  const emptyRequest: ApiGatewayEventParsed<ApplicationStepModel> = {} as any;
   const result = await handler(emptyRequest, {} as Context, () => null);
   expect(result).toBeInstanceOf(OtherErrorResponse);
   expect(result).toEqual(NO_SUCH_PORTFOLIO_DRAFT_404);
   expect(result?.statusCode).toEqual(ErrorStatusCode.NOT_FOUND);
 });
 it("should return error when path param not UUIDv4 (to avoid performing query)", async () => {
-  const invalidRequest: ApiGatewayEventParsed<ApplicationStep> = {
+  const invalidRequest: ApiGatewayEventParsed<ApplicationStepModel> = {
     pathParameters: { portfolioDraftId: "invalid" },
   } as any;
   const result = await handler(invalidRequest, {} as Context, () => null);

--- a/packages/api/portfolioDrafts/application/getApplicationStep.ts
+++ b/packages/api/portfolioDrafts/application/getApplicationStep.ts
@@ -1,6 +1,6 @@
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyResult, Context } from "aws-lambda";
-import { ApplicationStep } from "../../models/ApplicationStep";
+import { ApplicationStepModel } from "../../models/ApplicationStep";
 import { APPLICATION_STEP } from "../../models/PortfolioDraft";
 import { dynamodbDocumentClient as client } from "../../utils/aws-sdk/dynamodb";
 import { DATABASE_ERROR, NO_SUCH_APPLICATION_STEP, NO_SUCH_PORTFOLIO_DRAFT_400 } from "../../utils/errors";
@@ -19,10 +19,10 @@ import { errorHandlingMiddleware } from "../../utils/errorHandlingMiddleware";
  * @param event - The GET request from API Gateway
  */
 export async function baseHandler(
-  event: ApiGatewayEventParsed<ApplicationStep>,
+  event: ApiGatewayEventParsed<ApplicationStepModel>,
   context?: Context
 ): Promise<APIGatewayProxyResult> {
-  validateRequestShape<ApplicationStep>(event);
+  validateRequestShape<ApplicationStepModel>(event);
   const portfolioDraftId = event.pathParameters?.portfolioDraftId as string;
 
   try {
@@ -41,8 +41,8 @@ export async function baseHandler(
     if (!result.Item?.application_step) {
       return NO_SUCH_APPLICATION_STEP;
     }
-    return new ApiSuccessResponse<ApplicationStep>(
-      result.Item.application_step as ApplicationStep,
+    return new ApiSuccessResponse<ApplicationStepModel>(
+      result.Item.application_step as ApplicationStepModel,
       SuccessStatusCode.OK
     );
   } catch (error) {

--- a/packages/api/portfolioDrafts/commonPortfolioDraftMockData.ts
+++ b/packages/api/portfolioDrafts/commonPortfolioDraftMockData.ts
@@ -2,14 +2,14 @@ import { APIGatewayProxyEvent } from "aws-lambda";
 import { mockApplicationStep } from "./application/commonApplicationMockData";
 import { mockFundingStep } from "./funding/commonFundingMockData";
 import { mockPortfolioStep } from "./portfolio/commonPortfolioMockData";
-import { PortfolioDraft } from "../models/PortfolioDraft";
-import { PortfolioDraftSummary } from "../models/PortfolioDraftSummary";
+import { PortfolioDraftModel } from "../models/PortfolioDraft";
+import { PortfolioDraftSummaryModel } from "../models/PortfolioDraftSummary";
 import { ProvisioningStatus } from "../models/ProvisioningStatus";
 import { v4 as uuidv4 } from "uuid";
 
 const now = new Date().toISOString();
 
-export const mockPortfolioDraftSummary: PortfolioDraftSummary = {
+export const mockPortfolioDraftSummary: PortfolioDraftSummaryModel = {
   id: uuidv4(),
   status: ProvisioningStatus.NOT_STARTED,
   updated_at: now,
@@ -22,7 +22,7 @@ export const mockPortfolioDraftSummary: PortfolioDraftSummary = {
   num_environments: 0,
 };
 
-export const mockPortfolioDraft: PortfolioDraft = {
+export const mockPortfolioDraft: PortfolioDraftModel = {
   ...mockPortfolioDraftSummary,
   portfolio_step: mockPortfolioStep,
   funding_step: mockFundingStep,

--- a/packages/api/portfolioDrafts/createPortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/createPortfolioDraft.ts
@@ -1,7 +1,7 @@
 import { PutCommand } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { v4 as uuidv4 } from "uuid";
-import { PortfolioDraftSummary } from "../models/PortfolioDraftSummary";
+import { PortfolioDraftSummaryModel } from "../models/PortfolioDraftSummary";
 import { ProvisioningStatus } from "../models/ProvisioningStatus";
 import { dynamodbDocumentClient as client } from "../utils/aws-sdk/dynamodb";
 import { DATABASE_ERROR, REQUEST_BODY_NOT_EMPTY } from "../utils/errors";
@@ -23,7 +23,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
   console.log(await databaseConnection.query("SELECT * FROM pg_catalog.pg_tables;"));
 
   const now = new Date().toISOString();
-  const item: PortfolioDraftSummary = {
+  const item: PortfolioDraftSummaryModel = {
     id: uuidv4(),
     created_at: now,
     updated_at: now,
@@ -43,7 +43,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
         Item: item,
       })
     );
-    return new ApiSuccessResponse<PortfolioDraftSummary>(item, SuccessStatusCode.CREATED);
+    return new ApiSuccessResponse<PortfolioDraftSummaryModel>(item, SuccessStatusCode.CREATED);
   } catch (error) {
     console.error("Database error: " + error);
     return DATABASE_ERROR;

--- a/packages/api/portfolioDrafts/funding/commonFundingMockData.ts
+++ b/packages/api/portfolioDrafts/funding/commonFundingMockData.ts
@@ -1,6 +1,6 @@
-import { Clin } from "../../models/Clin";
-import { FileMetadataSummary } from "../../models/FileMetadataSummary";
-import { FundingStep } from "../../models/FundingStep";
+import { ClinModel } from "../../models/Clin";
+import { FileMetadataSummaryModel } from "../../models/FileMetadataSummary";
+import { FundingStepModel } from "../../models/FundingStep";
 
 const isoFormatDay = (base: number, offset = 0) => new Date(base + offset).toISOString().slice(0, 10);
 export const millisInDay = 24 * 60 * 60 * 1000;
@@ -9,12 +9,12 @@ export const yesterday = isoFormatDay(now, -millisInDay);
 export const today = isoFormatDay(now);
 export const tomorrow = isoFormatDay(now, millisInDay);
 
-export const mockFileMetadataSummary: FileMetadataSummary = {
+export const mockFileMetadataSummary: FileMetadataSummaryModel = {
   id: "b91db32f-40fa-4225-9885-b032f0d229fe",
   name: "TO_12345678910.pdf",
 };
 
-export const mockClin: Clin = {
+export const mockClin: ClinModel = {
   clin_number: "0001",
   idiq_clin: "1234",
   obligated_funds: 10000,
@@ -22,7 +22,7 @@ export const mockClin: Clin = {
   pop_end_date: tomorrow,
   total_clin_value: 200000,
 };
-export const mockClinObligatedEqualsTotal: Clin = {
+export const mockClinObligatedEqualsTotal: ClinModel = {
   ...mockClin,
   obligated_funds: 1,
   total_clin_value: 1,
@@ -30,7 +30,7 @@ export const mockClinObligatedEqualsTotal: Clin = {
 // clins containing good data that should not cause any validation errors
 export const mockClinArrayGoodData = [mockClin, mockClinObligatedEqualsTotal];
 
-export const mockFundingStep: FundingStep = {
+export const mockFundingStep: FundingStepModel = {
   task_orders: [
     {
       task_order_number: "12345678910123",
@@ -43,48 +43,48 @@ export const mockFundingStep: FundingStep = {
 /* ABOVE THIS LINE ARE VALID OBJECTS WITH GOOD DATA */
 /* BELOW THIS LINE ARE INVALID OBJECTS WITH MISSING FIELDS AND BAD DATA */
 
-export const mockClinInvalidClinNumberTooShort: Clin = {
+export const mockClinInvalidClinNumberTooShort: ClinModel = {
   ...mockClin,
   clin_number: "1",
 };
-export const mockClinInvalidClinNumberTooLong: Clin = {
+export const mockClinInvalidClinNumberTooLong: ClinModel = {
   ...mockClin,
   clin_number: "55555",
 };
-export const mockClinInvalidClinNumberAllZeros: Clin = {
+export const mockClinInvalidClinNumberAllZeros: ClinModel = {
   ...mockClin,
   clin_number: "0000",
 };
-export const mockClinInvalidDates: Clin = {
+export const mockClinInvalidDates: ClinModel = {
   ...mockClin,
   pop_start_date: "not an ISO date",
   pop_end_date: "2021-13-01",
 };
-export const mockClinStartAfterEnd: Clin = {
+export const mockClinStartAfterEnd: ClinModel = {
   ...mockClin,
   pop_start_date: tomorrow,
   pop_end_date: today,
 };
-export const mockClinStartEqualsEnd: Clin = {
+export const mockClinStartEqualsEnd: ClinModel = {
   ...mockClin,
   pop_start_date: today,
   pop_end_date: today,
 };
-export const mockClinAlreadyEnded: Clin = {
+export const mockClinAlreadyEnded: ClinModel = {
   ...mockClin,
   pop_end_date: yesterday,
 };
-export const mockClinLessThanZeroFunds: Clin = {
+export const mockClinLessThanZeroFunds: ClinModel = {
   ...mockClin,
   obligated_funds: -1,
   total_clin_value: -1,
 };
-export const mockClinZeroFunds: Clin = {
+export const mockClinZeroFunds: ClinModel = {
   ...mockClin,
   obligated_funds: 0,
   total_clin_value: 0,
 };
-export const mockClinObligatedGreaterThanTotal: Clin = {
+export const mockClinObligatedGreaterThanTotal: ClinModel = {
   ...mockClin,
   obligated_funds: 2,
   total_clin_value: 1,
@@ -109,7 +109,7 @@ export const mockClinArrayBadData = [
   mockClinZeroFunds,
   mockClinObligatedGreaterThanTotal,
 ];
-export const mockFundingStepBadData: FundingStep = {
+export const mockFundingStepBadData: FundingStepModel = {
   task_orders: [
     {
       task_order_number: "12345678910", // invalid task number, too short
@@ -125,7 +125,7 @@ export const mockClinArrayBadBusinessRulesData = [
   mockClinObligatedGreaterThanTotal,
 ];
 
-export const mockFundingStepBadBusinessRulesData: FundingStep = {
+export const mockFundingStepBadBusinessRulesData: FundingStepModel = {
   task_orders: [
     {
       task_order_number: "12345678910123",

--- a/packages/api/portfolioDrafts/funding/createFundingStep.test.ts
+++ b/packages/api/portfolioDrafts/funding/createFundingStep.test.ts
@@ -6,16 +6,16 @@ import {
   SuccessStatusCode,
   ValidationErrorResponse,
 } from "../../utils/response";
-import { Clin } from "../../models/Clin";
+import { ClinModel } from "../../models/Clin";
 import { handler } from "./createFundingStep";
 import { DynamoDBDocumentClient, UpdateCommand, UpdateCommandOutput } from "@aws-sdk/lib-dynamodb";
-import { FundingStep, ValidationMessage } from "../../models/FundingStep";
+import { FundingStepModel, ValidationMessage } from "../../models/FundingStep";
 import { mockClient } from "aws-sdk-client-mock";
 import { ProvisioningStatus } from "../../models/ProvisioningStatus";
 import { v4 as uuidv4 } from "uuid";
 import { DATABASE_ERROR, NO_SUCH_PORTFOLIO_DRAFT_404 } from "../../utils/errors";
 import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
-import { FileMetadataSummary } from "../../models/FileMetadataSummary";
+import { FileMetadataSummaryModel } from "../../models/FileMetadataSummary";
 import {
   createBusinessRulesValidationErrorResponse,
   validateClin,
@@ -51,17 +51,17 @@ beforeEach(() => {
   ddbMock.reset();
 });
 
-const validRequest: ApiGatewayEventParsed<FundingStep> = {
+const validRequest: ApiGatewayEventParsed<FundingStepModel> = {
   body: mockFundingStep,
   pathParameters: { portfolioDraftId: uuidv4() },
 } as any;
 
-const validRequestBadData: ApiGatewayEventParsed<FundingStep> = {
+const validRequestBadData: ApiGatewayEventParsed<FundingStepModel> = {
   body: mockFundingStepBadData,
   pathParameters: { portfolioDraftId: uuidv4() },
 } as any;
 
-const validRequestBadBusinessRulesData: ApiGatewayEventParsed<FundingStep> = {
+const validRequestBadBusinessRulesData: ApiGatewayEventParsed<FundingStepModel> = {
   body: mockFundingStepBadBusinessRulesData,
   pathParameters: { portfolioDraftId: uuidv4() },
 } as any;
@@ -93,7 +93,7 @@ describe("Handle service level error", () => {
 
 describe("Path parameter tests", () => {
   it("should require path param", async () => {
-    const emptyRequest: ApiGatewayEventParsed<FundingStep> = {
+    const emptyRequest: ApiGatewayEventParsed<FundingStepModel> = {
       body: mockFundingStep,
     } as any;
     const result = await handler(emptyRequest, {} as Context, () => null);
@@ -103,7 +103,7 @@ describe("Path parameter tests", () => {
   });
 
   it("should return error when path param not UUIDv4 (to avoid attempting update)", async () => {
-    const invalidRequest: ApiGatewayEventParsed<FundingStep> = {
+    const invalidRequest: ApiGatewayEventParsed<FundingStepModel> = {
       body: mockFundingStep,
       pathParameters: { portfolioDraftId: "invalid" },
     } as any;
@@ -117,7 +117,7 @@ describe("Path parameter tests", () => {
 
 describe("Request body tests", () => {
   it("should return error when request body is empty", async () => {
-    const invalidRequest: ApiGatewayEventParsed<FundingStep> = {
+    const invalidRequest: ApiGatewayEventParsed<FundingStepModel> = {
       pathParameters: { portfolioDraftId: uuidv4() },
       body: undefined, // invalid JSON
     } as any;
@@ -131,7 +131,7 @@ describe("Request body tests", () => {
   });
 
   it("should return error when request body is not a funding step", async () => {
-    const notFundingStepRequest: ApiGatewayEventParsed<FundingStep> = {
+    const notFundingStepRequest: ApiGatewayEventParsed<FundingStepModel> = {
       body: JSON.stringify({ foo: "bar" }), // valid json
       pathParameters: { portfolioDraftId: uuidv4() },
     } as any;

--- a/packages/api/portfolioDrafts/funding/createFundingStep.ts
+++ b/packages/api/portfolioDrafts/funding/createFundingStep.ts
@@ -2,7 +2,7 @@ import { APIGatewayProxyResult, Context } from "aws-lambda";
 import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
 import { dynamodbDocumentClient as client } from "../../utils/aws-sdk/dynamodb";
 import { FUNDING_STEP } from "../../models/PortfolioDraft";
-import { FundingStep } from "../../models/FundingStep";
+import { FundingStepModel } from "../../models/FundingStep";
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { DATABASE_ERROR, NO_SUCH_PORTFOLIO_DRAFT_404 } from "../../utils/errors";
 import schema = require("../../models/schema.json");
@@ -24,10 +24,10 @@ import { wrapSchema } from "../../utils/schemaWrapper";
  * @param event - The POST request from API Gateway
  */
 export async function baseHandler(
-  event: ApiGatewayEventParsed<FundingStep>,
+  event: ApiGatewayEventParsed<FundingStepModel>,
   context?: Context
 ): Promise<APIGatewayProxyResult> {
-  validateRequestShape<FundingStep>(event);
+  validateRequestShape<FundingStepModel>(event);
   const portfolioDraftId = event.pathParameters?.portfolioDraftId as string;
   const fundingStep = event.body;
   validateBusinessRulesForFundingStep(fundingStep);
@@ -60,7 +60,7 @@ export async function baseHandler(
     console.error("Database error: " + error);
     return DATABASE_ERROR;
   }
-  return new ApiSuccessResponse<FundingStep>(fundingStep, SuccessStatusCode.CREATED);
+  return new ApiSuccessResponse<FundingStepModel>(fundingStep, SuccessStatusCode.CREATED);
 }
 export const handler = middy(baseHandler)
   .use(xssSanitizer())

--- a/packages/api/portfolioDrafts/funding/getFundingStep.test.ts
+++ b/packages/api/portfolioDrafts/funding/getFundingStep.test.ts
@@ -2,7 +2,7 @@ import { Context } from "aws-lambda";
 import { ApiSuccessResponse, ErrorStatusCode, OtherErrorResponse, SuccessStatusCode } from "../../utils/response";
 import { handler } from "./getFundingStep";
 import { DynamoDBDocumentClient, GetCommand, GetCommandOutput } from "@aws-sdk/lib-dynamodb";
-import { FundingStep, ValidationMessage } from "../../models/FundingStep";
+import { FundingStepModel, ValidationMessage } from "../../models/FundingStep";
 import { mockClient } from "aws-sdk-client-mock";
 import { v4 as uuidv4 } from "uuid";
 import { DATABASE_ERROR, NO_SUCH_FUNDING_STEP, NO_SUCH_PORTFOLIO_DRAFT_404 } from "../../utils/errors";
@@ -13,8 +13,8 @@ beforeEach(() => {
   ddbMock.reset();
 });
 
-const emptyRequest: ApiGatewayEventParsed<FundingStep> = {} as any;
-const mockFundingStep: FundingStep = {
+const emptyRequest: ApiGatewayEventParsed<FundingStepModel> = {} as any;
+const mockFundingStep: FundingStepModel = {
   task_orders: [
     {
       task_order_file: {
@@ -35,7 +35,7 @@ const mockFundingStep: FundingStep = {
     },
   ],
 };
-const validRequest: ApiGatewayEventParsed<FundingStep> = {
+const validRequest: ApiGatewayEventParsed<FundingStepModel> = {
   pathParameters: { portfolioDraftId: uuidv4() },
   body: "",
 } as any;

--- a/packages/api/portfolioDrafts/funding/getFundingStep.ts
+++ b/packages/api/portfolioDrafts/funding/getFundingStep.ts
@@ -2,7 +2,7 @@ import { APIGatewayProxyResult, Context } from "aws-lambda";
 import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
 import { dynamodbDocumentClient as client } from "../../utils/aws-sdk/dynamodb";
 import { FUNDING_STEP } from "../../models/PortfolioDraft";
-import { FundingStep } from "../../models/FundingStep";
+import { FundingStepModel } from "../../models/FundingStep";
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
 import { DATABASE_ERROR, NO_SUCH_PORTFOLIO_DRAFT_404, NO_SUCH_FUNDING_STEP } from "../../utils/errors";
 import { validateRequestShape } from "../../utils/requestValidation";
@@ -18,10 +18,10 @@ import { errorHandlingMiddleware } from "../../utils/errorHandlingMiddleware";
  * @param event - The GET request from API Gateway
  */
 export async function baseHandler(
-  event: ApiGatewayEventParsed<FundingStep>,
+  event: ApiGatewayEventParsed<FundingStepModel>,
   context?: Context
 ): Promise<APIGatewayProxyResult> {
-  validateRequestShape<FundingStep>(event);
+  validateRequestShape<FundingStepModel>(event);
   const portfolioDraftId = event.pathParameters?.portfolioDraftId as string;
   try {
     const result = await client.send(
@@ -39,7 +39,7 @@ export async function baseHandler(
     if (!result.Item?.funding_step) {
       return NO_SUCH_FUNDING_STEP;
     }
-    return new ApiSuccessResponse<FundingStep>(result.Item.funding_step as FundingStep, SuccessStatusCode.OK);
+    return new ApiSuccessResponse<FundingStepModel>(result.Item.funding_step as FundingStepModel, SuccessStatusCode.OK);
   } catch (error) {
     console.error("Database error: " + error);
     return DATABASE_ERROR;

--- a/packages/api/portfolioDrafts/getPortfolioDraft.test.ts
+++ b/packages/api/portfolioDrafts/getPortfolioDraft.test.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyEvent } from "aws-lambda";
-import { Application } from "../models/Application";
+import { ApplicationModel } from "../models/Application";
 import { DATABASE_ERROR } from "../utils/errors";
 import { DynamoDBDocumentClient, GetCommand, GetCommandOutput } from "@aws-sdk/lib-dynamodb";
 import { handler, NO_PORTFOLIO_PATH_PARAM, NO_SUCH_PORTFOLIO } from "./getPortfolioDraft";
@@ -69,7 +69,7 @@ describe("Successful operation tests", () => {
     const result = await handler(validRequest);
     const responseBody = JSON.parse(result.body);
     expect(mockPortfolioDraft.num_environments).toBe(
-      responseBody.application_step.applications.flatMap((app: Application) => app.environments).length
+      responseBody.application_step.applications.flatMap((app: ApplicationModel) => app.environments).length
     );
   });
 });

--- a/packages/api/portfolioDrafts/getPortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/getPortfolioDraft.ts
@@ -1,6 +1,6 @@
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { PortfolioDraft } from "../models/PortfolioDraft";
+import { PortfolioDraftModel } from "../models/PortfolioDraft";
 import { dynamodbDocumentClient as client } from "../utils/aws-sdk/dynamodb";
 import { DATABASE_ERROR } from "../utils/errors";
 import { ApiSuccessResponse, ErrorStatusCode, OtherErrorResponse, SuccessStatusCode } from "../utils/response";
@@ -41,7 +41,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     if (!result.Item) {
       return NO_SUCH_PORTFOLIO;
     }
-    return new ApiSuccessResponse<PortfolioDraft>(result.Item as PortfolioDraft, SuccessStatusCode.OK);
+    return new ApiSuccessResponse<PortfolioDraftModel>(result.Item as PortfolioDraftModel, SuccessStatusCode.OK);
   } catch (err) {
     console.log("Database error: " + err);
     return DATABASE_ERROR;

--- a/packages/api/portfolioDrafts/getPortfolioDrafts.ts
+++ b/packages/api/portfolioDrafts/getPortfolioDrafts.ts
@@ -1,6 +1,6 @@
 import { ScanCommand, ScanCommandInput } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { portfolioDraftSummaryProperties, PortfolioDraftSummary } from "../models/PortfolioDraftSummary";
+import { portfolioDraftSummaryProperties, PortfolioDraftSummaryModel } from "../models/PortfolioDraftSummary";
 import { exhaustivePick } from "../models/TypeFields";
 import { dynamodbDocumentClient as client } from "../utils/aws-sdk/dynamodb";
 import { ApiSuccessResponse, ErrorStatusCode, OtherErrorResponse, SuccessStatusCode } from "../utils/response";
@@ -55,9 +55,9 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
   try {
     const data = await client.send(command);
-    const items = (data.Items ?? []) as PortfolioDraftSummary[];
+    const items = (data.Items ?? []) as PortfolioDraftSummaryModel[];
     const summaries = items.map((draft) => exhaustivePick(draft, portfolioDraftSummaryProperties));
-    return new ApiSuccessResponse<PortfolioDraftSummary[]>(summaries, SuccessStatusCode.OK);
+    return new ApiSuccessResponse<PortfolioDraftSummaryModel[]>(summaries, SuccessStatusCode.OK);
   } catch (error) {
     console.log("Database error (" + error.name + "): " + error);
     return new OtherErrorResponse("Database error", ErrorStatusCode.INTERNAL_SERVER_ERROR);

--- a/packages/api/portfolioDrafts/portfolio/commonPortfolioMockData.ts
+++ b/packages/api/portfolioDrafts/portfolio/commonPortfolioMockData.ts
@@ -1,8 +1,8 @@
 import { CloudServiceProvider } from "../../models/CloudServiceProvider";
-import { PortfolioStep } from "../../models/PortfolioStep";
+import { PortfolioStepModel } from "../../models/PortfolioStep";
 
 // The example PortfolioStepEx from the API Specification
-export const mockPortfolioStep: PortfolioStep = {
+export const mockPortfolioStep: PortfolioStepModel = {
   name: "Mock Portfolio",
   csp: CloudServiceProvider.CSP_A,
   description: "Mock portfolio description",
@@ -10,7 +10,7 @@ export const mockPortfolioStep: PortfolioStep = {
   portfolio_managers: ["joe.manager@example.com", "jane.manager@example.com"],
 };
 
-export const mockValidPortfolioSteps: PortfolioStep[] = [
+export const mockValidPortfolioSteps: PortfolioStepModel[] = [
   mockPortfolioStep,
   // This checks that we don't regress and error on a body that we worked to debug.
   // The issue at the time seemed to be due to a missing `description` field in the

--- a/packages/api/portfolioDrafts/portfolio/createPortfolioStep.test.ts
+++ b/packages/api/portfolioDrafts/portfolio/createPortfolioStep.test.ts
@@ -4,7 +4,7 @@ import { DynamoDBDocumentClient, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { handler } from "./createPortfolioStep";
 import { mockClient } from "aws-sdk-client-mock";
 import { NO_SUCH_PORTFOLIO_DRAFT_404 } from "../../utils/errors";
-import { PortfolioStep } from "../../models/PortfolioStep";
+import { PortfolioStepModel } from "../../models/PortfolioStep";
 import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
 import { mockPortfolioStep, mockValidPortfolioSteps } from "./commonPortfolioMockData";
 import { validRequest } from "../commonPortfolioDraftMockData";
@@ -18,7 +18,7 @@ describe("Successful operations test", () => {
   it.each(mockValidPortfolioSteps)(
     "should return portfolio step and http status code 201",
     async (mockPortfolioStep) => {
-      const request: ApiGatewayEventParsed<PortfolioStep> = {
+      const request: ApiGatewayEventParsed<PortfolioStepModel> = {
         ...validRequest,
         body: mockPortfolioStep,
       } as any;
@@ -34,14 +34,14 @@ describe("Validation of handler", () => {
     const request = {
       body: mockPortfolioStep,
       // no pathParameter portfolioDraftId
-    } as ApiGatewayEventParsed<PortfolioStep>;
+    } as ApiGatewayEventParsed<PortfolioStepModel>;
     const response = await handler(request, {} as Context, null as unknown as Callback)!;
     expect(response).toEqual(NO_SUCH_PORTFOLIO_DRAFT_404);
   });
 });
 
 describe.each(mockValidPortfolioSteps)("Handler response with mock dynamodb", (mockPortfolioStep) => {
-  const request: ApiGatewayEventParsed<PortfolioStep> = {
+  const request: ApiGatewayEventParsed<PortfolioStepModel> = {
     ...validRequest,
     body: mockPortfolioStep,
   } as any;
@@ -57,12 +57,12 @@ describe("Cross-Site Scripting (XSS) tests", () => {
   // example attacks from ASD STIG: V-222602 text
   const attacks = ["<script>alert('attack!')</script>", "<img src=x onerror='alert(document.cookie);'"];
   it.each(attacks)("should sanitize input for XSS attacks", async (attackCode) => {
-    const mockPortfolioStep: PortfolioStep = {
+    const mockPortfolioStep: PortfolioStepModel = {
       ...mockValidPortfolioSteps[0],
       description: attackCode,
       name: attackCode,
     };
-    const request: ApiGatewayEventParsed<PortfolioStep> = {
+    const request: ApiGatewayEventParsed<PortfolioStepModel> = {
       ...validRequest,
       body: mockPortfolioStep,
     } as any;

--- a/packages/api/portfolioDrafts/portfolio/createPortfolioStep.ts
+++ b/packages/api/portfolioDrafts/portfolio/createPortfolioStep.ts
@@ -1,7 +1,7 @@
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyResult, Context } from "aws-lambda";
 import { PORTFOLIO_STEP } from "../../models/PortfolioDraft";
-import { PortfolioStep } from "../../models/PortfolioStep";
+import { PortfolioStepModel } from "../../models/PortfolioStep";
 import { dynamodbDocumentClient as client } from "../../utils/aws-sdk/dynamodb";
 import { NO_SUCH_PORTFOLIO_DRAFT_404 } from "../../utils/errors";
 import { ApiSuccessResponse, SuccessStatusCode, DynamoDBException, DatabaseResult } from "../../utils/response";
@@ -24,10 +24,10 @@ import { errorHandlingMiddleware } from "../../utils/errorHandlingMiddleware";
  */
 
 export async function baseHandler(
-  event: ApiGatewayEventParsed<PortfolioStep>,
+  event: ApiGatewayEventParsed<PortfolioStepModel>,
   context?: Context
 ): Promise<APIGatewayProxyResult> {
-  validateRequestShape<PortfolioStep>(event);
+  validateRequestShape<PortfolioStepModel>(event);
   const portfolioDraftId = event.pathParameters?.portfolioDraftId as string;
   const portfolioStep = event.body;
   // Perform database call
@@ -35,7 +35,7 @@ export async function baseHandler(
   if (databaseResult instanceof DynamoDBException) {
     return databaseResult.errorResponse;
   }
-  return new ApiSuccessResponse<PortfolioStep>(portfolioStep, SuccessStatusCode.CREATED);
+  return new ApiSuccessResponse<PortfolioStepModel>(portfolioStep, SuccessStatusCode.CREATED);
 }
 
 export const handler = middy(baseHandler)
@@ -52,7 +52,7 @@ export const handler = middy(baseHandler)
 
 export async function createPortfolioStepCommand(
   portfolioDraftId: string,
-  portfolioStep: PortfolioStep
+  portfolioStep: PortfolioStepModel
 ): Promise<DatabaseResult> {
   const now = new Date().toISOString();
   try {

--- a/packages/api/portfolioDrafts/portfolio/getPortfolioStep.ts
+++ b/packages/api/portfolioDrafts/portfolio/getPortfolioStep.ts
@@ -4,7 +4,7 @@ import { dynamodbDocumentClient as client } from "../../utils/aws-sdk/dynamodb";
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
 import { isPathParameterPresent, isValidUuidV4 } from "../../utils/validation";
 import { PORTFOLIO_STEP } from "../../models/PortfolioDraft";
-import { PortfolioStep } from "../../models/PortfolioStep";
+import { PortfolioStepModel } from "../../models/PortfolioStep";
 import {
   DATABASE_ERROR,
   NO_SUCH_PORTFOLIO_DRAFT_404,
@@ -42,7 +42,10 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     if (!result.Item?.portfolio_step) {
       return NO_SUCH_PORTFOLIO_STEP;
     }
-    return new ApiSuccessResponse<PortfolioStep>(result.Item.portfolio_step as PortfolioStep, SuccessStatusCode.OK);
+    return new ApiSuccessResponse<PortfolioStepModel>(
+      result.Item.portfolio_step as PortfolioStepModel,
+      SuccessStatusCode.OK
+    );
   } catch (error) {
     console.error("Database error: " + error);
     return DATABASE_ERROR;

--- a/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/submit/submitPortfolioDraft.ts
@@ -9,7 +9,7 @@ import {
   PORTFOLIO_ALREADY_SUBMITTED,
   PATH_PARAMETER_REQUIRED_BUT_MISSING,
 } from "../../utils/errors";
-import { PortfolioDraft, PORTFOLIO_STEP } from "../../models/PortfolioDraft";
+import { PortfolioDraftModel, PORTFOLIO_STEP } from "../../models/PortfolioDraft";
 import { v4 as uuidv4 } from "uuid";
 import { ProvisioningStatus, ProvisioningRequestType } from "../../models/ProvisioningStatus";
 import { dynamodbDocumentClient as client } from "../../utils/aws-sdk/dynamodb";
@@ -38,9 +38,9 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
   try {
     const result = await submitPortfolioDraftCommand(TABLE_NAME, portfolioDraftId);
-    const portfolioDraft = result.Attributes as PortfolioDraft;
+    const portfolioDraft = result.Attributes as PortfolioDraftModel;
     // structure message body for provisioning state machine
-    const portfolioDraftToProvision = new ProvisioningJob<PortfolioDraft>(
+    const portfolioDraftToProvision = new ProvisioningJob<PortfolioDraftModel>(
       portfolioDraft,
       ProvisioningRequestType.FULL_PORTFOLIO,
       portfolioDraft[PORTFOLIO_STEP].csp

--- a/packages/api/provision/provisioningRequest.ts
+++ b/packages/api/provision/provisioningRequest.ts
@@ -1,12 +1,12 @@
 import { Context } from "aws-lambda";
-import { ProvisioningTaskInput } from "../models/ProvisioningStatus";
+import { ProvisioningTaskInputModel } from "../models/ProvisioningStatus";
 
 /**
  * Mock lambda for provisioning requests submitted by user
  *
  * @param stateInput - input to the state task that is processed
  */
-export async function handler(stateInput: ProvisioningTaskInput, context?: Context): Promise<unknown> {
+export async function handler(stateInput: ProvisioningTaskInputModel, context?: Context): Promise<unknown> {
   console.log("STATE INPUT: " + JSON.stringify(stateInput));
 
   // A mock function that is used as a placeholder for each state and returns the input.

--- a/packages/api/provision/validateCompletePortfolioDraft.ts
+++ b/packages/api/provision/validateCompletePortfolioDraft.ts
@@ -1,5 +1,5 @@
 import { Context } from "aws-lambda";
-import { PortfolioDraft } from "../models/PortfolioDraft";
+import { PortfolioDraftModel } from "../models/PortfolioDraft";
 import middy from "@middy/core";
 import validator from "@middy/validator";
 import schema = require("../models/schema.json");
@@ -8,12 +8,12 @@ export enum ValidationResult {
   SUCCESS = "SUCCESS",
   FAILED = "FAILED",
 }
-export interface ValidatedPortfolioDraft extends PortfolioDraft {
+export interface ValidatedPortfolioDraft extends PortfolioDraftModel {
   validationResult: ValidationResult;
   error?: unknown;
 }
 export interface StateInput {
-  body: PortfolioDraft;
+  body: PortfolioDraftModel;
 }
 
 /**

--- a/packages/api/taskOrderFiles/uploadTaskOrder.ts
+++ b/packages/api/taskOrderFiles/uploadTaskOrder.ts
@@ -2,7 +2,7 @@ import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import * as parser from "lambda-multipart-parser";
 import { v4 as uuidv4 } from "uuid";
-import { FileMetadata, FileScanStatus } from "../models/FileMetadata";
+import { FileMetadataModel, FileScanStatus } from "../models/FileMetadata";
 import { ApiSuccessResponse, ErrorStatusCode, OtherErrorResponse, SuccessStatusCode } from "../utils/response";
 import { s3Client } from "../utils/aws-sdk/s3";
 
@@ -43,7 +43,7 @@ async function uploadFile(file: parser.MultipartFile): Promise<APIGatewayProxyRe
   });
   await s3Client.send(command);
   const now = new Date().toISOString();
-  const metadata: FileMetadata = {
+  const metadata: FileMetadataModel = {
     id: key,
     created_at: now,
     updated_at: now,
@@ -51,5 +51,5 @@ async function uploadFile(file: parser.MultipartFile): Promise<APIGatewayProxyRe
     size: file.content.length,
     name: file.filename,
   };
-  return new ApiSuccessResponse<FileMetadata>(metadata, SuccessStatusCode.CREATED);
+  return new ApiSuccessResponse<FileMetadataModel>(metadata, SuccessStatusCode.CREATED);
 }

--- a/packages/api/utils/requestValidation.test.ts
+++ b/packages/api/utils/requestValidation.test.ts
@@ -1,15 +1,15 @@
 import { validateRequestShape } from "../utils/requestValidation";
-import { PortfolioStep } from "../models/PortfolioStep";
+import { PortfolioStepModel } from "../models/PortfolioStep";
 import { ApiGatewayEventParsed } from "./eventHandlingTool";
 import { v4 as uuidv4 } from "uuid";
 import { isPortfolioStep } from "./validation";
 
 describe("Shape validation tests", () => {
-  const undefinedBodyEvent: ApiGatewayEventParsed<PortfolioStep> = {
+  const undefinedBodyEvent: ApiGatewayEventParsed<PortfolioStepModel> = {
     body: undefined,
     pathParameters: { portfolioDraftId: uuidv4() },
   } as any;
-  const shouldBeEmptyBodyEvent: ApiGatewayEventParsed<PortfolioStep> = {
+  const shouldBeEmptyBodyEvent: ApiGatewayEventParsed<PortfolioStepModel> = {
     body: { hi: "this is not empty" },
     pathParameters: { portfolioDraftId: uuidv4() },
   } as any;
@@ -17,14 +17,14 @@ describe("Shape validation tests", () => {
     jest.spyOn(console, "error").mockImplementation(() => jest.fn()); // suppress output
     // jest.spyOn(console, "error").mockImplementation(() => jest.fn()); // suppress output
     expect(() => {
-      validateRequestShape<PortfolioStep>(undefinedBodyEvent);
+      validateRequestShape<PortfolioStepModel>(undefinedBodyEvent);
     }).toThrow(Error("Shape validation failed, invalid request body"));
   });
   it("should throw error if request body is not a portfolio step", async () => {
     jest.spyOn(console, "error").mockImplementation(() => jest.fn()); // suppress output
 
     expect(() => {
-      validateRequestShape<PortfolioStep>(shouldBeEmptyBodyEvent, isPortfolioStep);
+      validateRequestShape<PortfolioStepModel>(shouldBeEmptyBodyEvent, isPortfolioStep);
     }).toThrow(Error("Shape validation failed, invalid request body"));
   });
 });

--- a/packages/api/utils/requestValidation.ts
+++ b/packages/api/utils/requestValidation.ts
@@ -1,10 +1,10 @@
 import { SetupResult, SetupSuccess, ValidationErrorResponse } from "./response";
 import { isValidUuidV4 } from "./validation";
 import { ApiGatewayEventParsed } from "./eventHandlingTool";
-import { FundingStep, ValidationMessage } from "../models/FundingStep";
-import { Clin } from "../models/Clin";
+import { FundingStepModel, ValidationMessage } from "../models/FundingStep";
+import { ClinModel } from "../models/Clin";
 import createError from "http-errors";
-import { ApplicationStep } from "../models/ApplicationStep";
+import { ApplicationStepModel } from "../models/ApplicationStep";
 import { Operators, isAdministrator } from "../models/Operator";
 
 /**
@@ -52,7 +52,7 @@ export interface ClinValidationError {
  * @returns an ValidationErrorResponse (by throwing an error to the middleware) if there are Clin validation errors
  */
 
-export function validateBusinessRulesForFundingStep(fs: FundingStep): ValidationErrorResponse | undefined {
+export function validateBusinessRulesForFundingStep(fs: FundingStepModel): ValidationErrorResponse | undefined {
   const errors: Array<ClinValidationError> = validateFundingStepClins(fs);
   if (errors.length) {
     return createBusinessRulesValidationErrorResponse({ input_validation_errors: errors });
@@ -60,7 +60,7 @@ export function validateBusinessRulesForFundingStep(fs: FundingStep): Validation
   return undefined;
 }
 
-export function validateFundingStepClins(fs: FundingStep): Array<ClinValidationError> {
+export function validateFundingStepClins(fs: FundingStepModel): Array<ClinValidationError> {
   return fs.task_orders
     .flatMap((taskOrder) => taskOrder.clins)
     .map(validateClin)
@@ -72,7 +72,7 @@ export function validateFundingStepClins(fs: FundingStep): Array<ClinValidationE
  * @returns a collection of clin validation errors
  */
 
-export function validateClin(clin: Clin): Array<ClinValidationError> {
+export function validateClin(clin: ClinModel): Array<ClinValidationError> {
   const errors = Array<ClinValidationError>();
   if (new Date(clin.pop_start_date) >= new Date(clin.pop_end_date)) {
     const obj = {
@@ -164,7 +164,7 @@ export function validateBusinessRulesForApplicationStep(as: ApplicationStep): Va
  * @param applicationStep - the incoming applicationStep request body
  * @returns - an object summarizing the admin roles found or missing
  */
-export function findAdministrators(applicationStep: ApplicationStep): AdministratorsFound {
+export function findAdministrators(applicationStep: ApplicationStepModel): AdministratorsFound {
   const { operators, applications } = applicationStep;
   const hasPortfolioAdminRole = adminRoleFound(operators);
 

--- a/packages/api/utils/response.test.ts
+++ b/packages/api/utils/response.test.ts
@@ -1,4 +1,4 @@
-import { Error, ErrorCode } from "../models/Error";
+import { ErrorModel, ErrorCode } from "../models/Error";
 import * as response from "./response";
 
 describe("Validation for No Content responses", () => {
@@ -16,7 +16,7 @@ describe("Validation for No Content responses", () => {
 
 describe("Validate parsing results in the same object", () => {
   it("should result in the same error after parsing", async () => {
-    const sampleError: Error = { code: ErrorCode.OTHER, message: "Test Error" };
+    const sampleError: ErrorModel = { code: ErrorCode.OTHER, message: "Test Error" };
     const errorResponse = new response.OtherErrorResponse(
       sampleError.message,
       response.ErrorStatusCode.INTERNAL_SERVER_ERROR

--- a/packages/api/utils/response.ts
+++ b/packages/api/utils/response.ts
@@ -1,6 +1,6 @@
 import { DeleteCommandOutput, GetCommandOutput, UpdateCommandOutput } from "@aws-sdk/lib-dynamodb";
 import { APIGatewayProxyResult } from "aws-lambda";
-import { Error, ErrorCode, ValidationError } from "../models/Error";
+import { ErrorModel, ErrorCode, ValidationErrorModel } from "../models/Error";
 
 type Headers = { [header: string]: string | number | boolean } | undefined;
 type MultiValueHeaders = { [header: string]: (string | number | boolean)[] } | undefined;
@@ -138,7 +138,12 @@ export abstract class ErrorResponse extends Response {
    * @param headers - HTTP response headers
    * @param multiValueHeaders - HTTP response headers, allowing multiple values for a header
    */
-  constructor(error: Error, statusCode: ErrorStatusCode, headers?: Headers, multiValueHeaders?: MultiValueHeaders) {
+  constructor(
+    error: ErrorModel,
+    statusCode: ErrorStatusCode,
+    headers?: Headers,
+    multiValueHeaders?: MultiValueHeaders
+  ) {
     super(JSON.stringify(error), statusCode, headers, multiValueHeaders, false);
   }
 }
@@ -156,7 +161,7 @@ export class OtherErrorResponse extends ErrorResponse {
    * @param multiValueHeaders - HTTP response headers, allowing multiple values for a header
    */
   constructor(message: string, statusCode: ErrorStatusCode, headers?: Headers, multiValueHeaders?: MultiValueHeaders) {
-    const error: Error = {
+    const error: ErrorModel = {
       code: ErrorCode.OTHER,
       message,
     };
@@ -182,7 +187,7 @@ export class ValidationErrorResponse extends ErrorResponse {
     headers?: Headers,
     multiValueHeaders?: MultiValueHeaders
   ) {
-    const error: ValidationError = {
+    const error: ValidationErrorModel = {
       code: ErrorCode.INVALID_INPUT,
       message,
       error_map: errorMap,

--- a/packages/api/utils/validation.ts
+++ b/packages/api/utils/validation.ts
@@ -1,4 +1,4 @@
-import { PortfolioStep } from "../models/PortfolioStep";
+import { PortfolioStepModel } from "../models/PortfolioStep";
 import { validate as uuidValidate, version as uuidVersion } from "uuid";
 
 /**
@@ -30,7 +30,7 @@ function isValidObject(object: unknown): object is any {
  * @param object - The object to check
  * @returns true if the object has all the attributes of a {@link PortfolioStep}
  */
-export function isPortfolioStep(object: unknown): object is PortfolioStep {
+export function isPortfolioStep(object: unknown): object is PortfolioStepModel {
   // Ensure that the given item is a valid object prior to checks its members
   if (!isValidObject(object)) {
     return false;


### PR DESCRIPTION
Refactor of models and entities in the `api/package` to prevent name collisions and add clarity. The only changes done are the name of the models or entities, and the locations they are being used (a lot of the files in `api/packages`). For example `Application` becomes `EnvironmentModel` for the model and `EnvironmentEntity` for the typeORM entity. 

Since a large amount of files were updated, a deployed stack was tested to ensure all the original routes worked as expected and nothing was found. 