### PR TITLE
Make pipeline track `develop` by default

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -29,7 +29,7 @@
       "aws-us-gov"
     ],
     "atat:GitHubPatName": "auth/github/pat",
-    "atat:VersionControlBranch": "feature/AT-7204",
+    "atat:VersionControlBranch": "develop",
     "atat:VersionControlRepo": "dod-ccpo/atat-web-api"
   }
 }


### PR DESCRIPTION
This couldn't be included in the initial PR because the pipeline was
already deployed and watching the feature branch. Had it switched to
watching develop before the pipeline was merged all sorts of wonkiness
could have occurred and I didn't really want to clean that up. This just
switches the default.
