### PR TITLE
Fix logged output of DbTest lambda function

### DIFF
--- a/packages/api/dbTest.ts
+++ b/packages/api/dbTest.ts
@@ -16,7 +16,7 @@ async function baseHandler(
       console.log(
         JSON.stringify({
           query: query,
-          result: connection.query(query),
+          result: await connection.query(query),
         })
       );
     }


### PR DESCRIPTION
Previously query results were not logged and `result` appeared to be empty when function returned status 200.
This change logs query results as expected.
