### PR TITLE
Fix Step Functions LogGroup Error and other database errors

### DIFF
--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -387,6 +387,7 @@ export class AtatWebApiStack extends cdk.Stack {
       .next(httpResponseChoices);
     const stateMachineLogGroup = new logs.LogGroup(this, "StepFunctionsLogs", {
       retention: logs.RetentionDays.ONE_WEEK,
+      logGroupName: `/aws/vendedlogs/states/StepFunctionsLogs${this.environmentId}`,
     });
     this.provisioningStateMachine = new SecureStateMachine(this, "ProvisioningStateMachine", {
       stateMachineProps: {

--- a/packages/api/utils/database.ts
+++ b/packages/api/utils/database.ts
@@ -3,6 +3,11 @@ import * as rdsIam from "atat-web-api-rds/auth/iam";
 import path from "path";
 import * as fs from "fs";
 import { TlsOptions } from "tls";
+import { Portfolio } from "../../orm/entity/Portfolio";
+import { Application } from "../../orm/entity/Application";
+import { Environment } from "../../orm/entity/Environment";
+import { TaskOrder } from "../../orm/entity/TaskOrder";
+import { Clin } from "../../orm/entity/Clin";
 
 let CONNECTION: Connection | undefined;
 
@@ -80,7 +85,7 @@ export async function createConnection(): Promise<Connection> {
     },
     logging: "all",
     database: databaseName,
-    entities: ["/opt/nodejs/orm/entity/**.js"],
+    entities: [Portfolio, Application, Environment, TaskOrder, Clin, "/opt/nodejs/orm/entity/**.js"],
     migrations: ["/opt/nodejs/orm/migration/**.js"],
   });
   return CONNECTION;

--- a/packages/orm/entity/Application.ts
+++ b/packages/orm/entity/Application.ts
@@ -5,10 +5,10 @@ import { ProvisionableEntity } from "./ProvisionableEntity";
 
 @Entity("application")
 export class Application extends ProvisionableEntity {
-  @Column({ length: 100 })
+  @Column({ type: "varchar", length: 100 })
   name: string;
 
-  @Column({ nullable: true, length: 300 })
+  @Column({ type: "varchar", nullable: true, length: 300 })
   description: string;
 
   @ManyToOne(() => Portfolio, (portfolio) => portfolio.applications)

--- a/packages/orm/entity/Clin.ts
+++ b/packages/orm/entity/Clin.ts
@@ -5,12 +5,14 @@ import { TaskOrder } from "./TaskOrder";
 @Entity("clin")
 export class Clin extends BaseEntity {
   @Column({
+    type: "varchar",
     length: 4,
     comment: "contract line item number from task order, 0001 through 9999",
   })
   clinNumber: string;
 
   @Column({
+    type: "varchar",
     comment: "indefinite-delivery, indefinite-quantity CLIN specific to JWCC",
   })
   idiqClin: string;

--- a/packages/orm/entity/Environment.ts
+++ b/packages/orm/entity/Environment.ts
@@ -4,7 +4,7 @@ import { ProvisionableEntity } from "./ProvisionableEntity";
 
 @Entity("environment")
 export class Environment extends ProvisionableEntity {
-  @Column({ length: 100 })
+  @Column({ type: "varchar", length: 100 })
   name: string;
 
   @ManyToOne(() => Application, (application) => application.environments)

--- a/packages/orm/entity/Portfolio.ts
+++ b/packages/orm/entity/Portfolio.ts
@@ -23,13 +23,13 @@ export enum DodComponent {
 
 @Entity("portfolio")
 export class Portfolio extends ProvisionableEntity {
-  @Column({ length: 100 })
+  @Column({ type: "varchar", length: 100 })
   name: string;
 
-  @Column({ nullable: true, length: 300 })
+  @Column({ type: "varchar", nullable: true, length: 300 })
   description: string;
 
-  @Column()
+  @Column({ type: "varchar" })
   owner: string;
 
   @Column({ type: "enum", enum: CloudServiceProvider })

--- a/packages/orm/entity/TaskOrder.ts
+++ b/packages/orm/entity/TaskOrder.ts
@@ -12,6 +12,7 @@ export enum FileScanStatus {
 @Entity("task_order")
 export class TaskOrder extends BaseEntity {
   @Column({
+    type: "varchar",
     length: 17,
     comment: "TO numbers are 13 characters. TO modifications are 17 characters.",
   })
@@ -20,10 +21,10 @@ export class TaskOrder extends BaseEntity {
   @Column({ type: "uuid", comment: "S3 object key of task order pdf" })
   fileId: string;
 
-  @Column({ length: 256, comment: "name of pdf file when uploaded" })
+  @Column({ type: "varchar", length: 256, comment: "name of pdf file when uploaded" })
   fileName: string;
 
-  @Column({ nullable: true, comment: "pdf file size in bytes" })
+  @Column({ type: "integer", nullable: true, comment: "pdf file size in bytes" })
   fileSize: number;
 
   @Column({ type: "enum", enum: FileScanStatus, default: FileScanStatus.PENDING })


### PR DESCRIPTION
This PR fixes a few common errors that were seen across the team and implements the changes that fixes those errors (RDS endpoints implementation).
- Add `logGroupName` for the state machine in the stack and use the prefix `/aws/vendedlogs/states/` to over come the `Invalid Logging Configuration: The CloudWatch Logs Resource Policy size was exceeded.` when trying to `cdk deploy`.
- Add entities classes for the connection configuration to prevent `EntityMetadataNotFoundError`.
- Add column types to entities to prevent `CloumnTypeUndefinedError`.