### PR TITLE
Create additional CDK unit tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -106,6 +106,12 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "package-lock.json"
+      ]
     }
   ],
   "results": {
@@ -115,9 +121,9 @@
         "filename": "lib/atat-iam-stack.ts",
         "hashed_secret": "cbc1f47e57ba98544b156d9f7d45542e9475686f",
         "is_verified": false,
-        "line_number": 198
+        "line_number": 199
       }
     ]
   },
-  "generated_at": "2022-03-02T13:42:48Z"
+  "generated_at": "2022-03-09T20:39:04Z"
 }

--- a/lib/atat-iam-stack.ts
+++ b/lib/atat-iam-stack.ts
@@ -116,6 +116,7 @@ export class AtatIamStack extends cdk.Stack {
     });
 
     const baseDenies = new iam.ManagedPolicy(this, "AtatUserDenyPolicy", {
+      description: "Denies access to all resources not explicitly granted in other IAM policies",
       statements: [
         new iam.PolicyStatement({
           sid: "DenyAllOrganizations",

--- a/lib/atat-iam-stack.ts
+++ b/lib/atat-iam-stack.ts
@@ -116,7 +116,7 @@ export class AtatIamStack extends cdk.Stack {
     });
 
     const baseDenies = new iam.ManagedPolicy(this, "AtatUserDenyPolicy", {
-      description: "Denies access to all resources not explicitly granted in other IAM policies",
+      description: "Denies access to sensitive resources and actions",
       statements: [
         new iam.PolicyStatement({
           sid: "DenyAllOrganizations",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=dod-ccpo_atat-web-api
 sonar.organization=dod-ccpo
 
-sonar.coverage.exclusions=**/*.js
+sonar.coverage.exclusions=**/*.js, bin/**
 sonar.test.inclusions=**/*.test.ts
 
 # According to https://docs.sonarqube.org/latest/analysis/coverage/, the following property should still

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=dod-ccpo_atat-web-api
 sonar.organization=dod-ccpo
 
-sonar.coverage.exclusions=**/*.js, bin/**
+sonar.coverage.exclusions=**/*.js,bin/**
 sonar.test.inclusions=**/*.test.ts
 
 # According to https://docs.sonarqube.org/latest/analysis/coverage/, the following property should still

--- a/test/apigateway.test.ts
+++ b/test/apigateway.test.ts
@@ -28,7 +28,6 @@ describe("ATAT apigateway construct creation", () => {
     testApigw.grantOnRoute(testUser, "*", "/");
     // THEN
     const template = Template.fromStack(stack);
-    // template.hasResourceProperties("AWS::IAM::Policy", {});
     template.hasResourceProperties(
       "AWS::IAM::Policy",
       Match.objectLike({

--- a/test/apigateway.test.ts
+++ b/test/apigateway.test.ts
@@ -1,8 +1,8 @@
 import * as cdk from "aws-cdk-lib";
-import { Match, Template } from "aws-cdk-lib/assertions";
-import { User } from "aws-cdk-lib/aws-iam";
-import { AtatRestApi, RestApiVpcConfiguration } from "../lib/constructs/apigateway";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as iam from "aws-cdk-lib/aws-iam";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { AtatRestApi, RestApiVpcConfiguration } from "../lib/constructs/apigateway";
 
 describe("ATAT apigateway construct creation", () => {
   test("Ensure AtatRestApi is created", async () => {

--- a/test/apigateway.test.ts
+++ b/test/apigateway.test.ts
@@ -1,0 +1,108 @@
+import * as cdk from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { User } from "aws-cdk-lib/aws-iam";
+import { AtatRestApi, RestApiVpcConfiguration } from "../lib/constructs/apigateway";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+
+describe("ATAT apigateway construct creation", () => {
+  test("Ensure AtatRestApi is created", async () => {
+    // GIVEN
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack");
+    // WHEN
+    const testApigw = new AtatRestApi(stack, "SampleApi");
+    testApigw.restApi.root.addMethod("ANY");
+    // THEN
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::ApiGateway::RestApi", {});
+  });
+
+  test("Ensure grantOnRoute method properly generates IAM policy with execute-api:Invoke action", async () => {
+    // GIVEN
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack");
+    // WHEN
+    const testApigw = new AtatRestApi(stack, "SampleApi");
+    testApigw.restApi.root.addMethod("ANY");
+    const testUser = new User(stack, "testUser");
+    testApigw.grantOnRoute(testUser, "*", "/");
+    // THEN
+    const template = Template.fromStack(stack);
+    // template.hasResourceProperties("AWS::IAM::Policy", {});
+    template.hasResourceProperties(
+      "AWS::IAM::Policy",
+      Match.objectLike({
+        PolicyDocument: {
+          Statement: [
+            {
+              Action: "execute-api:Invoke",
+              Effect: "Allow",
+            },
+          ],
+          Version: "2012-10-17",
+        },
+      })
+    );
+  });
+
+  test("Ensures AtatRestApi with vpcConfig in props properly sets EndpointConfiguration to PRIVATE", async () => {
+    // GIVEN
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack");
+    // WHEN
+    const vpc = new cdk.aws_ec2.Vpc(stack, "TestVpc", {});
+    const interfaceEndpoint = new cdk.aws_ec2.InterfaceVpcEndpoint(stack, "Test VPC Endpoint", {
+      vpc,
+      service: new ec2.InterfaceVpcEndpointService("test service", 443),
+    });
+    const vpcConfig = { vpc, interfaceEndpoint } as RestApiVpcConfiguration;
+    const testApigw = new AtatRestApi(stack, "SampleApi", { vpcConfig });
+    testApigw.restApi.root.addMethod("ANY");
+    // THEN
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties(
+      "AWS::ApiGateway::RestApi",
+      Match.objectLike({
+        EndpointConfiguration: {
+          Types: ["PRIVATE"],
+        },
+        Policy: {
+          Statement: [
+            {
+              Action: "execute-api:Invoke",
+              Effect: "Allow",
+              Principal: {
+                AWS: {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        Ref: "AWS::Partition",
+                      },
+                      ":iam::",
+                      {
+                        Ref: "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+              Resource: "execute-api:/*",
+            },
+            {
+              Action: "execute-api:Invoke",
+              Effect: "Deny",
+              Principal: {
+                AWS: "*",
+              },
+              Resource: "execute-api:/*",
+            },
+          ],
+          Version: "2012-10-17",
+        },
+      })
+    );
+  });
+});

--- a/test/apigateway.test.ts
+++ b/test/apigateway.test.ts
@@ -99,8 +99,8 @@ describe("ATAT apigateway construct creation", () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "TestStack");
     // WHEN
-    const vpc = new cdk.aws_ec2.Vpc(stack, "TestVpc", {});
-    const interfaceEndpoint = new cdk.aws_ec2.InterfaceVpcEndpoint(stack, "Test VPC Endpoint", {
+    const vpc = new ec2.Vpc(stack, "TestVpc", {});
+    const interfaceEndpoint = new ec2.InterfaceVpcEndpoint(stack, "Test VPC Endpoint", {
       vpc,
       service: new ec2.InterfaceVpcEndpointService("test service", 443),
     });

--- a/test/apigateway.test.ts
+++ b/test/apigateway.test.ts
@@ -90,7 +90,7 @@ describe("ATAT apigateway construct creation", () => {
         ],
         Version: "2012-10-17",
       },
-      Users: ["testUser"],
+      Users: [testUser.userName],
     });
   });
 

--- a/test/apigateway.test.ts
+++ b/test/apigateway.test.ts
@@ -28,20 +28,17 @@ describe("ATAT apigateway construct creation", () => {
     testApigw.grantOnRoute(testUser, "*", "/");
     // THEN
     const template = Template.fromStack(stack);
-    template.hasResourceProperties(
-      "AWS::IAM::Policy",
-      Match.objectLike({
-        PolicyDocument: {
-          Statement: [
-            {
-              Action: "execute-api:Invoke",
-              Effect: "Allow",
-            },
-          ],
-          Version: "2012-10-17",
-        },
-      })
-    );
+    template.hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: "execute-api:Invoke",
+            Effect: "Allow",
+          },
+        ],
+        Version: "2012-10-17",
+      },
+    });
   });
 
   test("Ensure grantOnRoute method properly attaches User to policy document", async () => {

--- a/test/apigateway.test.ts
+++ b/test/apigateway.test.ts
@@ -24,7 +24,7 @@ describe("ATAT apigateway construct creation", () => {
     // WHEN
     const testApigw = new AtatRestApi(stack, "SampleApi");
     testApigw.restApi.root.addMethod("ANY");
-    const testUser = new User(stack, "testUser");
+    const testUser = new iam.User(stack, "testUser");
     testApigw.grantOnRoute(testUser, "*", "/");
     // THEN
     const template = Template.fromStack(stack);
@@ -51,7 +51,7 @@ describe("ATAT apigateway construct creation", () => {
     // WHEN
     const testApigw = new AtatRestApi(stack, "SampleApi");
     testApigw.restApi.root.addMethod("ANY");
-    const testUser = User.fromUserName(stack, "sampleApiUser", "testUser");
+    const testUser = iam.User.fromUserName(stack, "sampleApiUser", "testUser");
     const routeName = "/testEndpoint";
     testApigw.grantOnRoute(testUser, "*", routeName);
     // THEN

--- a/test/atat-iam.test.ts
+++ b/test/atat-iam.test.ts
@@ -42,27 +42,6 @@ describe("ATAT IAM Policy creation", () => {
         PolicyDocument: {
           Statement: [
             {
-              Action: ["dynamodb:*GetItem", "dynamodb:PartiQLSelect", "dynamodb:Scan", "dynamodb:Query"],
-              Effect: "Allow",
-              Resource: {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      Ref: "AWS::Partition",
-                    },
-                    ":dynamodb:*:",
-                    {
-                      Ref: "AWS::AccountId",
-                    },
-                    ":table/*",
-                  ],
-                ],
-              },
-              Sid: "DynamoDBItemAccess",
-            },
-            {
               Action: "apigateway:GET",
               Effect: "Allow",
               Resource: {
@@ -193,15 +172,57 @@ describe("ATAT IAM Policy creation", () => {
               Sid: "AllowModifyingCdkToolBuckets",
             },
             {
-              Action: [
-                "dynamodb:RestoreTable*",
-                "dynamodb:ExportTableToPointInTime",
-                "dynamodb:ListBackups",
-                "dynamodb:Describe*Backup*",
-              ],
+              Action: "sts:AssumeRole",
               Effect: "Allow",
-              Resource: "*",
-              Sid: "AllowDynamoDbBackupRestore",
+              Resource: {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      Ref: "AWS::Partition",
+                    },
+                    ":iam::",
+                    {
+                      Ref: "AWS::AccountId",
+                    },
+                    ":role/cdk-hnb659fds-*-role-",
+                    {
+                      Ref: "AWS::AccountId",
+                    },
+                    "-",
+                    {
+                      Ref: "AWS::Region",
+                    },
+                  ],
+                ],
+              },
+              Sid: "AllowAssumingCdkRoles",
+            },
+            {
+              Action: "ssm:GetParameter",
+              Effect: "Allow",
+              Resource: {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      Ref: "AWS::Partition",
+                    },
+                    ":ssm:",
+                    {
+                      Ref: "AWS::Region",
+                    },
+                    ":",
+                    {
+                      Ref: "AWS::AccountId",
+                    },
+                    ":parameter/cdk-bootstrap/hnb659fds/*",
+                  ],
+                ],
+              },
+              Sid: "AllowReadingCdkParameters",
             },
           ],
           Version: "2012-10-17",

--- a/test/atat-iam.test.ts
+++ b/test/atat-iam.test.ts
@@ -25,15 +25,17 @@ describe("ATAT network creation", () => {
 });
 
 describe("ATAT IAM Policy creation", () => {
+  let app: cdk.App;
+  let stack: cdk.Stack;
+  let template: Template;
+
+  beforeEach(() => {
+    app = new cdk.App();
+    stack = new AtatIam.AtatIamStack(app, "TestIamStack", {});
+    template = Template.fromStack(stack);
+  });
+
   test("Fully assert generalReadAccess IAM managed policy with matchers", async () => {
-    // GIVEN
-    const app = new cdk.App();
-
-    // WHEN
-    const stack = new AtatIam.AtatIamStack(app, "TestIamStack", {});
-    const template = Template.fromStack(stack);
-
-    // THEN
     template.hasResourceProperties(
       "AWS::IAM::ManagedPolicy",
       Match.objectEquals({
@@ -108,6 +110,123 @@ describe("ATAT IAM Policy creation", () => {
           Version: "2012-10-17",
         },
         Description: "Grants read access to specific resources not in ViewOnlyAccess",
+        Path: "/",
+      })
+    );
+  });
+  test("Fully assert auditorAccess IAM managed policy with matchers", async () => {
+    template.hasResourceProperties(
+      "AWS::IAM::ManagedPolicy",
+      Match.objectEquals({
+        PolicyDocument: {
+          Statement: [
+            {
+              Action: "artifact:Get",
+              Effect: "Allow",
+              Resource: {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      Ref: "AWS::Partition",
+                    },
+                    ":artifact:::report-package/*",
+                  ],
+                ],
+              },
+              Sid: "AllowArtifactReportPackageAccess",
+            },
+            {
+              Action: "artifact:DownloadAgreement",
+              Effect: "Allow",
+              Resource: "*",
+              Sid: "AllowArtifactAgreementDownload",
+            },
+          ],
+          Version: "2012-10-17",
+        },
+        Description: "Grants additional security auditor access beyond SecurityAudit",
+        Path: "/",
+      })
+    );
+  });
+  test("Fully assert developerRwAccess IAM managed policy with matchers", async () => {
+    template.hasResourceProperties(
+      "AWS::IAM::ManagedPolicy",
+      Match.objectEquals({
+        PolicyDocument: {
+          Statement: [
+            {
+              Action: "s3:*",
+              Effect: "Allow",
+              Resource: [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        Ref: "AWS::Partition",
+                      },
+                      ":s3:::cdk-*-assets-",
+                      {
+                        Ref: "AWS::AccountId",
+                      },
+                      "-*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        Ref: "AWS::Partition",
+                      },
+                      ":s3:::cdktoolkit-stagingbucket-*",
+                    ],
+                  ],
+                },
+              ],
+              Sid: "AllowModifyingCdkToolBuckets",
+            },
+            {
+              Action: [
+                "dynamodb:RestoreTable*",
+                "dynamodb:ExportTableToPointInTime",
+                "dynamodb:ListBackups",
+                "dynamodb:Describe*Backup*",
+              ],
+              Effect: "Allow",
+              Resource: "*",
+              Sid: "AllowDynamoDbBackupRestore",
+            },
+          ],
+          Version: "2012-10-17",
+        },
+        Description: "Grants read/write access to developer-specific actions and resources",
+        Path: "/",
+      })
+    );
+  });
+  test("Fully assert baseDenies IAM managed policy with matchers", async () => {
+    template.hasResourceProperties(
+      "AWS::IAM::ManagedPolicy",
+      Match.objectEquals({
+        PolicyDocument: {
+          Statement: [
+            {
+              Action: "organizations:*",
+              Effect: "Deny",
+              Resource: "*",
+              Sid: "DenyAllOrganizations",
+            },
+          ],
+          Version: "2012-10-17",
+        },
+        Description: "",
         Path: "/",
       })
     );

--- a/test/atat-iam.test.ts
+++ b/test/atat-iam.test.ts
@@ -56,18 +56,18 @@ describe("ATAT IAM Policy creation", () => {
                   ],
                 ],
               },
-              Sid: "AllowArtifactReportPackageAccess",
+              Sid: Match.anyValue(),
             },
             {
               Action: "artifact:DownloadAgreement",
               Effect: "Allow",
               Resource: "*",
-              Sid: "AllowArtifactAgreementDownload",
+              Sid: Match.anyValue(),
             },
           ],
           Version: "2012-10-17",
         },
-        Description: "Grants additional security auditor access beyond SecurityAudit",
+        Description: Match.anyValue(),
         Path: "/",
       })
     );
@@ -111,7 +111,7 @@ describe("ATAT IAM Policy creation", () => {
                   ],
                 },
               ],
-              Sid: "AllowModifyingCdkToolBuckets",
+              Sid: Match.anyValue(),
             },
             {
               Action: "sts:AssumeRole",
@@ -139,7 +139,7 @@ describe("ATAT IAM Policy creation", () => {
                   ],
                 ],
               },
-              Sid: "AllowAssumingCdkRoles",
+              Sid: Match.anyValue(),
             },
             {
               Action: "ssm:GetParameter",
@@ -164,12 +164,12 @@ describe("ATAT IAM Policy creation", () => {
                   ],
                 ],
               },
-              Sid: "AllowReadingCdkParameters",
+              Sid: Match.anyValue(),
             },
           ],
           Version: "2012-10-17",
         },
-        Description: "Grants read/write access to developer-specific actions and resources",
+        Description: Match.anyValue(),
         Path: "/",
       })
     );
@@ -184,12 +184,12 @@ describe("ATAT IAM Policy creation", () => {
               Action: "organizations:*",
               Effect: "Deny",
               Resource: "*",
-              Sid: "DenyAllOrganizations",
+              Sid: Match.anyValue(),
             },
           ],
           Version: "2012-10-17",
         },
-        Description: "Denies access to all resources not explicitly granted in other IAM policies",
+        Description: Match.anyValue(),
         Path: "/",
       })
     );

--- a/test/atat-iam.test.ts
+++ b/test/atat-iam.test.ts
@@ -247,7 +247,7 @@ describe("ATAT IAM Policy creation", () => {
           ],
           Version: "2012-10-17",
         },
-        Description: "",
+        Description: "Denies access to all resources not explicitly granted in other IAM policies",
         Path: "/",
       })
     );

--- a/test/atat-iam.test.ts
+++ b/test/atat-iam.test.ts
@@ -1,5 +1,5 @@
 import * as cdk from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
+import { Match, Template } from "aws-cdk-lib/assertions";
 import * as AtatIam from "../lib/atat-iam-stack";
 
 describe("ATAT network creation", () => {
@@ -21,5 +21,95 @@ describe("ATAT network creation", () => {
     for (const output of expectedOutputNames) {
       template.hasOutput("*", { Export: { Name: output } });
     }
+  });
+});
+
+describe("ATAT IAM Policy creation", () => {
+  test("Fully assert generalReadAccess IAM managed policy with matchers", async () => {
+    // GIVEN
+    const app = new cdk.App();
+
+    // WHEN
+    const stack = new AtatIam.AtatIamStack(app, "TestIamStack", {});
+    const template = Template.fromStack(stack);
+
+    // THEN
+    template.hasResourceProperties(
+      "AWS::IAM::ManagedPolicy",
+      Match.objectEquals({
+        PolicyDocument: {
+          Statement: [
+            {
+              Action: ["dynamodb:*GetItem", "dynamodb:PartiQLSelect", "dynamodb:Scan", "dynamodb:Query"],
+              Effect: "Allow",
+              Resource: {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      Ref: "AWS::Partition",
+                    },
+                    ":dynamodb:*:",
+                    {
+                      Ref: "AWS::AccountId",
+                    },
+                    ":table/*",
+                  ],
+                ],
+              },
+              Sid: "DynamoDBItemAccess",
+            },
+            {
+              Action: "apigateway:GET",
+              Effect: "Allow",
+              Resource: {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      Ref: "AWS::Partition",
+                    },
+                    ":apigateway:*::/restapis*",
+                  ],
+                ],
+              },
+              Sid: "APIGatewayRestApiReadAccess",
+            },
+            {
+              Action: ["states:List*", "states:Describe*", "states:GetExecutionHistory"],
+              Effect: "Allow",
+              Resource: {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      Ref: "AWS::Partition",
+                    },
+                    ":states:*:",
+                    {
+                      Ref: "AWS::AccountId",
+                    },
+                    ":stateMachine:*",
+                  ],
+                ],
+              },
+              Sid: "StepFunctionsReadAccess",
+            },
+            {
+              Action: ["xray:BatchGetTraces", "xray:Get*", "xray:List*"],
+              Effect: "Allow",
+              Resource: "*",
+              Sid: "XRayReadAccess",
+            },
+          ],
+          Version: "2012-10-17",
+        },
+        Description: "Grants read access to specific resources not in ViewOnlyAccess",
+        Path: "/",
+      })
+    );
   });
 });

--- a/test/atat-iam.test.ts
+++ b/test/atat-iam.test.ts
@@ -35,64 +35,6 @@ describe("ATAT IAM Policy creation", () => {
     template = Template.fromStack(stack);
   });
 
-  test("Fully assert generalReadAccess IAM managed policy with matchers", async () => {
-    template.hasResourceProperties(
-      "AWS::IAM::ManagedPolicy",
-      Match.objectEquals({
-        PolicyDocument: {
-          Statement: [
-            {
-              Action: "apigateway:GET",
-              Effect: "Allow",
-              Resource: {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      Ref: "AWS::Partition",
-                    },
-                    ":apigateway:*::/restapis*",
-                  ],
-                ],
-              },
-              Sid: "APIGatewayRestApiReadAccess",
-            },
-            {
-              Action: ["states:List*", "states:Describe*", "states:GetExecutionHistory"],
-              Effect: "Allow",
-              Resource: {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      Ref: "AWS::Partition",
-                    },
-                    ":states:*:",
-                    {
-                      Ref: "AWS::AccountId",
-                    },
-                    ":stateMachine:*",
-                  ],
-                ],
-              },
-              Sid: "StepFunctionsReadAccess",
-            },
-            {
-              Action: ["xray:BatchGetTraces", "xray:Get*", "xray:List*"],
-              Effect: "Allow",
-              Resource: "*",
-              Sid: "XRayReadAccess",
-            },
-          ],
-          Version: "2012-10-17",
-        },
-        Description: "Grants read access to specific resources not in ViewOnlyAccess",
-        Path: "/",
-      })
-    );
-  });
   test("Fully assert auditorAccess IAM managed policy with matchers", async () => {
     template.hasResourceProperties(
       "AWS::IAM::ManagedPolicy",

--- a/test/atat-iam.test.ts
+++ b/test/atat-iam.test.ts
@@ -130,7 +130,7 @@ describe("ATAT IAM Policy creation", () => {
       })
     );
   });
-  test("Fully assert developerRwAccess IAM managed policy with matchers", async () => {
+  test("Ensure developers can access CDK-related resources", async () => {
     template.hasResourceProperties(
       "AWS::IAM::ManagedPolicy",
       Match.objectEquals({


### PR DESCRIPTION
## Overview
This PR involves creating additional unit tests to verify that the CloudFormation templates generated by CDK meet our expectations.

This included writing fine-grained assertions to test specific stacks (`atat-iam-stack`, `atat-net-stack`, and `atat-web-api-stack`)

### Resources used
Official CDK v2 documentation: https://docs.aws.amazon.com/cdk/v2/guide/testing.html