### PR TITLE
Implement updateEnvironment func (RDS endpoint)

### DIFF
--- a/atat_internal_api.yaml
+++ b/atat_internal_api.yaml
@@ -775,7 +775,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${NotImplementedFunction.Arn}/invocations"
+          Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UpdateEnvironmentFunction.Arn}/invocations"
         type: "aws_proxy"
       security:
         Fn::If:

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -151,6 +151,7 @@ export class AtatWebApiStack extends cdk.Stack {
 
     // Portfolios Operations using the internal API spec
     this.addDatabaseApiFunction("createEnvironment", "portfolios/environments/", props.vpc, TablePermissions.WRITE);
+    this.addDatabaseApiFunction("updateEnvironment", "portfolios/environments/", props.vpc, TablePermissions.WRITE);
 
     // PortfolioDraft Operations
     this.addDatabaseApiFunction("getPortfolioDrafts", "portfolioDrafts/", props.vpc, TablePermissions.READ);

--- a/packages/api/portfolios/environments/createEnvironment.test.ts
+++ b/packages/api/portfolios/environments/createEnvironment.test.ts
@@ -18,6 +18,21 @@ describe("createEnvironment", () => {
     console.log(result?.body);
     expect(result?.statusCode).toBe(SuccessStatusCode.CREATED);
   });
+  it.skip("requests with properties from BaseObject should cause status code 400", async () => {
+    const validRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
+      body: {
+        name: "flaw check 1",
+        id: "7bc938ca-4c1c-4740-8ccf-18c940a70865",
+        createdAt: "2020-12-17T18:29:42.769Z",
+        updatedAt: "2020-12-17T18:29:42.769Z",
+        archivedAt: "2099-12-17T18:29:42.769Z",
+      },
+      requestContext: { identity: { sourceIp: "7.7.7.7" } },
+    } as any;
+    const result = await handler(validRequest, {} as Context, () => null);
+    console.log(result?.body);
+    expect(result?.statusCode).toBe(ErrorStatusCode.BAD_REQUEST);
+  });
   it.skip("not a unique env name error, testing locally only", async () => {
     const validRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
       body: { name: "naming makes a big difference" },

--- a/packages/api/portfolios/environments/createEnvironment.test.ts
+++ b/packages/api/portfolios/environments/createEnvironment.test.ts
@@ -5,21 +5,22 @@ import { IEnvironmentCreate } from "../../../orm/entity/Environment";
 import { ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
 
 describe("createEnvironment", () => {
+  const validRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
+    body: { name: "new local testing after refactor" },
+    pathParameters: {
+      portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
+      applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
+    },
+    requestContext: { identity: { sourceIp: "7.7.7.7" } },
+  } as any;
   it.skip("successful operation testing locally only", async () => {
-    const validRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
-      body: { name: "new local testing and a unique name" },
-      pathParameters: {
-        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
-        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
-      },
-      requestContext: { identity: { sourceIp: "7.7.7.7" } },
-    } as any;
     const result = await handler(validRequest, {} as Context, () => null);
     console.log(result?.body);
     expect(result?.statusCode).toBe(SuccessStatusCode.CREATED);
   });
   it.skip("requests with properties from BaseObject should cause status code 400", async () => {
-    const validRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
+    const badPropertiesRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
+      ...validRequest,
       body: {
         name: "flaw check 1",
         id: "7bc938ca-4c1c-4740-8ccf-18c940a70865",
@@ -27,61 +28,51 @@ describe("createEnvironment", () => {
         updatedAt: "2020-12-17T18:29:42.769Z",
         archivedAt: "2099-12-17T18:29:42.769Z",
       },
-      requestContext: { identity: { sourceIp: "7.7.7.7" } },
     } as any;
-    const result = await handler(validRequest, {} as Context, () => null);
+    const result = await handler(badPropertiesRequest, {} as Context, () => null);
     console.log(result?.body);
     expect(result?.statusCode).toBe(ErrorStatusCode.BAD_REQUEST);
   });
   it.skip("not a unique env name error, testing locally only", async () => {
-    const validRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
+    const sameNameRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
+      ...validRequest,
       body: { name: "naming makes a big difference" },
-      pathParameters: {
-        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
-        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
-      },
-      requestContext: { identity: { sourceIp: "7.7.7.7" } },
     } as any;
-    const result = await handler(validRequest, {} as Context, () => null);
+    const result = await handler(sameNameRequest, {} as Context, () => null);
     console.log(result?.body);
     expect(result?.statusCode).toBe(ErrorStatusCode.BAD_REQUEST);
   });
   it.skip("no body, testing locally only", async () => {
-    const validRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
+    const noBodyRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
       // body: { name: "coolest env" },
-      pathParameters: {
-        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
-        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
-      },
+      pathParameters: validRequest.pathParameters,
       requestContext: { identity: { sourceIp: "7.7.7.7" } },
     } as any;
-    const result = await handler(validRequest, {} as Context, () => null);
+    const result = await handler(noBodyRequest, {} as Context, () => null);
     console.log(result?.body);
     expect(result?.statusCode).toBe(ErrorStatusCode.BAD_REQUEST);
   });
   it.skip("portfolioId not found error, testing locally only", async () => {
-    const validRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
-      body: { name: "try errors again" },
+    const badPortfolioIdRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
+      ...validRequest,
       pathParameters: {
         portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad5", // bad portfolio Id
         applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
       },
-      requestContext: { identity: { sourceIp: "7.7.7.7" } },
     } as any;
-    const result = await handler(validRequest, {} as Context, () => null);
+    const result = await handler(badPortfolioIdRequest, {} as Context, () => null);
     console.log(result?.body);
     expect(result?.statusCode).toBe(ErrorStatusCode.NOT_FOUND);
   });
   it.skip("applicationId not found error, testing locally only", async () => {
-    const validRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
-      body: { name: "try errors again" },
+    const badApplicationIdRequest: ApiGatewayEventParsed<IEnvironmentCreate> = {
+      ...validRequest,
       pathParameters: {
         portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
         applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70864", // bad application Id
       },
-      requestContext: { identity: { sourceIp: "7.7.7.7" } },
     } as any;
-    const result = await handler(validRequest, {} as Context, () => null);
+    const result = await handler(badApplicationIdRequest, {} as Context, () => null);
     console.log(result?.body);
     expect(result?.statusCode).toBe(ErrorStatusCode.NOT_FOUND);
   });

--- a/packages/api/portfolios/environments/createEnvironment.ts
+++ b/packages/api/portfolios/environments/createEnvironment.ts
@@ -17,9 +17,9 @@ import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
 import { CORS_CONFIGURATION } from "../../utils/corsConfig";
 import { wrapSchema } from "../../utils/schemaWrapper";
 import { errorHandlingMiddleware } from "../../utils/errorHandlingMiddleware";
-import createError from "http-errors";
 import { IpCheckerMiddleware } from "../../utils/ipLogging";
 import { validateRequestShape } from "../../utils/shapeValidator";
+import { uniqueNameValidator } from "../../utils/businessRulesValidation";
 
 /**
  * Submits the environment of an application
@@ -48,20 +48,13 @@ export async function baseHandler(
     });
 
     // get all environment names for application
-    const environments = await connection
+    const environmentNames = await connection
       .getCustomRepository(EnvironmentRepository)
       .getAllEnvironmentNames(application.id);
 
     // ensure the environment name is unique for the application
     // according to business rule 3.3
-    for (const environment of environments) {
-      if (environment.name === environmentBody.name) {
-        throw createError(400, "Duplicate environment name in application", {
-          errorName: "DuplicateEnvironmentName",
-          environmentName: environmentBody.name,
-        });
-      }
-    }
+    uniqueNameValidator(environmentBody.name, environmentNames);
 
     const insertResult = await connection
       .getCustomRepository(EnvironmentRepository)

--- a/packages/api/portfolios/environments/updateEnvironment.test.ts
+++ b/packages/api/portfolios/environments/updateEnvironment.test.ts
@@ -5,79 +5,70 @@ import { IEnvironment } from "../../../orm/entity/Environment";
 import { ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
 
 describe("updateEnvironment", () => {
+  const validRequest: ApiGatewayEventParsed<IEnvironment> = {
+    body: {
+      name: "new name",
+      // an empty array is returned when an operator property is not provided
+      administrators: ["rootAdmin@mail.mil"],
+      contributors: ["dev@mail.mil"],
+      // readOnlyOperators: ["qa@mail.mil"],
+    },
+    pathParameters: {
+      portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
+      applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
+      environmentId: "4097ff2a-7a1e-4e2d-ac30-21e9faa4ae9b",
+    },
+    requestContext: { identity: { sourceIp: "7.7.7.7" } },
+  } as any;
   it.skip("successful operation testing locally only", async () => {
-    const validRequest: ApiGatewayEventParsed<IEnvironment> = {
-      body: {
-        name: "new name",
-        // an empty array is returned when an operator property is not provided
-        administrators: ["rootAdmin@mail.mil"],
-        // contributors: ["dev@mail.mil"],
-        // readOnlyOperators: ["qa@mail.mil"],
-      },
-      pathParameters: {
-        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
-        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
-        environmentId: "4097ff2a-7a1e-4e2d-ac30-21e9faa4ae9b",
-      },
-      requestContext: { identity: { sourceIp: "7.7.7.7" } },
-    } as any;
     const result = await handler(validRequest, {} as Context, () => null);
     console.log(result?.body);
     expect(result?.statusCode).toBe(SuccessStatusCode.OK);
   });
   it.skip("no body, testing locally only", async () => {
-    const validRequest: ApiGatewayEventParsed<IEnvironment> = {
+    const noBodyRequest: ApiGatewayEventParsed<IEnvironment> = {
       // body: { name: "coolest env" },
-      pathParameters: {
-        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
-        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
-        environmentId: "4097ff2a-7a1e-4e2d-ac30-21e9faa4ae9b",
-      },
+      pathParameters: validRequest.pathParameters,
       requestContext: { identity: { sourceIp: "7.7.7.7" } },
     } as any;
-    const result = await handler(validRequest, {} as Context, () => null);
+    const result = await handler(noBodyRequest, {} as Context, () => null);
     console.log(result?.body);
     expect(result?.statusCode).toBe(ErrorStatusCode.BAD_REQUEST);
   });
   it.skip("portfolioId not found error, testing locally only", async () => {
-    const validRequest: ApiGatewayEventParsed<IEnvironment> = {
-      body: { name: "try errors again" },
+    const badPortfolioIdRequest: ApiGatewayEventParsed<IEnvironment> = {
+      ...validRequest,
       pathParameters: {
+        ...validRequest.pathParameters,
         portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad5", // bad portfolio Id
-        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
-        environmentId: "4097ff2a-7a1e-4e2d-ac30-21e9faa4ae9b",
       },
-      requestContext: { identity: { sourceIp: "7.7.7.7" } },
     } as any;
-    const result = await handler(validRequest, {} as Context, () => null);
+    const result = await handler(badPortfolioIdRequest, {} as Context, () => null);
     console.log(result?.body);
     expect(result?.statusCode).toBe(ErrorStatusCode.NOT_FOUND);
   });
   it.skip("applicationId not found error, testing locally only", async () => {
-    const validRequest: ApiGatewayEventParsed<IEnvironment> = {
-      body: { name: "try errors again" },
+    const badApplicationIdRequest: ApiGatewayEventParsed<IEnvironment> = {
+      ...validRequest,
       pathParameters: {
-        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
+        ...validRequest.pathParameters,
         applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70864", // bad application Id
-        environmentId: "4097ff2a-7a1e-4e2d-ac30-21e9faa4ae9b",
       },
-      requestContext: { identity: { sourceIp: "7.7.7.7" } },
     } as any;
-    const result = await handler(validRequest, {} as Context, () => null);
+    const result = await handler(badApplicationIdRequest, {} as Context, () => null);
     console.log(result?.body);
     expect(result?.statusCode).toBe(ErrorStatusCode.NOT_FOUND);
   });
   it.skip("environmentId not found error, testing locally only", async () => {
-    const validRequest: ApiGatewayEventParsed<IEnvironment> = {
-      body: { name: "try errors again" },
+    const badEnvironmentIdRequest: ApiGatewayEventParsed<IEnvironment> = {
+      ...validRequest,
       pathParameters: {
-        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
-        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
+        ...validRequest.pathParameters,
         environmentId: "4097ff2a-7a1e-4e2d-ac30-21e9faa4ae98", // bad environment Id
       },
       requestContext: { identity: { sourceIp: "7.7.7.7" } },
     } as any;
-    const result = await handler(validRequest, {} as Context, () => null);
+    const result = await handler(badEnvironmentIdRequest, {} as Context, () => null);
     console.log(result?.body);
     expect(result?.statusCode).toBe(ErrorStatusCode.NOT_FOUND);
   });

--- a/packages/api/portfolios/environments/updateEnvironment.test.ts
+++ b/packages/api/portfolios/environments/updateEnvironment.test.ts
@@ -1,0 +1,84 @@
+import { handler } from "./updateEnvironment";
+import { Context } from "aws-lambda";
+import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
+import { IEnvironment } from "../../../orm/entity/Environment";
+import { ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
+
+describe("updateEnvironment", () => {
+  it.skip("successful operation testing locally only", async () => {
+    const validRequest: ApiGatewayEventParsed<IEnvironment> = {
+      body: {
+        name: "new name",
+        // an empty array is returned when an operator property is not provided
+        administrators: ["rootAdmin@mail.mil"],
+        // contributors: ["dev@mail.mil"],
+        // readOnlyOperators: ["qa@mail.mil"],
+      },
+      pathParameters: {
+        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
+        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
+        environmentId: "4097ff2a-7a1e-4e2d-ac30-21e9faa4ae9b",
+      },
+      requestContext: { identity: { sourceIp: "7.7.7.7" } },
+    } as any;
+    const result = await handler(validRequest, {} as Context, () => null);
+    console.log(result?.body);
+    expect(result?.statusCode).toBe(SuccessStatusCode.OK);
+  });
+  it.skip("no body, testing locally only", async () => {
+    const validRequest: ApiGatewayEventParsed<IEnvironment> = {
+      // body: { name: "coolest env" },
+      pathParameters: {
+        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
+        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
+        environmentId: "4097ff2a-7a1e-4e2d-ac30-21e9faa4ae9b",
+      },
+      requestContext: { identity: { sourceIp: "7.7.7.7" } },
+    } as any;
+    const result = await handler(validRequest, {} as Context, () => null);
+    console.log(result?.body);
+    expect(result?.statusCode).toBe(ErrorStatusCode.BAD_REQUEST);
+  });
+  it.skip("portfolioId not found error, testing locally only", async () => {
+    const validRequest: ApiGatewayEventParsed<IEnvironment> = {
+      body: { name: "try errors again" },
+      pathParameters: {
+        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad5", // bad portfolio Id
+        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
+        environmentId: "4097ff2a-7a1e-4e2d-ac30-21e9faa4ae9b",
+      },
+      requestContext: { identity: { sourceIp: "7.7.7.7" } },
+    } as any;
+    const result = await handler(validRequest, {} as Context, () => null);
+    console.log(result?.body);
+    expect(result?.statusCode).toBe(ErrorStatusCode.NOT_FOUND);
+  });
+  it.skip("applicationId not found error, testing locally only", async () => {
+    const validRequest: ApiGatewayEventParsed<IEnvironment> = {
+      body: { name: "try errors again" },
+      pathParameters: {
+        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
+        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70864", // bad application Id
+        environmentId: "4097ff2a-7a1e-4e2d-ac30-21e9faa4ae9b",
+      },
+      requestContext: { identity: { sourceIp: "7.7.7.7" } },
+    } as any;
+    const result = await handler(validRequest, {} as Context, () => null);
+    console.log(result?.body);
+    expect(result?.statusCode).toBe(ErrorStatusCode.NOT_FOUND);
+  });
+  it.skip("environmentId not found error, testing locally only", async () => {
+    const validRequest: ApiGatewayEventParsed<IEnvironment> = {
+      body: { name: "try errors again" },
+      pathParameters: {
+        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
+        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
+        environmentId: "4097ff2a-7a1e-4e2d-ac30-21e9faa4ae98", // bad environment Id
+      },
+      requestContext: { identity: { sourceIp: "7.7.7.7" } },
+    } as any;
+    const result = await handler(validRequest, {} as Context, () => null);
+    console.log(result?.body);
+    expect(result?.statusCode).toBe(ErrorStatusCode.NOT_FOUND);
+  });
+});

--- a/packages/api/portfolios/environments/updateEnvironment.ts
+++ b/packages/api/portfolios/environments/updateEnvironment.ts
@@ -36,6 +36,7 @@ export async function baseHandler(
 
   // set up database connection
   const connection = await createConnection();
+  const environmentRepository = connection.getCustomRepository(EnvironmentRepository);
   let response: Environment;
 
   try {
@@ -46,20 +47,14 @@ export async function baseHandler(
     const application = await connection.getRepository(Application).findOneOrFail({
       id: applicationId,
     });
-    const environment = await connection
-      .getCustomRepository(EnvironmentRepository)
-      .findOneOrFail({ id: environmentId });
 
-    const environmentNames = await connection
-      .getCustomRepository(EnvironmentRepository)
-      .getAllEnvironmentNames(application.id);
+    const environment = await environmentRepository.findOneOrFail({ id: environmentId });
+    const environmentNames = await environmentRepository.getAllEnvironmentNames(application.id);
 
     // Throws error if duplicate name found
     uniqueNameValidator(requestBody.name, environmentNames);
 
-    response = await connection
-      .getCustomRepository(EnvironmentRepository)
-      .updateEnvironment(environment.id, requestBody);
+    response = await environmentRepository.updateEnvironment(environment.id, requestBody);
     console.log("Updated Environment: " + JSON.stringify(response));
   } finally {
     connection.close();

--- a/packages/api/portfolios/environments/updateEnvironment.ts
+++ b/packages/api/portfolios/environments/updateEnvironment.ts
@@ -4,22 +4,22 @@ import { Portfolio } from "../../../orm/entity/Portfolio";
 import { Application } from "../../../orm/entity/Application";
 import { Environment, IEnvironment } from "../../../orm/entity/Environment";
 import { EnvironmentRepository } from "../../repository/EnvironmentRepository";
+import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
 import { APIGatewayProxyResult, Context } from "aws-lambda";
 import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
-import internalSchema = require("../../models/internalSchema.json");
 import middy from "@middy/core";
-import xssSanitizer from "../../portfolioDrafts/xssSanitizer";
+import xssSanitizer from "../../utils/xssSanitizer";
 import jsonBodyParser from "@middy/http-json-body-parser";
 import validator from "@middy/validator";
 import JSONErrorHandlerMiddleware from "middy-middleware-json-error-handler";
 import cors from "@middy/http-cors";
-import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
 import { CORS_CONFIGURATION } from "../../utils/corsConfig";
-import { wrapSchema } from "../../utils/schemaWrapper";
 import { errorHandlingMiddleware } from "../../utils/errorHandlingMiddleware";
 import { IpCheckerMiddleware } from "../../utils/ipLogging";
 import { validateRequestShape } from "../../utils/shapeValidator";
 import { uniqueNameValidator } from "../../utils/businessRulesValidation";
+import { environmentSchema } from "./createEnvironment";
+import { wrapSchema } from "../../utils/schemaWrapper";
 
 /**
  * Submits an update to an environment of an application
@@ -72,7 +72,7 @@ export const handler = middy(baseHandler)
   .use(IpCheckerMiddleware())
   .use(xssSanitizer())
   .use(jsonBodyParser())
-  .use(validator({ inputSchema: wrapSchema(internalSchema.Environment) }))
+  .use(validator({ inputSchema: wrapSchema(environmentSchema) }))
   .use(errorHandlingMiddleware())
   .use(JSONErrorHandlerMiddleware())
   .use(cors(CORS_CONFIGURATION));

--- a/packages/api/portfolios/environments/updateEnvironment.ts
+++ b/packages/api/portfolios/environments/updateEnvironment.ts
@@ -1,0 +1,70 @@
+import "reflect-metadata";
+import { createConnection } from "../../utils/database";
+import { Portfolio } from "../../../orm/entity/Portfolio";
+import { Application } from "../../../orm/entity/Application";
+import { Environment, IEnvironment } from "../../../orm/entity/Environment";
+import { EnvironmentRepository } from "../../repository/EnvironmentRepository";
+import { APIGatewayProxyResult, Context } from "aws-lambda";
+import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
+import internalSchema = require("../../models/internalSchema.json");
+import middy from "@middy/core";
+import xssSanitizer from "../../portfolioDrafts/xssSanitizer";
+import jsonBodyParser from "@middy/http-json-body-parser";
+import validator from "@middy/validator";
+import JSONErrorHandlerMiddleware from "middy-middleware-json-error-handler";
+import cors from "@middy/http-cors";
+import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
+import { CORS_CONFIGURATION } from "../../utils/corsConfig";
+import { wrapSchema } from "../../utils/schemaWrapper";
+import { errorHandlingMiddleware } from "../../utils/errorHandlingMiddleware";
+import { IpCheckerMiddleware } from "../../utils/ipLogging";
+import { validateRequestShape } from "../../utils/shapeValidator";
+
+/**
+ * Submits an update to an environment of an application
+ *
+ * @param event - The PUT request from API Gateway
+ */
+export async function baseHandler(
+  event: ApiGatewayEventParsed<IEnvironment>,
+  context?: Context
+): Promise<APIGatewayProxyResult> {
+  const setupResult = validateRequestShape<IEnvironment>(event);
+  const { portfolioId, applicationId, environmentId } = setupResult.path;
+  const requestBody = setupResult.bodyObject;
+
+  // set up database connection
+  const connection = await createConnection();
+  let response: Environment;
+
+  try {
+    // ensures the portfolio, application, and environment id exists
+    await connection.getRepository(Portfolio).findOneOrFail({
+      id: portfolioId,
+    });
+    await connection.getRepository(Application).findOneOrFail({
+      id: applicationId,
+    });
+    const environment = await connection
+      .getCustomRepository(EnvironmentRepository)
+      .findOneOrFail({ id: environmentId });
+
+    await connection.getCustomRepository(EnvironmentRepository).updateEnvironment(environment.id, requestBody);
+
+    response = await connection.getCustomRepository(EnvironmentRepository).getEnvironment(environment.id);
+    console.log("Updated Environment: " + JSON.stringify(response));
+  } finally {
+    connection.close();
+  }
+
+  return new ApiSuccessResponse<Environment>(response, SuccessStatusCode.OK);
+}
+
+export const handler = middy(baseHandler)
+  .use(IpCheckerMiddleware())
+  .use(xssSanitizer())
+  .use(jsonBodyParser())
+  .use(validator({ inputSchema: wrapSchema(internalSchema.Environment) }))
+  .use(errorHandlingMiddleware())
+  .use(JSONErrorHandlerMiddleware())
+  .use(cors(CORS_CONFIGURATION));

--- a/packages/api/repository/EnvironmentRepository.ts
+++ b/packages/api/repository/EnvironmentRepository.ts
@@ -36,11 +36,12 @@ export class EnvironmentRepository extends Repository<Environment> {
       .getManyAndCount();
   }
 
-  getAllEnvironmentNames(applicationId: string): Promise<Array<Environment>> {
-    return this.createQueryBuilder("environment")
+  async getAllEnvironmentNames(applicationId: string): Promise<Array<string>> {
+    const environments = await this.createQueryBuilder("environment")
       .select(["environment.name"])
       .where("environment.applicationId = :applicationId", { applicationId })
       .getMany();
+    return environments.map((env) => env.name);
   }
 
   // POST create new environment
@@ -49,13 +50,14 @@ export class EnvironmentRepository extends Repository<Environment> {
   }
 
   // PUT update environment
-  updateEnvironment(id: string, overwrites: IEnvironment): Promise<UpdateResult> {
-    return this.update(id, {
+  async updateEnvironment(id: string, overwrites: IEnvironment): Promise<Environment> {
+    await this.update(id, {
       administrators: [],
       contributors: [],
       readOnlyOperators: [],
       ...overwrites,
     });
+    return this.getEnvironment(id);
   }
 
   // DELETE environment (hard delete)

--- a/packages/api/repository/EnvironmentRepository.ts
+++ b/packages/api/repository/EnvironmentRepository.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, Repository, InsertResult, UpdateResult } from "typeorm";
+import { EntityRepository, Repository, InsertResult } from "typeorm";
 import { Environment, IEnvironmentCreate, IEnvironment } from "../../orm/entity/Environment";
 
 @EntityRepository(Environment)

--- a/packages/api/repository/EnvironmentRepository.ts
+++ b/packages/api/repository/EnvironmentRepository.ts
@@ -49,8 +49,13 @@ export class EnvironmentRepository extends Repository<Environment> {
   }
 
   // PUT update environment
-  updateEnvironment(id: string, changes: IEnvironment): Promise<UpdateResult> {
-    return this.update(id, { ...changes });
+  updateEnvironment(id: string, overwrites: IEnvironment): Promise<UpdateResult> {
+    return this.update(id, {
+      administrators: [],
+      contributors: [],
+      readOnlyOperators: [],
+      ...overwrites,
+    });
   }
 
   // DELETE environment (hard delete)

--- a/packages/api/repository/EnvironmentRepository.ts
+++ b/packages/api/repository/EnvironmentRepository.ts
@@ -57,7 +57,7 @@ export class EnvironmentRepository extends Repository<Environment> {
       readOnlyOperators: [],
       ...overwrites,
     });
-    return this.getEnvironment(id);
+    return await this.getEnvironment(id);
   }
 
   // DELETE environment (hard delete)

--- a/packages/api/utils/businessRulesValidation.test.ts
+++ b/packages/api/utils/businessRulesValidation.test.ts
@@ -1,0 +1,9 @@
+import { uniqueNameValidator } from "./businessRulesValidation";
+
+describe("uniqueNameValidator", function () {
+  it("should throw an error if name is not unique", async () => {
+    const name = "unique name";
+    const names = ["not unique", "unique name"];
+    expect(() => uniqueNameValidator(name, names)).toThrowError("Duplicate name. Name must be unique.");
+  });
+});

--- a/packages/api/utils/businessRulesValidation.test.ts
+++ b/packages/api/utils/businessRulesValidation.test.ts
@@ -2,8 +2,8 @@ import { uniqueNameValidator } from "./businessRulesValidation";
 
 describe("uniqueNameValidator", function () {
   it("should throw an error if name is not unique", async () => {
-    const name = "unique name";
-    const names = ["not unique", "unique name"];
+    const name = "apple";
+    const names = ["orange", "apple"];
     expect(() => uniqueNameValidator(name, names)).toThrowError("Duplicate name. Name must be unique.");
   });
 });

--- a/packages/api/utils/businessRulesValidation.ts
+++ b/packages/api/utils/businessRulesValidation.ts
@@ -1,0 +1,20 @@
+import createError from "http-errors";
+
+/**
+ * Checks if a name is unique in an array of names and
+ * throws an error if there is a duplicate
+ *
+ * Used for Business rule 3.3 - ensure that names are unique
+ *
+ * @param name - name sent in by request body
+ * @param names - an array of names to check for duplication
+ * @returns void - throws an error if duplicate name found otherwise does nothing
+ */
+export function uniqueNameValidator(name: string, names: Array<string>): void {
+  if (names.includes(name)) {
+    throw createError(400, "Duplicate name. Name must be unique.", {
+      errorName: "DuplicateName",
+      duplicateName: name,
+    });
+  }
+}

--- a/packages/api/utils/errorHandlingMiddleware.ts
+++ b/packages/api/utils/errorHandlingMiddleware.ts
@@ -20,10 +20,10 @@ export const errorHandlingMiddleware = (): middy.MiddlewareObj<APIGatewayProxyEv
       console.log("Invalid parameter entered: " + JSON.stringify(error));
       return NO_SUCH_PORTFOLIO_OR_APPLICATION;
     }
-    if (error.errorName === "DuplicateEnvironmentName") {
+    if (error.errorName === "DuplicateName") {
       return new ValidationErrorResponse("Request failed validation (business rules)", {
-        issue: "Environment name already exists in this application",
-        name: error?.environmentName,
+        issue: "This name already exists",
+        name: error?.duplicateName,
       });
     }
 


### PR DESCRIPTION
Implement `PUT /portfolios/:portfolioId/applications/:applicationId/environments/:environmentId`

Add `updateEnvironment` operation to completely replace an environment by id 
(internal api - RDS endpoint) with tests only for local development to ensure the 
expected behavior.

Connect function with infrastructure.

Ticket: AT-6893