### PR TITLE
Retain Step Function logs indefinitely

### DIFF
--- a/lib/constructs/provisioning-sfn-workflow.ts
+++ b/lib/constructs/provisioning-sfn-workflow.ts
@@ -134,7 +134,7 @@ export class ProvisioningWorkflow extends Construct implements IProvisioningWork
     // Composing state machine
     this.workflow = InvokeCspApi.sfnTask.next(httpResponseChoices);
     this.logGroup = new logs.LogGroup(scope, "StepFunctionsLogs", {
-      retention: logs.RetentionDays.ONE_WEEK,
+      retention: logs.RetentionDays.INFINITE,
       logGroupName: `/aws/vendedlogs/states/StepFunctionsLogs${environmentName}`,
     });
     this.stateMachine = new StateMachine(this, "ProvisioningStateMachine", {


### PR DESCRIPTION
This matches what the defaults are for Lambda and we can add a more
strict retention period further down the road
