### PR TITLE
Make using the console easier

### DIFF
--- a/lib/atat-iam-stack.ts
+++ b/lib/atat-iam-stack.ts
@@ -76,6 +76,10 @@ export class AtatIamStack extends cdk.Stack {
         // Grant access to read the pipeline state
         new statement.Codepipeline().allReadActions(),
         new statement.Codebuild().allReadActions(),
+        // This allows listing/viewing functions in the AWS console
+        new statement.Lambda().allListActions().toGetAccountSettings().toGetFunction(),
+        // Allow developers to describe APIs
+        new statement.Apigateway().toGET().onAccount().onRestApis().onRestApi("*"),
       ],
     });
 

--- a/lib/atat-net-stack.ts
+++ b/lib/atat-net-stack.ts
@@ -59,7 +59,7 @@ export class AtatNetStack extends cdk.Stack {
     const tgwAttachment = new ec2.CfnTransitGatewayAttachment(this, "VpcTgwAttachment", {
       vpcId: vpc.vpcId,
       subnetIds: vpc.isolatedSubnets.map((subnet) => (subnet as ec2.Subnet).subnetId),
-      transitGatewayId: transitGatewayId,
+      transitGatewayId,
     });
     this.addDefaultTransitGatewayRoute(tgwAttachment);
 


### PR DESCRIPTION
This gives developers the ability to read and poke in the Lambda and API
Gateway consoles, permissions that may have been missing before. This
doesn't grant everything (and definitely not permission to invoke
anything) but hopefully it makes life a little easier.
