### PR TITLE
Configure logs for indefinite retention

### DIFF
--- a/lib/atat-net-stack.ts
+++ b/lib/atat-net-stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as logs from "aws-cdk-lib/aws-logs";
 import * as custom from "aws-cdk-lib/custom-resources";
 
 import { Construct } from "constructs";
@@ -45,8 +46,15 @@ export class AtatNetStack extends cdk.Stack {
         },
       ],
     });
-    // Default is capturing all logs and pushing to CloudWatchLogs
-    vpc.addFlowLog("AllFlowLogs");
+
+    // Capture all VPC flow logs and send to CloudWatch Logs with indefinite retention
+    vpc.addFlowLog("AllFlowLogs", {
+      destination: ec2.FlowLogDestination.toCloudWatchLogs(
+        new logs.LogGroup(this, "AllFlowLogs", {
+          retention: logs.RetentionDays.INFINITE,
+        })
+      ),
+    });
     this.vpc = vpc;
     this.outputs.push(
       new cdk.CfnOutput(this, "VpcId", {

--- a/lib/constructs/apigateway.ts
+++ b/lib/constructs/apigateway.ts
@@ -50,7 +50,9 @@ export class AtatRestApi extends Construct {
 
   constructor(scope: Construct, id: string, props?: AtatRestApiProps) {
     super(scope, id);
-    const accessLogs = new logs.LogGroup(this, "AccessLogs");
+    const accessLogs = new logs.LogGroup(this, "AccessLogs", {
+      retention: logs.RetentionDays.INFINITE,
+    });
 
     // When a VPC is provided (which may not always be the case), a private
     // endpoint is configured within the given VPC using a given VPC interface

--- a/lib/constructs/provisioning-sfn-workflow.ts
+++ b/lib/constructs/provisioning-sfn-workflow.ts
@@ -134,7 +134,7 @@ export class ProvisioningWorkflow extends Construct implements IProvisioningWork
     // Composing state machine
     this.workflow = InvokeCspApi.sfnTask.next(httpResponseChoices);
     this.logGroup = new logs.LogGroup(scope, "StepFunctionsLogs", {
-      retention: logs.RetentionDays.ONE_WEEK,
+      retention: logs.RetentionDays.INFINITE,
       logGroupName: `/aws/vendedlogs/states/StepFunctionsLogs${environmentName}`,
     });
     this.stateMachine = new StateMachine(this, "ProvisioningStateMachine", {


### PR DESCRIPTION
Right now most of our logs are AWS Lambda function logs, which have
their logs groups created automatically. Those log groups have
indefinite retention specified. Our other log groups use different
configurations and we should just make everything consistent until we
really solidify how long we plan on retaining for.
