### PR TITLE
Only give the PR test workflow read access

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
       - develop
       - main
 
+permissions:
+  contents: read
+
 jobs:
   assertPackageLockVersion:
     name: Ensure package-lock lockfileVersion has not changed


### PR DESCRIPTION
The default the [permissions on the GitHub token][1] grant a lot more
access than is actually required as part of this workflow, especially
for PRs that originate from within this repository. Because the
`GITHUB_TOKEN` is accessible not only via `secrets.GITHUB_TOKEN` but
also on the context object as `github.token`, theoretically, other
actions in use could access the secret. Limiting the permissions is a
good idea.

[1]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
