### PR TITLE
Fix 500 errors on file upload

### DIFF
--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -23,8 +23,7 @@ import {
 } from "./constructs/compliant-resources";
 import { TaskOrderLifecycle } from "./constructs/task-order-lifecycle";
 import { HttpMethod } from "./http";
-import { TablePermissions } from "./table-permissions";
-import { QueuePermissions } from "./queue-permissions";
+import { TablePermissions, QueuePermissions, BucketPermissions } from "./resource-permissions";
 import * as utils from "./util";
 import { ApiFlexFunction, ApiFunctionPropstest } from "./constructs/lambda-fn";
 import { Database } from "./constructs/database";
@@ -507,6 +506,7 @@ export class AtatWebApiStack extends cdk.Stack {
       new ApiFlexFunction(this, "UploadTaskOrder", {
         lambdaVpc: props.vpc,
         bucket: taskOrderManagement.pendingBucket,
+        bucketPermissions: BucketPermissions.PUT,
         method: HttpMethod.POST,
         handlerPath: this.determineApiHandlerPath("uploadTaskOrder", "taskOrderFiles/"),
         functionPropsOverride: {
@@ -517,6 +517,7 @@ export class AtatWebApiStack extends cdk.Stack {
         lambdaVpc: props.vpc,
         bucket: taskOrderManagement.acceptedBucket,
         method: HttpMethod.DELETE,
+        bucketPermissions: BucketPermissions.DELETE,
         handlerPath: this.determineApiHandlerPath("deleteTaskOrder", "taskOrderFiles/"),
       }).fn
     );

--- a/infrastructure/lib/constructs/lambda-fn.ts
+++ b/infrastructure/lib/constructs/lambda-fn.ts
@@ -12,7 +12,7 @@ import * as sqs from "@aws-cdk/aws-sqs";
 import { SqsEventSource } from "@aws-cdk/aws-lambda-event-sources";
 import * as sfn from "@aws-cdk/aws-stepfunctions";
 import { Database } from "./database";
-import { TablePermissions } from "../table-permissions";
+import { TablePermissions, QueuePermissions, BucketPermissions } from "../resource-permissions";
 
 /**
  * The path within the Lambda function where the RDS CA Bundle is stored.
@@ -90,7 +90,7 @@ export interface ApiFunctionPropstest {
    *
    * @default - Read access is given to the Lambda function if no value is specified.
    */
-  readonly bucketPermissions?: string;
+  readonly bucketPermissions?: BucketPermissions;
 
   /**
    * The SQS queue where messages are sent
@@ -103,7 +103,7 @@ export interface ApiFunctionPropstest {
    *
    * @default - Read access is given to the Lambda function if no value is specified.
    */
-  readonly queuePermissions?: string;
+  readonly queuePermissions?: QueuePermissions;
 
   /**
    * Optional param to create an SQS event source to receive queue messages
@@ -239,39 +239,39 @@ export class ApiFlexFunction extends cdk.Construct {
     }
   }
 
-  private grantTablePermissions(tablePermissions: string | undefined): iam.Grant | undefined {
+  private grantTablePermissions(tablePermissions?: TablePermissions): iam.Grant | undefined {
     switch (tablePermissions) {
-      case "ALL":
+      case TablePermissions.ALL:
         return this.table.grantFullAccess(this.fn);
-      case "READ":
+      case TablePermissions.READ:
         return this.table.grantReadData(this.fn);
-      case "READ_WRITE":
+      case TablePermissions.READ_WRITE:
         return this.table.grantReadWriteData(this.fn);
-      case "WRITE":
+      case TablePermissions.WRITE:
         return this.table.grantWriteData(this.fn);
       default:
         return this.table.grantReadWriteData(this.fn);
     }
   }
 
-  private grantBucketPermissions(bucketPermissions: string | undefined): iam.Grant | undefined {
+  private grantBucketPermissions(bucketPermissions?: BucketPermissions): iam.Grant | undefined {
     switch (bucketPermissions) {
-      case "READ":
+      case BucketPermissions.READ:
         return this.bucket.grantRead(this.fn);
-      case "PUT":
+      case BucketPermissions.PUT:
         return this.bucket.grantPut(this.fn);
-      case "DELETE":
+      case BucketPermissions.DELETE:
         return this.bucket.grantDelete(this.fn);
       default:
         return this.bucket.grantRead(this.fn);
     }
   }
 
-  private grantSQSPermissions(queuePermissions: string | undefined): iam.Grant | undefined {
+  private grantSQSPermissions(queuePermissions?: QueuePermissions): iam.Grant | undefined {
     switch (queuePermissions) {
-      case "SEND":
+      case QueuePermissions.SEND:
         return this.queue.grantSendMessages(this.fn);
-      case "CONSUME":
+      case QueuePermissions.CONSUME:
         return this.queue.grantConsumeMessages(this.fn);
       default:
         return this.queue.grantSendMessages(this.fn);

--- a/infrastructure/lib/queue-permissions.ts
+++ b/infrastructure/lib/queue-permissions.ts
@@ -1,7 +1,0 @@
-/**
- * Supported Queue Permissions for the application.
- */
-export enum QueuePermissions {
-  SEND = "SEND",
-  CONSUME = "CONSUME",
-}

--- a/infrastructure/lib/resource-permissions.ts
+++ b/infrastructure/lib/resource-permissions.ts
@@ -1,0 +1,26 @@
+/**
+ * Supported Queue Permissions for the application.
+ */
+export enum QueuePermissions {
+  SEND = "SEND",
+  CONSUME = "CONSUME",
+}
+
+/**
+ * Supported Table Permissions for the application.
+ */
+export enum TablePermissions {
+  ALL = "ALL",
+  READ = "READ",
+  READ_WRITE = "READ_WRITE",
+  WRITE = "WRITE",
+}
+
+/**
+ * Supported permissions on an S3 bucket.
+ */
+export enum BucketPermissions {
+  READ = "READ",
+  PUT = "PUT",
+  DELETE = "DELETE",
+}

--- a/infrastructure/lib/table-permissions.ts
+++ b/infrastructure/lib/table-permissions.ts
@@ -1,9 +1,0 @@
-/**
- * Supported Table Permissions for the application.
- */
-export enum TablePermissions {
-  ALL = "ALL",
-  READ = "READ",
-  READ_WRITE = "READ_WRITE",
-  WRITE = "WRITE",
-}


### PR DESCRIPTION
There were errors during file upload due to a missing S3 bucket name
parameter. This ensures that is added by setting permissions between the
function(s) and the bucket.
