### PR TITLE
Implement getApplication function

### DIFF
--- a/atat_internal_api.yaml
+++ b/atat_internal_api.yaml
@@ -410,7 +410,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${NotImplementedFunction.Arn}/invocations"
+          Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetApplicationFunction.Arn}/invocations"
         type: "aws_proxy"
       security:
         Fn::If:

--- a/infrastructure/lib/atat-web-api-stack.ts
+++ b/infrastructure/lib/atat-web-api-stack.ts
@@ -198,6 +198,7 @@ export class AtatWebApiStack extends cdk.Stack {
 
     // Internal API Operations
     this.addDatabaseApiFunction("createApplication", "portfolios/application/", props.vpc, TablePermissions.WRITE);
+    this.addDatabaseApiFunction("getApplication", "portfolios/application/", props.vpc, TablePermissions.READ);
 
     // The API spec, which just so happens to be a valid CloudFormation snippet (with some actual CloudFormation
     // in it) gets uploaded to S3. The Asset resource reuses the same bucket that the CDK does, so this does not

--- a/packages/api/portfolios/application/getApplication.test.ts
+++ b/packages/api/portfolios/application/getApplication.test.ts
@@ -1,0 +1,39 @@
+import { handler } from "../application/getApplication";
+import { Context } from "aws-lambda";
+import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
+import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
+import { ErrorStatusCode } from "../../../email/utils/statusCodesAndErrors";
+
+const validRequest: ApiGatewayEventParsed<any> = {
+  body: {},
+  pathParameters: {
+    portfolioId: "8e935e1c-cbc9-4db5-81dd-d811652d2b8f",
+    applicationId: "1af0d060-5eb9-4817-8a34-c6cd5ec69b05",
+  },
+} as any;
+// These local tests only work the proper local db environment
+describe("Local createApplication tests", () => {
+  it.skip("should return valid Application", async () => {
+    const result = await handler(validRequest, {} as Context, () => null);
+    console.log(result);
+    expect(result).toBeInstanceOf(ApiSuccessResponse);
+    expect(result?.statusCode).toEqual(SuccessStatusCode.CREATED);
+  });
+});
+// Validation tests
+describe("Validation tests", () => {
+  it("should fail due to having an incorrect path parameter", async () => {
+    const validRequest: ApiGatewayEventParsed<any> = {
+      body: {},
+      pathParameters: {
+        portfolioId: "wrong",
+        applicationId: "also wrong", // both path params will trigger 404 due to not being UUIDv4
+      },
+      requestContext: { identity: { sourceIp: "7.7.7.7" } },
+    } as any;
+
+    const result = await handler(validRequest, {} as Context, () => null);
+    console.log(result?.body);
+    expect(result?.statusCode).toBe(ErrorStatusCode.NOT_FOUND);
+  });
+});

--- a/packages/api/portfolios/application/getApplication.ts
+++ b/packages/api/portfolios/application/getApplication.ts
@@ -17,7 +17,7 @@ import { ApplicationRepository } from "../../repository/ApplicationRepository";
 /**
  * Retrieve an Application based on applicationId
  *
- * @param event - The POST request from API Gateway
+ * @param event - The GET request from API Gateway
  */
 export async function baseHandler(
   event: ApiGatewayEventParsed<Application>,

--- a/packages/api/portfolios/application/getApplication.ts
+++ b/packages/api/portfolios/application/getApplication.ts
@@ -39,7 +39,7 @@ export async function baseHandler(
     connection.close();
   }
 
-  return new ApiSuccessResponse<IApplicationCreate>(response, SuccessStatusCode.CREATED);
+  return new ApiSuccessResponse<IApplicationCreate>(response, SuccessStatusCode.OK);
 }
 
 export const handler = middy(baseHandler)

--- a/packages/api/portfolios/application/getApplication.ts
+++ b/packages/api/portfolios/application/getApplication.ts
@@ -1,0 +1,50 @@
+import "reflect-metadata";
+import { APIGatewayProxyResult, Context } from "aws-lambda";
+import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
+import middy from "@middy/core";
+import xssSanitizer from "../../utils/xssSanitizer";
+import jsonBodyParser from "@middy/http-json-body-parser";
+import JSONErrorHandlerMiddleware from "middy-middleware-json-error-handler";
+import cors from "@middy/http-cors";
+import { ApiGatewayEventParsed } from "../../utils/eventHandlingTool";
+import { validateRequestShape } from "../../utils/shapeValidator";
+import { CORS_CONFIGURATION } from "../../utils/corsConfig";
+import { errorHandlingMiddleware } from "../../utils/errorHandlingMiddleware";
+import { Application, IApplicationCreate } from "../../../orm/entity/Application";
+import { createConnection } from "../../utils/database";
+import { ApplicationRepository } from "../../repository/ApplicationRepository";
+
+/**
+ * Retrieve an Application based on applicationId
+ *
+ * @param event - The POST request from API Gateway
+ */
+export async function baseHandler(
+  event: ApiGatewayEventParsed<Application>,
+  context?: Context
+): Promise<APIGatewayProxyResult> {
+  validateRequestShape<Application>(event);
+  // it seems that we don't even need the portfolioId for this operation
+  // we should bring this up to Jeff, and see what he thinks
+  const portfolioId = event.pathParameters?.portfolioId as string;
+  const applicationId = event.pathParameters?.applicationId as string;
+  let response;
+  // Establish database connection
+  const connection = await createConnection();
+  try {
+    // Retrieve application based on applicationId
+    response = await connection.getCustomRepository(ApplicationRepository).getApplication(applicationId);
+    console.log("Response:" + JSON.stringify(response));
+  } finally {
+    connection.close();
+  }
+
+  return new ApiSuccessResponse<IApplicationCreate>(response, SuccessStatusCode.CREATED);
+}
+
+export const handler = middy(baseHandler)
+  .use(xssSanitizer())
+  .use(jsonBodyParser())
+  .use(errorHandlingMiddleware())
+  .use(JSONErrorHandlerMiddleware())
+  .use(cors(CORS_CONFIGURATION));

--- a/packages/api/repository/ApplicationRepository.ts
+++ b/packages/api/repository/ApplicationRepository.ts
@@ -25,7 +25,6 @@ export class ApplicationRepository extends Repository<Application> {
         "administrators",
         "contributors",
         "readOnlyOperators",
-        "provisioningStatus",
       ],
       where: { id: applicationId },
       relations: ["environments"],


### PR DESCRIPTION
## Overview
Implemented GET `/portfolios/:portfolioId/applications/:applicationId`, which returns an Application based on the provided ApplicationId.

This request is interesting because `portfolioid` is part of the path, but it is **NOT** used in the actual retrieval or validation of the Application. Perhaps we should revised this API route in the future.


### Testing
In the **Atat Sandbox Dev** environment, the portfolioId required to make these requests is:
**portfolioId: `f215450e-8bc9-4c09-8cf2-f0377a9784e9`**

Use this ID with **POST** CreateApplication, which will return an **id** in the response, this **id** can be used with
**GET** GetApplication as the **applicationId**
![example request](https://user-images.githubusercontent.com/84199040/146665983-c5161a6d-0070-4f0b-adda-6e77dc128e9e.png)



Feature/at 6886