### PR TITLE
Added  CspInvocation and CspResponse objects

### DIFF
--- a/atat_internal_api.yaml
+++ b/atat_internal_api.yaml
@@ -2038,6 +2038,37 @@ components:
   #          type: string
   #        lastName:
   #          type: string
+    CspInvocation:
+      required:
+        - method
+        - endpoint
+        - payload
+      properties:
+        method:
+          type: string
+          enum:
+            - GET
+            - POST
+            - PUT
+            - DELETE
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+        endpoint:
+          type: string
+          format: uri
+        payload:
+          type: object
+    CspResponse:
+      properties:
+        code:
+          type: integer
+        content:
+          type: object
+            additionalProperties: true
+        request:
+          $ref: '#/components/schemas/CspInvocation'
   examples:
     PortfolioSummaries:
       value:

--- a/atat_internal_api.yaml
+++ b/atat_internal_api.yaml
@@ -2066,7 +2066,7 @@ components:
           type: integer
         content:
           type: object
-            additionalProperties: true
+          additionalProperties: true
         request:
           $ref: '#/components/schemas/CspInvocation'
   examples:


### PR DESCRIPTION
The CSP Provisioning process will be executed roughly as follows:

1. User interacts with ATAT UI / Internal API to update ATAT resources (Portfolios, Applications, Environments & Task Orders)
2. When ready, User submits all pending resources for provisioning. Pending resources are defined as new rows in the database whose status is not `COMPLETE` or `IN_PROGRESS`
3. The POST /portfolios/:idsubmit Lambda walks the tree of the given Portfolio and creates one or more `CspInvocation` objects and passing each to their own instance of a Step Function workflow
4. The  CSP Invocation Lambda reads the given `CspInvocation` object and makes a matching invocation to the endpoint contained within it (initial implementation in Phase 1 will be totally mocked out, but include ability to test all paths)
    1.  If a 5xx code is received, retry up to 6 times
    2. If a 4xx code is received, invoke the Reject CSP Response Lambda. This will mark each resource under the parent with `provisioning_status` = `FAILED`.
    3. If a 2xx code is received, invoke the Persist CSP Response Lambda. This will mark each resource under the parent with `provisioning_status` = `COMPLETE`.

We'll need a proper formal schema In order to properly exchange information between these Lambdas. It should also facilitate parallel development of these Lambdas. If any other objects need to be created, they can be added here later. In theory we could add them to a different spec file but this seems fine for now. 

Ticket: AT-6707 (CSP Provisioning Epic)