### PR TITLE
Cache IdP Client Secret

### DIFF
--- a/idp/client.ts
+++ b/idp/client.ts
@@ -9,6 +9,7 @@ const logger = new Logger({ serviceName: "TestIdp" });
 const IDP_CLIENT_ID = process.env.IDP_CLIENT_ID!;
 const IDP_CLIENT_SECRET_NAME = process.env.IDP_CLIENT_SECRET_NAME!;
 const IDP_DOMAIN = process.env.IDP_DOMAIN!;
+const IDP_CLIENT_SECRET = fetchClientSecret(IDP_CLIENT_SECRET_NAME);
 
 /**
  * Very basic encoding of the Cognito TOKEN endpoint response objects.
@@ -115,7 +116,7 @@ export async function handler(_event: Record<string, never>, context: Context): 
   try {
     const response = await getToken(
       IDP_CLIENT_ID,
-      await fetchClientSecret(IDP_CLIENT_SECRET_NAME),
+      IDP_CLIENT_SECRET,
       `https://${IDP_DOMAIN}`,
       context.getRemainingTimeInMillis() - 500,
       ["atat/read-cost"]


### PR DESCRIPTION
We should eagerly fetch the client secret and then cache it. Having to
look it up for every request is slow. The string will be stored
in-memory within the execution environment but not permanently as part
of the Environment configuration.

This follows the [recommendations to cache secrets][1].

[1]: https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets.html
