### PR TITLE
Add secret scanning with `detect-secrets`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# The Code Maintainers team owns the secret-scanning relating files
+# within the repository. Any change to these files will require
+# review from a member of the team.
+.secrets.baseline       @dod-ccpo/atat-code-maintainers
+.pre-commit-config.yaml @dod-ccpo/atat-code-maintainers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,3 +82,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  secretScan:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+          architecture: "x64"
+      - name: Install detect-secrets
+        run: pip install detect-secrets
+      - name: Scan for new (not-yet-allowed) secrets
+        run: >-
+          git ls-files -z |
+          xargs -0 detect-secrets-hook --baseline .secrets.baseline --exclude-files
+          'package-lock.json'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.2.0
+    hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,119 @@
+{
+  "version": "1.2.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "lib/atat-iam-stack.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "lib/atat-iam-stack.ts",
+        "hashed_secret": "f5dd2504ca1677707cb687397fe01f98a1c08fab",
+        "is_verified": false,
+        "line_number": 190
+      }
+    ]
+  },
+  "generated_at": "2022-02-28T00:22:49Z"
+}


### PR DESCRIPTION
This adds base secret scanning capabilities using the
`Yelp/detect-secrets` project which we've used before. For now, a
`.pre-commit-config.yaml` is added which we will require using as part
of AT-7100 (but it's added now for convenience and to demonstrate that
the selected secret scanning tool works with pre-commit).

Going forward, secrets can be added to the `.secrets.baseline` file;
however, modifying that file requires review from a member of the
`@dod-ccpo/atat-code-maintainers` team.

Additionally secrets going forward can be added to the allowlist in the
baseline file by running detect-secrets scan.

Ticket: AT-7099
