### PR TITLE
AT-6874: Added temporary logging for debugging GD integration 

### DIFF
--- a/packages/cognito/preTokenGeneration/groups.ts
+++ b/packages/cognito/preTokenGeneration/groups.ts
@@ -24,6 +24,8 @@ export function parseProviderType(event: PreTokenGenerationTriggerEvent): string
 }
 
 export function parseIdpGroups(event: PreTokenGenerationTriggerEvent): string[] {
+  // TODO: remove this log once GD integration is successful
+  console.log(JSON.stringify(event));
   try {
     return JSON.parse(event.request.userAttributes[groupsAttribute()]);
   } catch (err) {


### PR DESCRIPTION
Added console log to pretoken event as a temporary means of debugging GD integration (specifically, group mapping).

Ticket: AT-6874