### PR TITLE
Add database test route

### DIFF
--- a/packages/api/dbTest.ts
+++ b/packages/api/dbTest.ts
@@ -1,0 +1,36 @@
+import middy from "@middy/core";
+import { APIGatewayProxyWithCognitoAuthorizerEvent, APIGatewayProxyResult, Context } from "aws-lambda";
+
+import { createConnection } from "./utils/database";
+import { IpCheckerMiddleware } from "./utils/ipLogging";
+
+async function baseHandler(
+  event: APIGatewayProxyWithCognitoAuthorizerEvent,
+  context: Context
+): Promise<APIGatewayProxyResult> {
+  try {
+    const connection = await createConnection();
+    const queries = [`SELECT current_database();`, `SELECT * FROM pg_catalog.pg_tables;`];
+
+    for (const query of queries) {
+      console.log(
+        JSON.stringify({
+          query: query,
+          result: connection.query(query),
+        })
+      );
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ status: "200", message: "Hello, world" }),
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ status: "500", error: "Unknown" }),
+    };
+  }
+}
+
+export const handler = middy(baseHandler).use(IpCheckerMiddleware());

--- a/packages/api/portfolioDrafts/createPortfolioDraft.ts
+++ b/packages/api/portfolioDrafts/createPortfolioDraft.ts
@@ -1,6 +1,6 @@
 import { PutCommand } from "@aws-sdk/lib-dynamodb";
 import middy from "@middy/core";
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { APIGatewayProxyWithCognitoAuthorizerEvent, APIGatewayProxyResult } from "aws-lambda";
 import { v4 as uuidv4 } from "uuid";
 import { PortfolioDraftSummary } from "../models/PortfolioDraftSummary";
 import { ProvisioningStatus } from "../models/ProvisioningStatus";
@@ -14,7 +14,7 @@ import { ApiSuccessResponse, SuccessStatusCode } from "../utils/response";
  *
  * @param event - The POST request from API Gateway
  */
-export async function baseHandler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+export async function baseHandler(event: APIGatewayProxyWithCognitoAuthorizerEvent): Promise<APIGatewayProxyResult> {
   if (event.body && !JSON.parse(event.body)) {
     return REQUEST_BODY_NOT_EMPTY;
   }


### PR DESCRIPTION
We previously used `POST /portfolioDrafts` for this but that caused
problems because it was used by the UI directly so if there were issues
with talking to the database, we took down the app. This lets us test
them somewhere outside the actual app code.
