### PR TITLE
Update IAM configuration to work with CDKv2 roles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           npm ci
       - name: Synthesize CDK template
-        run: cdk synth
+        run: cdk synth -c "atat:EnvironmentId=CiTest"
       - name: Gather CloudFormation artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ node_modules
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+cdk.context.json
 
 coverage/

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -73,6 +73,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -109,11 +113,11 @@
       {
         "type": "Hex High Entropy String",
         "filename": "lib/atat-iam-stack.ts",
-        "hashed_secret": "f5dd2504ca1677707cb687397fe01f98a1c08fab",
+        "hashed_secret": "cbc1f47e57ba98544b156d9f7d45542e9475686f",
         "is_verified": false,
-        "line_number": 190
+        "line_number": 198
       }
     ]
   },
-  "generated_at": "2022-02-28T00:22:49Z"
+  "generated_at": "2022-03-02T13:42:48Z"
 }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 The ATAT Web API repo contains a set of services which enable ATAT Provisioning into vendor environments by way of the [ATAT CSP Specification](https://github.com/dod-ccpo/atat-csp-orchestration/blob/main/provisioning/atat_provisioning.yaml). It is implemented in a stateless fashion, using SQS Queues to pass information back to integrators. Initially, this API is only meant to be accessed by the Service Now component of ATAT, but it may be opened up to other integrators in the future.
 
-This is a blank project for TypeScript development with CDK.
-
-The `cdk.json` file tells the CDK Toolkit how to execute your app.
-
 ## Useful commands
 
  * `npm run build`   compile typescript to js
@@ -12,3 +8,33 @@ The `cdk.json` file tells the CDK Toolkit how to execute your app.
  * `cdk deploy`      deploy this stack to your default AWS account/region
  * `cdk diff`        compare deployed stack with current state
  * `cdk synth`       emits the synthesized CloudFormation template
+
+## Building an Application Environment
+
+The default deployment configuration in `cdk.json` is built for deploying an application
+environment, leveraging shared base infrastructure within an account. To deploy the
+application, run:
+
+```bash
+cdk diff -c atat:EnvironmentId=<ENVIRONMENT_ID>
+cdk deploy -c atat:EnvironmentId=<ENVIRONMENT_ID>
+```
+
+Replace `<ENVIRONMENT_ID>` with the name you want to use for your environment. This will
+show a diff and then actually deploy the applicaiton.
+
+## Building Base Infrastructure
+
+This is a more rare deployment that only needs to be performed when initially setting
+up a new AWS account or when changes have been made to one of the stacks deployed as
+part of this configuration. The base infrastructure is executed as a separate "app" and
+can be run by executing:
+
+```bash
+cdk diff -a 'npx ts-node --prefer-ts-exts bin/atat-base-infra.ts' -c atat:EnvironmentId=<ENVIRONMENT_ID>
+cdk deploy -a 'npx ts-node --prefer-ts-exts bin/atat-base-infra.ts' -c atat:EnvironmentId=<ENVIRONMENT_ID>
+```
+
+Because the base infrastructure app and stacks use named IAM that does not take the
+Environment ID into account, care must be taken to not deploy two instances of this
+into a single account.

--- a/bin/atat-base-infra.ts
+++ b/bin/atat-base-infra.ts
@@ -2,13 +2,16 @@
 import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 // import { NIST80053R4Checks, NIST80053R5Checks } from "cdk-nag";
-import { AtatWebApiStack } from "../lib/atat-web-api-stack";
+import { AtatIamStack } from "../lib/atat-iam-stack";
 import { GovCloudCompatibilityAspect } from "../lib/aspects/govcloud-compatibility";
-import { RemovalPolicySetter } from "../lib/aspects/removal-policy";
+import { AtatNetStack } from "../lib/atat-net-stack";
 import * as utils from "../lib/util";
 
 const app = new cdk.App();
-
+// These Aspects will not be enabled until more base infrastructure around KMS, etc
+// is in place.
+// cdk.Aspects.of(app).add(new NIST80053R4Checks({ verbose: true }));
+// cdk.Aspects.of(app).add(new NIST80053R5Checks({ verbose: true }));
 const environmentParam = app.node.tryGetContext("atat:EnvironmentId");
 
 if (!utils.isString(environmentParam)) {
@@ -19,16 +22,13 @@ if (!utils.isString(environmentParam)) {
 const environmentName = utils.normalizeEnvironmentName(environmentParam);
 const environmentId = utils.lowerCaseEnvironmentId(environmentParam);
 
-// Delete all resources in developer-specific sandbox environments by default, while
-// using the default for the specially-named long-lived "sandbox" resources, used
-// for persistent IAM configuration, etc.
-if (utils.isPossibleTemporaryEnvironment(environmentId)) {
-  cdk.Aspects.of(app).add(new RemovalPolicySetter({ globalRemovalPolicy: cdk.RemovalPolicy.DESTROY }));
-}
 // These Aspects will not be enabled until more base infrastructure around KMS, etc
 // is in place.
 // cdk.Aspects.of(app).add(new NIST80053R4Checks({ verbose: true }));
 // cdk.Aspects.of(app).add(new NIST80053R5Checks({ verbose: true }));
 cdk.Aspects.of(app).add(new GovCloudCompatibilityAspect());
 
-const apiStack = new AtatWebApiStack(app, `${environmentName}AtatWebApiStack`, {});
+// const netStack = new AtatNetStack(app, `${environmentName}AtatNetStack`, {
+//   vpcCidr: app.node.tryGetContext("atat:VpcCidr"),
+// });
+const iamStack = new AtatIamStack(app, `${environmentName}AtatIamStack`);

--- a/lib/aspects/removal-policy.ts
+++ b/lib/aspects/removal-policy.ts
@@ -1,0 +1,25 @@
+import * as cdk from "aws-cdk-lib";
+import { IConstruct } from "constructs";
+
+export interface RemovalPolicySetterProps {
+  globalRemovalPolicy?: cdk.RemovalPolicy;
+}
+
+/**
+ * Consistently apply a RemovalPolicy to all nodes in the tree.
+ */
+export class RemovalPolicySetter implements cdk.IAspect {
+  private readonly globalRemovalPolicy?: cdk.RemovalPolicy;
+  constructor(props?: RemovalPolicySetterProps) {
+    this.globalRemovalPolicy = props?.globalRemovalPolicy;
+  }
+
+  public visit(node: IConstruct): void {
+    // Removal policies must be set only (and directly) on CfnResource objects,
+    // the higher level constructs don't support it. We also should not set one
+    // if one was not provided (at the risk of returning it to undefined)
+    if (node instanceof cdk.CfnResource && this.globalRemovalPolicy) {
+      node.applyRemovalPolicy(this.globalRemovalPolicy);
+    }
+  }
+}

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,0 +1,64 @@
+const normalizationRejectionRegex = /[\W_]/g;
+
+/**
+ * Normalizes environment names.
+ *
+ * The first letter is capitalized and the rest is made lowercase.
+ * Any hyphens or other special characters are stripped.
+ *
+ * This ensures that accidentally typing "dev" doesn't result in a new
+ * environment from "Dev" and that ticket IDs such as "AT-0001" and
+ * "AT0001" are treated the same and still mostly look like ticket IDs.
+ *
+ * @param id The environment identifier
+ * @returns The normalized environment name
+ */
+export function normalizeEnvironmentName(id: string): string {
+  const strippedId = id.replace(normalizationRejectionRegex, "");
+  if (!strippedId) {
+    return strippedId;
+  }
+  return strippedId[0].toUpperCase() + lowerCaseEnvironmentId(strippedId.slice(1));
+}
+
+/**
+ * Normalize a lowercase version of the environment ID.
+ *
+ * In some scenarios, it is idiomatic (or required) to use a lowercase
+ * version of the environment ID without special characters. This
+ * strips all non-word characters, underscores, and hyphens and returns
+ * the lowercase identifier.
+ *
+ * @param id The environment identifier
+ * @returns the normalized lowercase identifier for the environment
+ */
+export function lowerCaseEnvironmentId(id: string): string {
+  return id.toLowerCase().replace(normalizationRejectionRegex, "");
+}
+
+/**
+ * Helper type guard to check whether an input is a string
+ * @param str the input to test
+ * @returns true if the input is a non-empty string and false otherwise
+ */
+export function isString(str: unknown): str is string {
+  if (str && typeof str === "string") {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Checks whether the given environment ID may be considered temporary or
+ * not. This is not a complete check and should be understood to be based on
+ * a general guess. Returning true does not necessarily mean the environment is
+ * absolutely temporary.
+ *
+ * @param environmentId the environment id to check
+ * @returns true if the environment ID looks like it is for a temporary environment
+ */
+// TODO: Replace with a more complete means of indicating an environment is not a
+// long-lived environment.
+export function isPossibleTemporaryEnvironment(environmentId: string): boolean {
+  return !/^(sandbox|dev|stag|prod)/.test(environmentId);
+}

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,0 +1,90 @@
+import * as utils from "../lib/util";
+
+const testEnvironmentIds = [
+  // Jira ticket ID-looking strings should be valid regardless of how they
+  // get entered
+  {
+    inputs: ["AT-0001", "AT0001", "at0001", "aT0001", "At0001", "AT_0_0_0_1"],
+    expectedName: "At0001",
+    expectedId: "at0001",
+  },
+  // And "special" environment names should work the same as sandbox environments
+  {
+    inputs: ["Dev", "Dev!", "dev", "DEV", "dEv", "_dev_"],
+    expectedName: "Dev",
+    expectedId: "dev",
+  },
+  {
+    inputs: ["Staging", "Staging!", "staging", "STAGING", "sTaGiNg", "_staging_"],
+    expectedName: "Staging",
+    expectedId: "staging",
+  },
+  {
+    inputs: ["Prod", "Prod!", "prod", "PROD", "PrOd", "_prod_"],
+    expectedName: "Prod",
+    expectedId: "prod",
+  },
+  // Numbered "special" environment names should be treated like any other
+  // string
+  {
+    inputs: ["Dev1", "dev1", "DEV1", "dEv1", "_dev1_", "Dev1!"],
+    expectedName: "Dev1",
+    expectedId: "dev1",
+  },
+  // Totally special or empty names should not break the function
+  {
+    inputs: ["", "&*(^&%^&$^%%*&", "_-__--_"],
+    expectedName: "",
+    expectedId: "",
+  },
+  // Even multi-word names get only one capital letter
+  {
+    inputs: ["LongEnvironmentName", "longenvironmentname", "lOnGeNvIrOnMeNtNaMe"],
+    expectedName: "Longenvironmentname",
+    expectedId: "longenvironmentname",
+  },
+  // Very short names should still work too
+  {
+    inputs: ["A", "a", "_A_", "_a_"],
+    expectedName: "A",
+    expectedId: "a",
+  },
+];
+
+describe("Validate environment normalization", () => {
+  it.each(["AT-1234", "&!@#!@", "", "at1234"])("should not contain special characters", async (testStr) => {
+    expect(utils.normalizeEnvironmentName(testStr)).not.toMatch(/[\W_-]+/g);
+  });
+
+  it.each(testEnvironmentIds)("should return a normalized name for ticket ID", async ({ inputs, expectedName }) => {
+    inputs.forEach((item) => expect(utils.normalizeEnvironmentName(item)).toEqual(expectedName));
+  });
+
+  it.each(testEnvironmentIds)("should return a normalized ID for ticket IDs", async ({ inputs, expectedId }) => {
+    inputs.forEach((item) => expect(utils.lowerCaseEnvironmentId(item)).toEqual(expectedId));
+  });
+});
+
+describe("Validate string type guards", () => {
+  it.each([1, {}, [], null, undefined, false, true])("should reject non-strings", async (item) => {
+    expect(utils.isString(item)).toEqual(false);
+  });
+  it("should reject the empty string", async () => {
+    expect(utils.isString("")).toEqual(false);
+  });
+  it.each(["a", "longstring", "1312987A*&(^&*AHL"])("should accept strings", async (item) => {
+    expect(utils.isString(item)).toEqual(true);
+  });
+});
+
+describe("Validate temporary environment", () => {
+  it.each(["dev", "sandbox", "staging", "prod", "development", "production"])(
+    "should return false for real-looking envs",
+    async (env) => {
+      expect(utils.isPossibleTemporaryEnvironment(env)).toBe(false);
+    }
+  );
+  it.each(["at1234", "usertestenv", "username20211108"])("should return true for generic names", async (env) => {
+    expect(utils.isPossibleTemporaryEnvironment(env)).toBe(true);
+  });
+});


### PR DESCRIPTION
The main changes to actually add the necessary permissions are in
`lib/atat-iam-stack.ts`. The remaining changes are simply adding
additional support code to make it easier to manage the deployments.

Eventually (but soon) we probably want to talk about identifying a path
to removing the `atat:EnvironmentId` context value as a requirement for
deploying the base infrastructure (since we really only want there to be
one per _account_ not per environment; and in some cases
account:environment may either be 1:1 or 1:N).
