### PR TITLE
Remove database connection from /portfolioDrafts

### DIFF
--- a/packages/api/portfolioDrafts/createPortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/createPortfolioDraft.ts
@@ -8,7 +8,6 @@ import { dynamodbDocumentClient as client } from "../utils/aws-sdk/dynamodb";
 import { DATABASE_ERROR, REQUEST_BODY_NOT_EMPTY } from "../utils/errors";
 import { IpCheckerMiddleware } from "../utils/ipLogging";
 import { ApiSuccessResponse, SuccessStatusCode } from "../utils/response";
-import { createConnection } from "../utils/database";
 
 /**
  * Creates a new Portfolio Draft
@@ -19,10 +18,6 @@ export async function baseHandler(event: APIGatewayProxyEvent): Promise<APIGatew
   if (event.body && !JSON.parse(event.body)) {
     return REQUEST_BODY_NOT_EMPTY;
   }
-
-  const databaseConnection = await createConnection();
-  // SAMPLE CODE -- TODO: REMOVE DURING ACTUAL IMPLEMENTATION
-  console.log(await databaseConnection.query("SELECT * FROM pg_catalog.pg_tables;"));
 
   const now = new Date().toISOString();
   const item: PortfolioDraftSummary = {


### PR DESCRIPTION
This causes performance issues on the first request that result in
persistent 500s. This removes the bottleneck to prevent this from being
an issue in the live dev environment.

A separate test route eventually will be created to support testing the
database interactions in a subsequent PR.
