### PR TITLE
Update API Gateway provisioning resource name

### DIFF
--- a/lib/atat-web-api-stack.ts
+++ b/lib/atat-web-api-stack.ts
@@ -62,7 +62,7 @@ export class AtatWebApiStack extends cdk.Stack {
     });
 
     // APIGW Provisioning Job Resource
-    const provisioningJobResource = api.restApi.root.addResource("provisioning-job");
+    const provisioningJobResource = api.restApi.root.addResource("provisioning-jobs");
     provisioningJobResource.addMethod(provisioningJob.method, new apigw.LambdaIntegration(provisioningJob.fn));
     provisioningJobResource.addMethod(
       provisioningSfn.provisioningQueueConsumer.method,


### PR DESCRIPTION
Update the name of the provisioning job resource to match the specification `/provisioning-jobs`.

Ticket: AT-7078