### PR TITLE
Use FIPS endpoints for all AWS APIs

### DIFF
--- a/utils/aws-sdk/sqs.ts
+++ b/utils/aws-sdk/sqs.ts
@@ -1,4 +1,4 @@
 import { SQSClient } from "@aws-sdk/client-sqs";
 
 // Create SQS service object.
-export const sqsClient = new SQSClient({});
+export const sqsClient = new SQSClient({ useFipsEndpoint: true });

--- a/utils/aws-sdk/step-functions.ts
+++ b/utils/aws-sdk/step-functions.ts
@@ -1,3 +1,3 @@
 import { SFN } from "@aws-sdk/client-sfn";
 
-export const sfnClient = new SFN({});
+export const sfnClient = new SFN({ useFipsEndpoint: true });


### PR DESCRIPTION
The FIPS-compliant endpoints in the AWS SDK's `endpoints.json` file have
been updated to properly reflect the correct hostname.
