### PR TITLE
Return an empty group list when unable to parse

### DIFF
--- a/packages/cognito/preTokenGeneration/groups.test.ts
+++ b/packages/cognito/preTokenGeneration/groups.test.ts
@@ -132,6 +132,15 @@ describe("Testing the handling of mock events", () => {
       const result = translateGroups(event.lambdaEvent);
       expect(result).toEqual(event.groupNames);
     });
+    it("should return an empty list of groups if the event doesn't have them", async () => {
+      const original = console.error;
+      console.error = jest.fn();
+      const event = createBasicSampleEvent({ groupCount: 0, groupAttribute: "notGroups", providerType });
+      const result = translateGroups(event.lambdaEvent);
+      expect(result).toEqual([]);
+      expect(console.error).toHaveBeenCalled();
+      console.error = original;
+    });
   });
   describe("For unsupported provider", () => {
     beforeEach(() => {

--- a/packages/cognito/preTokenGeneration/groups.ts
+++ b/packages/cognito/preTokenGeneration/groups.ts
@@ -24,7 +24,19 @@ export function parseProviderType(event: PreTokenGenerationTriggerEvent): string
 }
 
 export function parseIdpGroups(event: PreTokenGenerationTriggerEvent): string[] {
-  return JSON.parse(event.request.userAttributes[groupsAttribute()]);
+  try {
+    return JSON.parse(event.request.userAttributes[groupsAttribute()]);
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "Failed to parse groups",
+        expectedAttribute: groupsAttribute(),
+        availableAttributes: Object.keys(event.request.userAttributes),
+        details: err,
+      })
+    );
+    return [];
+  }
 }
 
 export function translateGroups(event: PreTokenGenerationTriggerEvent): string[] {
@@ -45,7 +57,13 @@ export function translateGroups(event: PreTokenGenerationTriggerEvent): string[]
     default:
       // Throwing an error here would likely cause problems with the groups being set
       // instead, we will just log the issue.
-      console.warn("Not handling groups for " + providerType + ": " + idpGroups);
+      console.warn(
+        JSON.stringify({
+          message: "Unsupported IdP type. Unable to handle groups.",
+          providerType: providerType,
+          groupsValue: idpGroups,
+        })
+      );
       break;
   }
   return [...originalGroups, ...newGroups];


### PR DESCRIPTION
If there is not a claim for groups or if we have the wrong key, rather
than failing to generate a token at all, we should just return an empty
list of groups.

To make logs somewhat easier to query in CloudWatch, I've made them
semi-structured. Clearly we still need to decide our logging framework
but I wanted to play with this for now.

This avoids an issue we're experiencing with a recently-added IdP that
either is not providing a groups attribute or the attribute name is
different than what we expect.
