### PR TITLE
Implement patchEnvironment operation (RDS endpoint)

### DIFF
--- a/atat_internal_api.yaml
+++ b/atat_internal_api.yaml
@@ -866,11 +866,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ValidationError'
+        '404':
+          description: Portfolio, Application or Environment with the given ID does not exist
       x-amazon-apigateway-request-validator: "request-params-validator"
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${NotImplementedFunction.Arn}/invocations"
+          Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PatchEnvironmentFunction.Arn}/invocations"
         type: "aws_proxy"
       security:
         Fn::If:
@@ -2015,6 +2017,7 @@ components:
         Represents a set of Operators who should be granted access to
         an Application or Environment at a specific access level. The same access
         levels are available for both Applications & Environments.
+      type: object
       properties:
         administrators:
           type: array

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -152,6 +152,7 @@ export class AtatWebApiStack extends cdk.Stack {
     // Portfolios Operations using the internal API spec
     this.addDatabaseApiFunction("createEnvironment", "portfolios/environments/", props.vpc, TablePermissions.WRITE);
     this.addDatabaseApiFunction("updateEnvironment", "portfolios/environments/", props.vpc, TablePermissions.WRITE);
+    this.addDatabaseApiFunction("patchEnvironment", "portfolios/environments/", props.vpc, TablePermissions.WRITE);
 
     // PortfolioDraft Operations
     this.addDatabaseApiFunction("getPortfolioDrafts", "portfolioDrafts/", props.vpc, TablePermissions.READ);

--- a/packages/api/portfolios/environments/patchEnvironment.test.ts
+++ b/packages/api/portfolios/environments/patchEnvironment.test.ts
@@ -1,0 +1,68 @@
+import { handler } from "./patchEnvironment";
+import { Context } from "aws-lambda";
+import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
+import { IEnvironment, IEnvironmentOperators } from "../../../orm/entity/Environment";
+import { ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
+
+describe("patchEnvironment", () => {
+  it.skip("successful operation testing locally only", async () => {
+    const validRequest: ApiGatewayEventParsed<IEnvironmentOperators> = {
+      body: {
+        administrators: ["admin1@mail.mil", "admin2@mail.mil"],
+        // contributors: ["worker@mail.mil"],
+        // readOnlyOperators: ["@mail.mil"],
+      },
+      pathParameters: {
+        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
+        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
+        environmentId: "fe9274d4-6045-4e9d-97da-65e63980a1b1",
+      },
+      requestContext: { identity: { sourceIp: "7.7.7.7" } },
+    } as any;
+    const result = await handler(validRequest, {} as Context, () => null);
+    console.log(result?.body);
+    expect(result?.statusCode).toBe(SuccessStatusCode.OK);
+  });
+  it.skip("portfolioId not found error, testing locally only", async () => {
+    const validRequest: ApiGatewayEventParsed<IEnvironment> = {
+      body: { administrators: ["admin@mail.mil"] },
+      pathParameters: {
+        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad5", // bad portfolio Id
+        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
+        environmentId: "fe9274d4-6045-4e9d-97da-65e63980a1b1",
+      },
+      requestContext: { identity: { sourceIp: "7.7.7.7" } },
+    } as any;
+    const result = await handler(validRequest, {} as Context, () => null);
+    console.log(result?.body);
+    expect(result?.statusCode).toBe(ErrorStatusCode.NOT_FOUND);
+  });
+  it.skip("applicationId not found error, testing locally only", async () => {
+    const validRequest: ApiGatewayEventParsed<IEnvironment> = {
+      body: { administrators: ["admin@mail.mil"] },
+      pathParameters: {
+        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
+        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70864", // bad application Id
+        environmentId: "fe9274d4-6045-4e9d-97da-65e63980a1b1",
+      },
+      requestContext: { identity: { sourceIp: "7.7.7.7" } },
+    } as any;
+    const result = await handler(validRequest, {} as Context, () => null);
+    console.log(result?.body);
+    expect(result?.statusCode).toBe(ErrorStatusCode.NOT_FOUND);
+  });
+  it.skip("environmentId not found error, testing locally only", async () => {
+    const validRequest: ApiGatewayEventParsed<IEnvironment> = {
+      body: { administrators: ["admin@mail.mil"] },
+      pathParameters: {
+        portfolioId: "91c6bd1f-5ed8-413b-8f85-55a62dd50ad3",
+        applicationId: "7bc938ca-4c1c-4740-8ccf-18c940a70862",
+        environmentId: "fe9274d4-6045-4e9d-97da-65e63980a1b5", // bad environment Id
+      },
+      requestContext: { identity: { sourceIp: "7.7.7.7" } },
+    } as any;
+    const result = await handler(validRequest, {} as Context, () => null);
+    console.log(result?.body);
+    expect(result?.statusCode).toBe(ErrorStatusCode.NOT_FOUND);
+  });
+});

--- a/packages/api/portfolios/environments/patchEnvironment.ts
+++ b/packages/api/portfolios/environments/patchEnvironment.ts
@@ -6,24 +6,24 @@ import { Environment, IEnvironmentOperators } from "../../../orm/entity/Environm
 import { EnvironmentRepository } from "../../repository/EnvironmentRepository";
 import { APIGatewayProxyResult, Context } from "aws-lambda";
 import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
-import internalSchema = require("../../models/internalSchema.json");
+import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
+import { validateRequestShape } from "../../utils/shapeValidator";
 import middy from "@middy/core";
-import xssSanitizer from "../../utils/xssSanitizer";
+import internalSchema = require("../../models/internalSchema.json");
+import { wrapSchema } from "../../utils/schemaWrapper";
+import { IpCheckerMiddleware } from "../../utils/ipLogging";
 import jsonBodyParser from "@middy/http-json-body-parser";
+import xssSanitizer from "../../utils/xssSanitizer";
 import validator from "@middy/validator";
 import JSONErrorHandlerMiddleware from "middy-middleware-json-error-handler";
-import cors from "@middy/http-cors";
-import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
-import { CORS_CONFIGURATION } from "../../utils/corsConfig";
-import { wrapSchema } from "../../utils/schemaWrapper";
 import { errorHandlingMiddleware } from "../../utils/errorHandlingMiddleware";
-import { IpCheckerMiddleware } from "../../utils/ipLogging";
-import { validateRequestShape } from "../../utils/shapeValidator";
+import cors from "@middy/http-cors";
+import { CORS_CONFIGURATION } from "../../utils/corsConfig";
 
 /**
- * Submits an update to an environment of an application
+ * Submits a request to update the operators of an environment
  *
- * @param event - The PUT request from API Gateway
+ * @param event - The PATCH request from API Gateway
  */
 export async function baseHandler(
   event: ApiGatewayEventParsed<IEnvironmentOperators>,

--- a/packages/api/portfolios/environments/patchEnvironment.ts
+++ b/packages/api/portfolios/environments/patchEnvironment.ts
@@ -1,0 +1,67 @@
+import "reflect-metadata";
+import { createConnection } from "../../utils/database";
+import { Portfolio } from "../../../orm/entity/Portfolio";
+import { Application } from "../../../orm/entity/Application";
+import { Environment, IEnvironmentOperators } from "../../../orm/entity/Environment";
+import { EnvironmentRepository } from "../../repository/EnvironmentRepository";
+import { APIGatewayProxyResult, Context } from "aws-lambda";
+import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
+import internalSchema = require("../../models/internalSchema.json");
+import middy from "@middy/core";
+import xssSanitizer from "../../utils/xssSanitizer";
+import jsonBodyParser from "@middy/http-json-body-parser";
+import validator from "@middy/validator";
+import JSONErrorHandlerMiddleware from "middy-middleware-json-error-handler";
+import cors from "@middy/http-cors";
+import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
+import { CORS_CONFIGURATION } from "../../utils/corsConfig";
+import { wrapSchema } from "../../utils/schemaWrapper";
+import { errorHandlingMiddleware } from "../../utils/errorHandlingMiddleware";
+import { IpCheckerMiddleware } from "../../utils/ipLogging";
+import { validateRequestShape } from "../../utils/shapeValidator";
+
+/**
+ * Submits an update to an environment of an application
+ *
+ * @param event - The PUT request from API Gateway
+ */
+export async function baseHandler(
+  event: ApiGatewayEventParsed<IEnvironmentOperators>,
+  context?: Context
+): Promise<APIGatewayProxyResult> {
+  const setupResult = validateRequestShape<IEnvironmentOperators>(event);
+  const { portfolioId, applicationId, environmentId } = setupResult.path;
+  const requestBody = setupResult.bodyObject;
+
+  // set up database connection
+  const connection = await createConnection();
+  const environmentRepository = connection.getCustomRepository(EnvironmentRepository);
+  let response: Environment;
+
+  try {
+    // ensures the portfolio, application, and environment id exists
+    await connection.getRepository(Portfolio).findOneOrFail({
+      id: portfolioId,
+    });
+    await connection.getRepository(Application).findOneOrFail({
+      id: applicationId,
+    });
+    const environment = await environmentRepository.findOneOrFail({ id: environmentId });
+
+    response = await environmentRepository.patchEnvironment(environment.id, requestBody);
+    console.log("Patched Environment: " + JSON.stringify(response));
+  } finally {
+    connection.close();
+  }
+
+  return new ApiSuccessResponse<Environment>(response, SuccessStatusCode.OK);
+}
+
+export const handler = middy(baseHandler)
+  .use(IpCheckerMiddleware())
+  .use(xssSanitizer())
+  .use(jsonBodyParser())
+  .use(validator({ inputSchema: wrapSchema(internalSchema.AppEnvAccess) }))
+  .use(errorHandlingMiddleware())
+  .use(JSONErrorHandlerMiddleware())
+  .use(cors(CORS_CONFIGURATION));

--- a/packages/api/repository/EnvironmentRepository.ts
+++ b/packages/api/repository/EnvironmentRepository.ts
@@ -1,5 +1,5 @@
 import { EntityRepository, Repository, InsertResult } from "typeorm";
-import { Environment, IEnvironmentCreate, IEnvironment } from "../../orm/entity/Environment";
+import { Environment, IEnvironmentCreate, IEnvironment, IEnvironmentOperators } from "../../orm/entity/Environment";
 
 @EntityRepository(Environment)
 export class EnvironmentRepository extends Repository<Environment> {
@@ -58,6 +58,12 @@ export class EnvironmentRepository extends Repository<Environment> {
       ...overwrites,
     });
     return await this.getEnvironment(id);
+  }
+
+  // PATCH update environment operators only
+  async patchEnvironment(id: string, operators: IEnvironmentOperators): Promise<Environment> {
+    await this.update(id, { ...operators });
+    return this.getEnvironment(id);
   }
 
   // DELETE environment (hard delete)

--- a/packages/orm/entity/Environment.ts
+++ b/packages/orm/entity/Environment.ts
@@ -2,11 +2,13 @@ import { Application } from "./Application";
 import { Column, Entity, ManyToOne } from "typeorm";
 import { ProvisionableEntity } from "./ProvisionableEntity";
 
-export interface IEnvironment {
-  name: string;
+export interface IEnvironmentOperators {
   administrators?: Array<string>;
   contributors?: Array<string>;
   readOnlyOperators?: Array<string>;
+}
+export interface IEnvironment extends IEnvironmentOperators {
+  name: string;
 }
 export interface IEnvironmentCreate extends IEnvironment {
   application: Application;


### PR DESCRIPTION
Implement PATCH /portfolios/:portfolioId/applications/:applicationId/environments/:environmentId

Add `patchEnvironment` operation to update operators in an environment by id
(internal api - RDS endpoint) with tests only for local development to ensure the
expected behavior.

Connect function with infrastructure.

Ticket: AT-6893