### PR TITLE
Define DescriptionOfWork schema (and supporting schema) in HOTH API

### DIFF
--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -330,7 +330,7 @@ components:
           maxLength: 300
         scope_surge:
           type: integer
-          maxLength: 50
+          maximum: 50
         current_environment: # DOW section 3
           $ref: "#/components/schemas/CurrentEnvironment"
         performance_requirements: # DOW section 4
@@ -381,22 +381,22 @@ components:
           maxLength: 1000
         number_of_vCPUs:
           type: integer
-          maxLength: 40
+          maximum: 40
         storage_type:
           type: string # Empty choice on SNOW side, set as empty String until we get details
         storage_amount:
           type: integer
-          maxLength: 40
+          maximum: 40
         storage_unit:
           $ref: "#/components/schemas/StorageUnit"
         memory_amount:
           type: integer
-          maxLength: 40
+          maximum: 40
         memory_unit:
           $ref: "#/components/schemas/StorageUnit"
         data_egress_monthly_amount:
           type: integer
-          maxLength: 40
+          maximum: 40
         data_egress_monthly_unit:
           $ref: "#/components/schemas/StorageUnit"
     ClassificationLevel:

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -342,8 +342,10 @@ components:
         current_environment:
           $ref: "#/components/schemas/CurrentEnvironment"
         # DOW section 4 (and its subtasks)
-        performance_requirements:
-          $ref: "#/components/schemas/PerformanceRequirements"
+        required_services:
+          type: array
+          items:
+            $ref: "#/components/schemas/RequiredService"
         # DOW section 5 TBD
         # DOW section 6 TBD
         # DOW section 7
@@ -474,17 +476,6 @@ components:
       enum:
         - GB
         - TB
-    PerformanceRequirements:
-      description: >
-        Part of DOW, encapsulates all data for 4. Performance Requirements and its subtasks. 
-        On the API side, the subtasks will filter through the provided required_services.service_offerings
-        to create the subtasks fields.
-      type: object
-      properties:
-        required_services:
-          type: array
-          items:
-            $ref: "#/components/schemas/RequiredService"
     RequiredService:
       description: "Part of DOW, represents a single required service"
       type: object

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -504,11 +504,7 @@ components:
           items:
             $ref: "#/components/schemas/Period"
         pop_start_request:
-          type: string
-          enum:
-            - Unselected
-            - Yes
-            - No
+          type: boolean
         requested_pop_start_date:
           type: string
           format: date
@@ -519,11 +515,7 @@ components:
             - No later than
             - No sooner than
         recurring_requirement:
-          type: string
-          enum:
-            - Unselected
-            - Yes
-            - No
+          type: boolean
     GFEOverview:
       description: "Part of DOW, represents GFE Overview fields"
       properties:
@@ -536,17 +528,9 @@ components:
           type: string
           maxLength: 6
         property_accountable:
-          type: string
-          enum:
-            - Unselected
-            - Yes
-            - No
+          type: boolean
         gfe_or_gfp_furnished:
-          type: string
-          enum:
-            - Unselected
-            - Yes
-            - No
+          type: boolean
     ContractConsiderations:
       description: "Part of DOW, represents Contract Considerations Table"
       properties:
@@ -557,21 +541,13 @@ components:
         packaging_shipping_other_explanation:
           type: string
         potential_conflict_of_interest:
-          type: string
-          enum:
-            - Unselected
-            - Yes
-            - No
+          type: boolean
         conflict_of_interest_explanation:
           type: string
         contractor_provided_transfer:
           type: boolean
         contractor_required_training:
-          type: string
-          enum:
-            - Unselected
-            - Yes
-            - No
+          type: boolean
         required_training_services: # This field looks incomplete on the SNOW side
           $ref: "#/components/schemas/TrainingCourses"
     TrainingCourses:
@@ -586,11 +562,7 @@ components:
       description: "Part of DOW, represents Sensitive Information Table fields"
       properties:
         pii_present:
-          type: string
-          enum:
-            - Unselected
-            - Yes
-            - No
+          type: boolean
         work_to_be_performed:
           type: string
         system_of_record_name:
@@ -619,22 +591,10 @@ components:
         FOIA_zip_postal_code:
           type: string
         BAA_required:
-          type: string
-          enum:
-            - Unselected
-            - Yes
-            - No
+          type: boolean
         potential_to_be_harmful:
-          type: string
-          enum:
-            - Unselected
-            - Yes
-            - No
+          type: boolean
         section_508_sufficient:
-          type: string
-          enum:
-            - Unselected
-            - Yes
-            - No
+          type: boolean
         accessibility_reqs_508:
           type: string

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -356,6 +356,7 @@ components:
           $ref: "#/components/schemas/SensitiveInformation"
     CurrentEnvironment:
       description: "Part of DOW, encapsulates all data for 3. Background/Current Environment section."
+      type: object
       properties:
         current_environment_exists:
           type: boolean
@@ -367,6 +368,7 @@ components:
           type: string
     EnvironmentInstance:
       description: "Part of DOW, represents a single Environment Instance"
+      type: object
       properties:
         instance_name:
           type: string
@@ -415,6 +417,7 @@ components:
           $ref: "#/components/schemas/StorageUnit"
     ClassificationLevel:
       description: "Part of DOW, Classification Level table fields"
+      type: object
       properties:
         classification:
           type: string
@@ -440,6 +443,7 @@ components:
         Part of DOW, encapsulates all data for 4. Performance Requirements and its subtasks. 
         On the API side, the subtasks will filter through the provided required_services.service_offerings
         to create the subtasks fields.
+      type: object
       properties:
         required_services:
           type: array
@@ -447,6 +451,7 @@ components:
             $ref: "#/components/schemas/RequiredService"
     RequiredService:
       description: "Part of DOW, represents a single required service"
+      type: object
       properties:
         applicable_classification_levels:
           type: array
@@ -468,6 +473,7 @@ components:
           type: string
     Period:
       description: "Part of DOW, represents Period Table fields"
+      type: object
       properties:
         period_type:
           type: string
@@ -487,6 +493,7 @@ components:
           type: integer
     ServiceOffering:
       description: "Part of DOW, represents a single Service Offering (Service Offering table)"
+      type: object
       properties:
         service_offering_group:
           type: string
@@ -507,6 +514,7 @@ components:
           type: string
     PeriodOfPerformance:
       description: "Part of DOW, represents a single Period of Performance"
+      type: object
       properties:
         base_period:
           $ref: "#/components/schemas/Period"
@@ -529,6 +537,7 @@ components:
           type: boolean
     GFEOverview:
       description: "Part of DOW, represents GFE Overview fields"
+      type: object
       properties:
         dpas_unit_id:
           type: string
@@ -544,6 +553,7 @@ components:
           type: boolean
     ContractConsiderations:
       description: "Part of DOW, represents Contract Considerations Table"
+      type: object
       properties:
         packaging_shipping_none_apply:
           type: boolean
@@ -571,6 +581,7 @@ components:
           type: string
     SensitiveInformation:
       description: "Part of DOW, represents Sensitive Information Table fields"
+      type: object
       properties:
         pii_present:
           type: boolean

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -331,6 +331,10 @@ components:
         scope_surge:
           type: integer
           maxLength: 50
+        current_environment: # DOW section 3
+          $ref: "#/components/schemas/CurrentEnvironment"
+        performance_requirements: # DOW section 4
+          $ref: "#/components/schemas/PerformanceRequirements"
     CurrentEnvironment:
       description: "Part of DOW, encapsulates all data for 3. Background/Current Environment section."
       properties:
@@ -419,3 +423,75 @@ components:
       enum:
         - GB
         - TB
+    PerformanceRequirements:
+      description: "Part of DOW, encapsulates all data for 4. Performance Requirements"
+      properties:
+        required_services:
+          type: array
+          items:
+            $ref: "#/components/schemas/RequiredService"
+          maxItems: 4000
+    RequiredService:
+      description: "Part of DOW, represents a single required service"
+      properties:
+        applicable_classification_levels:
+          type: array
+          items:
+            $ref: "#/components/schemas/ClassificationLevel"
+          maxItems: 4000 # This is the limit in SNOW, but it doesn't actually make sense to have a 4000 limit because there aren't 4000 classification levels
+        usage_description:
+          type: string
+          maxLength: 1000
+        need_for_entire_TO_duration:
+          type: boolean
+        applicable_periods:
+          type: array
+          items:
+            $ref: "#/components/schemas/Period"
+        service_offerings: # represents the "Select Service Offerings" field
+          type: array
+          items:
+            $ref: "#/components/schemas/ServiceOffering"
+        other_service_offering:
+          type: string
+          maxLength: 100
+    Period:
+      description: "Part of DOW, represents Period Table fields"
+      properties:
+        period_type:
+          type: string
+          enum:
+            - Base
+            - Option
+        period_unit_count:
+          type: integer
+        period_unit:
+          type: string
+          enum:
+            - Day(s)
+            - Week(s)
+            - Month(s)
+            - Year(s)
+        option_order:
+          type: integer
+    ServiceOffering:
+      description: "Part of DOW, represents a single Service Offering (Service Offering table)"
+      properties:
+        service_offering_group:
+          type: string
+          enum:
+            - Advanced Technology and Algorithmic Techniques (Machine Learning)
+            - Advisory and Assistance
+            - Applications
+            - Compute
+            - Database with Storage
+            - Developer Tools and Services
+            - Edge Computing and Tactical Edge (TE)
+            - General IaaS, PaaS, and SaaS
+            - Internet of Things (IoT)
+            - Networking
+            - Security
+            - Training
+        name:
+          type: string
+          maxLength: 100

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -325,14 +325,11 @@ components:
         # DOW section 1
         to_title:
           type: string
-          maxLength: 60
         # DOW section 2
         scope:
           type: string
-          maxLength: 300
         scope_surge:
           type: integer
-          maximum: 50
         # DOW section 3
         current_environment:
           $ref: "#/components/schemas/CurrentEnvironment"
@@ -541,12 +538,10 @@ components:
       properties:
         dpas_unit_id:
           type: string
-          maxLength: 6
         property_custodian_name:
           type: string
         dpas_custodian_number:
           type: string
-          maxLength: 6
         property_accountable:
           type: boolean
         gfe_or_gfp_furnished:

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -321,3 +321,14 @@ components:
     DescriptionOfWork:
       description: "TODO: AT-7341, define DescriptionOfWork schema"
       type: object
+      properties:
+        to_title:
+          type: string
+          maxLength: 60
+          description: "1. TO Title (Provide a short descriptive title of the work to be performed"
+        scope:
+          type: string
+          maxLength: 300
+          description: >
+            2. Scope. The scope of this requirement is (describe what is necessary to achieve mission specific outcome for this particular task: 
+            for example, move DITCO’s contract writing system to a cloud environment).

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -344,7 +344,7 @@ components:
           $ref: "#/components/schemas/GFEOverview"
         contract_considerations: # DOW section 10 (and its subtasks)
           $ref: "#/components/schemas/ContractConsiderations"
-        section_508_accessibility_standards_for_cloud_computing: # DOW section 11
+        section_508_accessibility: # DOW section 11
           $ref: "#/components/schemas/SensitiveInformation"
     CurrentEnvironment:
       description: "Part of DOW, encapsulates all data for 3. Background/Current Environment section."
@@ -355,16 +355,13 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/EnvironmentInstance"
-          maxItems: 4000
         additional_info:
           type: string
-          maxLength: 1000
     EnvironmentInstance:
       description: "Part of DOW, represents a single Environment Instance"
       properties:
         instance_name:
           type: string
-          maxLength: 100
         classification_level:
           $ref: "#/components/schemas/ClassificationLevel"
         instance_location:
@@ -389,25 +386,20 @@ components:
           example: "2022-07-01"
         operating_system_licensing:
           type: string
-          maxLength: 1000
         number_of_vCPUs:
           type: integer
-          maximum: 40
         storage_type:
           type: string # Empty choice on SNOW side, set as empty String until we get details
         storage_amount:
           type: integer
-          maximum: 40
         storage_unit:
           $ref: "#/components/schemas/StorageUnit"
         memory_amount:
           type: integer
-          maximum: 40
         memory_unit:
           $ref: "#/components/schemas/StorageUnit"
         data_egress_monthly_amount:
           type: integer
-          maximum: 40
         data_egress_monthly_unit:
           $ref: "#/components/schemas/StorageUnit"
     ClassificationLevel:
@@ -444,7 +436,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/RequiredService"
-          maxItems: 4000
     RequiredService:
       description: "Part of DOW, represents a single required service"
       properties:
@@ -452,10 +443,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ClassificationLevel"
-          maxItems: 4000 # This is the limit in SNOW, but it doesn't actually make sense to have a 4000 limit because there aren't 4000 classification levels
         usage_description:
           type: string
-          maxLength: 1000
         need_for_entire_TO_duration:
           type: boolean
         applicable_periods:
@@ -468,7 +457,6 @@ components:
             $ref: "#/components/schemas/ServiceOffering"
         other_service_offering:
           type: string
-          maxLength: 100
     Period:
       description: "Part of DOW, represents Period Table fields"
       properties:
@@ -508,7 +496,6 @@ components:
             - Training
         name:
           type: string
-          maxLength: 100
     PeriodOfPerformance:
       description: "Part of DOW, represents a single Period of Performance"
       properties:
@@ -518,7 +505,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Period"
-          maxItems: 4000
         pop_start_request:
           type: string
           enum:
@@ -548,7 +534,6 @@ components:
           maxLength: 6
         property_custodian_name:
           type: string
-          maxLength: 40 # This is another instance of maxLength in SNOW being weird, the person might have a name longer than 40 characters
         dpas_custodian_number: # DPAS Custodian Number
           type: string
           maxLength: 6
@@ -573,7 +558,6 @@ components:
           type: boolean
         packaging_shipping_other_explanation:
           type: string
-          maxLength: 1000
         potential_conflict_of_interest:
           type: string
           enum:
@@ -582,7 +566,6 @@ components:
             - No
         conflict_of_interest_explanation:
           type: string
-          maxLength: 1600
         contractor_provided_transfer:
           type: boolean
         contractor_required_training:
@@ -612,22 +595,16 @@ components:
             - No
         work_to_be_performed:
           type: string
-          maxLength: 400
         system_of_record_name:
           type: string
-          maxLength: 40
         FOIA_city_apo_fpo:
           type: string
-          maxLength: 50
         FOIA_country:
           type: string
-          maxLength: 50
         FOIA_street_address_1:
           type: string
-          maxLength: 40
         FOIA_street_address_2:
           type: string
-          maxLength: 40
         FOIA_address_type:
           type: string
           enum:
@@ -636,16 +613,13 @@ components:
             - U.S.
         FOIA_state_province_code:
           type: string
-          maxLength: 50
         FOIA_full_name:
           type: string
-          maxLength: 40
         FOIA_email:
           type: string
           format: email
         FOIA_zip_postal_code:
           type: string
-          maxLength: 40
         BAA_required:
           type: string
           enum:
@@ -666,4 +640,3 @@ components:
             - No
         accessibility_reqs_508:
           type: string
-          maxLength: 1000

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -536,7 +536,7 @@ components:
       properties:
         packaging_shipping_none_apply:
           type: boolean
-        packaging_shippping_other:
+        packaging_shipping_other:
           type: boolean
         packaging_shipping_other_explanation:
           type: string

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -333,8 +333,19 @@ components:
           maximum: 50
         current_environment: # DOW section 3
           $ref: "#/components/schemas/CurrentEnvironment"
-        performance_requirements: # DOW section 4
+        performance_requirements: # DOW section 4 (and its subtasks)
           $ref: "#/components/schemas/PerformanceRequirements"
+        # DOW section 5 TBD
+        # DOW section 6 TBD
+        period_of_performance: # DOW section 7
+          $ref: "#/components/schemas/PeriodOfPerformance"
+        # DOW section 8 TBD
+        gfe_overview: # DOW section 9
+          $ref: "#/components/schemas/GFEOverview"
+        contract_considerations: # DOW section 10 (and its subtasks)
+          $ref: "#/components/schemas/ContractConsiderations"
+        section_508_accessibility_standards_for_cloud_computing: # DOW section 11
+          $ref: "#/components/schemas/SensitiveInformation"
     CurrentEnvironment:
       description: "Part of DOW, encapsulates all data for 3. Background/Current Environment section."
       properties:
@@ -424,7 +435,10 @@ components:
         - GB
         - TB
     PerformanceRequirements:
-      description: "Part of DOW, encapsulates all data for 4. Performance Requirements"
+      description: >
+        Part of DOW, encapsulates all data for 4. Performance Requirements and its subtasks. 
+        On the API side, the subtasks will filter through the provided required_services.service_offerings
+        to create the subtasks fields.
       properties:
         required_services:
           type: array
@@ -495,3 +509,161 @@ components:
         name:
           type: string
           maxLength: 100
+    PeriodOfPerformance:
+      description: "Part of DOW, represents a single Period of Performance"
+      properties:
+        base_period:
+          $ref: "#/components/schemas/Period"
+        option_periods:
+          type: array
+          items:
+            $ref: "#/components/schemas/Period"
+          maxItems: 4000
+        pop_start_request:
+          type: string
+          enum:
+            - Unselected
+            - Yes
+            - No
+        requested_pop_start_date:
+          type: string
+          format: date
+          example: "2021-07-01"
+        time_frame:
+          type: string
+          enum:
+            - No later than
+            - No sooner than
+        recurring_requirement:
+          type: string
+          enum:
+            - Unselected
+            - Yes
+            - No
+    GFEOverview:
+      description: "Part of DOW, represents GFE Overview fields"
+      properties:
+        dpas_unit_id:
+          type: string
+          maxLength: 6
+        property_custodian_name:
+          type: string
+          maxLength: 40 # This is another instance of maxLength in SNOW being weird, the person might have a name longer than 40 characters
+        dpas_custodian_number: # DPAS Custodian Number
+          type: string
+          maxLength: 6
+        property_accountable:
+          type: string
+          enum:
+            - Unselected
+            - Yes
+            - No
+        gfe_or_gfp_furnished:
+          type: string
+          enum:
+            - Unselected
+            - Yes
+            - No
+    ContractConsiderations:
+      description: "Part of DOW, represents Contract Considerations Table"
+      properties:
+        packaging_shipping_none_apply:
+          type: boolean
+        packaging_shippping_other:
+          type: boolean
+        packaging_shipping_other_explanation:
+          type: string
+          maxLength: 1000
+        potential_conflict_of_interest:
+          type: string
+          enum:
+            - Unselected
+            - Yes
+            - No
+        conflict_of_interest_explanation:
+          type: string
+          maxLength: 1600
+        contractor_provided_transfer:
+          type: boolean
+        contractor_required_training:
+          type: string
+          enum:
+            - Unselected
+            - Yes
+            - No
+        required_training_services: # This field looks incomplete on the SNOW side
+          $ref: "#/components/schemas/TrainingCourses"
+    TrainingCourses:
+      description: "Part of DOW, part of schema for ContractConsiderations, includes training courses name and value"
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+    SensitiveInformation:
+      description: "Part of DOW, represents Sensitive Information Table fields"
+      properties:
+        pii_present:
+          type: string
+          enum:
+            - Unselected
+            - Yes
+            - No
+        work_to_be_performed:
+          type: string
+          maxLength: 400
+        system_of_record_name:
+          type: string
+          maxLength: 40
+        FOIA_city_apo_fpo:
+          type: string
+          maxLength: 50
+        FOIA_country:
+          type: string
+          maxLength: 50
+        FOIA_street_address_1:
+          type: string
+          maxLength: 40
+        FOIA_street_address_2:
+          type: string
+          maxLength: 40
+        FOIA_address_type:
+          type: string
+          enum:
+            - Foreign
+            - Military
+            - U.S.
+        FOIA_state_province_code:
+          type: string
+          maxLength: 50
+        FOIA_full_name:
+          type: string
+          maxLength: 40
+        FOIA_email:
+          type: string
+          format: email
+        FOIA_zip_postal_code:
+          type: string
+          maxLength: 40
+        BAA_required:
+          type: string
+          enum:
+            - Unselected
+            - Yes
+            - No
+        potential_to_be_harmful:
+          type: string
+          enum:
+            - Unselected
+            - Yes
+            - No
+        section_508_sufficient:
+          type: string
+          enum:
+            - Unselected
+            - Yes
+            - No
+        accessibility_reqs_508:
+          type: string
+          maxLength: 1000

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -344,7 +344,7 @@ components:
           $ref: "#/components/schemas/GFEOverview"
         contract_considerations: # DOW section 10 (and its subtasks)
           $ref: "#/components/schemas/ContractConsiderations"
-        section_508_accessibility: # DOW section 11
+        section_508_accessibility_standards: # DOW section 11
           $ref: "#/components/schemas/SensitiveInformation"
     CurrentEnvironment:
       description: "Part of DOW, encapsulates all data for 3. Background/Current Environment section."

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -322,6 +322,14 @@ components:
       description: "Schema used to generate DescriptionOfWork document"
       type: object
       properties:
+        # DOW award history
+        award_history:
+          type: array
+          items:
+            $ref: "#/components/schemas/Award"
+        # DOW contract information table
+        contract_information:
+          $ref: "#/components/schemas/ContractInformation"
         # DOW section 1
         to_title:
           type: string
@@ -351,6 +359,37 @@ components:
           # DOW section 11
         section_508_accessibility_standards:
           $ref: "#/components/schemas/SensitiveInformation"
+    Award:
+      description: "Part of DOW, represents a single Award in the Award History table"
+      type: object
+      properties:
+        contract_award_type:
+          type: string
+          enum:
+            - INITIAL_AWARD
+            - MODIFICATION
+        modification_order:
+          type: integer
+        effective_date:
+          type: string
+          format: date
+    ContractInformation:
+      description: "Part of DOW, represents Current Contract Information table fields"
+      type: object
+      properties:
+        contract_number:
+          type: string
+        current_contract_exists:
+          type: boolean
+        contract_expiration_date:
+          type: string
+          format: date
+        incumbent_contractor_name:
+          type: string
+        task_order_number:
+          type: string
+        previous_task_order_number:
+          type: string
     CurrentEnvironment:
       description: "Part of DOW, encapsulates all data for 3. Background/Current Environment section."
       type: object
@@ -456,7 +495,7 @@ components:
             $ref: "#/components/schemas/ClassificationLevel"
         usage_description:
           type: string
-        need_for_entire_TO_duration:
+        need_for_entire_to_duration:
           type: boolean
         applicable_periods:
           type: array

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -322,29 +322,37 @@ components:
       description: "Schema used to generate DescriptionOfWork document"
       type: object
       properties:
+        # DOW section 1
         to_title:
           type: string
           maxLength: 60
+        # DOW section 2
         scope:
           type: string
           maxLength: 300
         scope_surge:
           type: integer
           maximum: 50
-        current_environment: # DOW section 3
+        # DOW section 3
+        current_environment:
           $ref: "#/components/schemas/CurrentEnvironment"
-        performance_requirements: # DOW section 4 (and its subtasks)
+        # DOW section 4 (and its subtasks)
+        performance_requirements:
           $ref: "#/components/schemas/PerformanceRequirements"
         # DOW section 5 TBD
         # DOW section 6 TBD
-        period_of_performance: # DOW section 7
+        # DOW section 7
+        period_of_performance:
           $ref: "#/components/schemas/PeriodOfPerformance"
         # DOW section 8 TBD
-        gfe_overview: # DOW section 9
+        # DOW section 9
+        gfe_overview:
           $ref: "#/components/schemas/GFEOverview"
-        contract_considerations: # DOW section 10 (and its subtasks)
+        # DOW section 10 (and its subtasks)
+        contract_considerations:
           $ref: "#/components/schemas/ContractConsiderations"
-        section_508_accessibility_standards: # DOW section 11
+          # DOW section 11
+        section_508_accessibility_standards:
           $ref: "#/components/schemas/SensitiveInformation"
     CurrentEnvironment:
       description: "Part of DOW, encapsulates all data for 3. Background/Current Environment section."
@@ -371,8 +379,10 @@ components:
             - Hybrid
             - Not in the cloud / On-premise
         csp_region:
-          $ref: "#/components/schemas/TargetCloudServiceProviderName" #On the SNOW side, this is CSP_REGION a choice field with no options, so using TargetCSPName instead
-        performance_tier: # This is also an empty choice on the SNOW side, set as empty String until we get details
+          # On the SNOW side, this is CSP_REGION a choice field with no options, so using TargetCSPName instead
+          $ref: "#/components/schemas/TargetCloudServiceProviderName"
+        performance_tier:
+          # This is also an empty choice on the SNOW side, set as empty String until we get details
           type: string
         pricing_model:
           type: string
@@ -389,7 +399,8 @@ components:
         number_of_vCPUs:
           type: integer
         storage_type:
-          type: string # Empty choice on SNOW side, set as empty String until we get details
+          # Empty choice on SNOW side, set as empty String until we get details
+          type: string
         storage_amount:
           type: integer
         storage_unit:
@@ -449,7 +460,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Period"
-        service_offerings: # represents the "Select Service Offerings" field
+        service_offerings:
           type: array
           items:
             $ref: "#/components/schemas/ServiceOffering"
@@ -524,7 +535,7 @@ components:
           maxLength: 6
         property_custodian_name:
           type: string
-        dpas_custodian_number: # DPAS Custodian Number
+        dpas_custodian_number:
           type: string
           maxLength: 6
         property_accountable:
@@ -548,7 +559,7 @@ components:
           type: boolean
         contractor_required_training:
           type: boolean
-        required_training_services: # This field looks incomplete on the SNOW side
+        required_training_services:
           $ref: "#/components/schemas/TrainingCourses"
     TrainingCourses:
       description: "Part of DOW, part of schema for ContractConsiderations, includes training courses name and value"

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -416,8 +416,8 @@ components:
           type: string
           enum:
             - CSP
-            - Hybrid
-            - Not in the cloud / On-premise
+            - HYBRID
+            - ON_PREMISE
         csp_region:
           # On the SNOW side, this is CSP_REGION a choice field with no options, so using TargetCSPName instead
           $ref: "#/components/schemas/TargetCloudServiceProviderName"
@@ -427,9 +427,9 @@ components:
         pricing_model:
           type: string
           enum:
-            - On-demand
-            - Pay-as-you-go
-            - Reserved
+            - ON_DEMAND
+            - PAY_AS_YOU_GO
+            - RESERVED
         pricing_model_expiration:
           type: string
           format: date
@@ -460,9 +460,9 @@ components:
         classification:
           type: string
           enum:
-            - Unclassified
-            - Top Secret
-            - Secret
+            - U
+            - S
+            - TS
         impact_level:
           type: string
           enum:
@@ -505,17 +505,17 @@ components:
         period_type:
           type: string
           enum:
-            - Base
-            - Option
+            - BASE
+            - OPTION
         period_unit_count:
           type: integer
         period_unit:
           type: string
           enum:
-            - Day(s)
-            - Week(s)
-            - Month(s)
-            - Year(s)
+            - DAY
+            - WEEK
+            - MONTH
+            - YEAR
         option_order:
           type: integer
     ServiceOffering:
@@ -525,18 +525,18 @@ components:
         service_offering_group:
           type: string
           enum:
-            - Advanced Technology and Algorithmic Techniques (Machine Learning)
-            - Advisory and Assistance
-            - Applications
-            - Compute
-            - Database with Storage
-            - Developer Tools and Services
-            - Edge Computing and Tactical Edge (TE)
-            - General IaaS, PaaS, and SaaS
-            - Internet of Things (IoT)
-            - Networking
-            - Security
-            - Training
+            - ADVISORY
+            - APPLICATIONS
+            - COMPUTE
+            - DATABASE
+            - DEVELOPER_TOOLS
+            - EDGE_COMPUTING
+            - GENERAL_XAAS
+            - IOT
+            - MACHINE_LEARNING
+            - NETWORKING
+            - SECURITY
+            - TRAINING
         name:
           type: string
     PeriodOfPerformance:
@@ -558,8 +558,8 @@ components:
         time_frame:
           type: string
           enum:
-            - No later than
-            - No sooner than
+            - NO_LATER_THAN
+            - NO_SOONER_THAN
         recurring_requirement:
           type: boolean
     GFEOverview:
@@ -625,9 +625,9 @@ components:
         FOIA_address_type:
           type: string
           enum:
-            - Foreign
-            - Military
-            - U.S.
+            - FOREGIN
+            - MILITARY
+            - US
         FOIA_state_province_code:
           type: string
         FOIA_full_name:

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -319,16 +319,103 @@ components:
       oneOf:
         - $ref: "#/components/schemas/DescriptionOfWork"
     DescriptionOfWork:
-      description: "TODO: AT-7341, define DescriptionOfWork schema"
+      description: "Schema used to generate DescriptionOfWork document"
       type: object
       properties:
         to_title:
           type: string
           maxLength: 60
-          description: "1. TO Title (Provide a short descriptive title of the work to be performed"
         scope:
           type: string
           maxLength: 300
-          description: >
-            2. Scope. The scope of this requirement is (describe what is necessary to achieve mission specific outcome for this particular task: 
-            for example, move DITCO’s contract writing system to a cloud environment).
+        scope_surge:
+          type: integer
+          maxLength: 50
+    CurrentEnvironment:
+      description: "Part of DOW, encapsulates all data for 3. Background/Current Environment section."
+      properties:
+        current_environment_exists:
+          type: boolean
+        environment_instances:
+          type: array
+          items:
+            $ref: "#/components/schemas/EnvironmentInstance"
+          maxItems: 4000
+        additional_info:
+          type: string
+          maxLength: 1000
+    EnvironmentInstance:
+      description: "Part of DOW, represents a single Environment Instance"
+      properties:
+        instance_name:
+          type: string
+          maxLength: 100
+        classification_level:
+          $ref: "#/components/schemas/ClassificationLevel"
+        instance_location:
+          type: string
+          enum:
+            - CSP
+            - Hybrid
+            - Not in the cloud / On-premise
+        csp_region:
+          $ref: "#/components/schemas/TargetCloudServiceProviderName" #On the SNOW side, this is CSP_REGION a choice field with no options, so using TargetCSPName instead
+        performance_tier: # This is also an empty choice on the SNOW side, set as empty String until we get details
+          type: string
+        pricing_model:
+          type: string
+          enum:
+            - On-demand
+            - Pay-as-you-go
+            - Reserved
+        pricing_model_expiration:
+          type: string
+          format: date
+          example: "2022-07-01"
+        operating_system_licensing:
+          type: string
+          maxLength: 1000
+        number_of_vCPUs:
+          type: integer
+          maxLength: 40
+        storage_type:
+          type: string # Empty choice on SNOW side, set as empty String until we get details
+        storage_amount:
+          type: integer
+          maxLength: 40
+        storage_unit:
+          $ref: "#/components/schemas/StorageUnit"
+        memory_amount:
+          type: integer
+          maxLength: 40
+        memory_unit:
+          $ref: "#/components/schemas/StorageUnit"
+        data_egress_monthly_amount:
+          type: integer
+          maxLength: 40
+        data_egress_monthly_unit:
+          $ref: "#/components/schemas/StorageUnit"
+    ClassificationLevel:
+      description: "Part of DOW, Classification Level table fields"
+      properties:
+        classification:
+          type: string
+          enum:
+            - Unclassified
+            - Top Secret
+            - Secret
+        impact_level:
+          type: string
+          nullable: true
+          enum:
+            - IL2
+            - IL4
+            - IL5
+            - IL6
+            - null
+    StorageUnit:
+      description: "Part of DOW, used in EnvironmentInstance schema"
+      type: string
+      enum:
+        - GB
+        - TB

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -413,13 +413,11 @@ components:
             - Secret
         impact_level:
           type: string
-          nullable: true
           enum:
             - IL2
             - IL4
             - IL5
             - IL6
-            - null
     StorageUnit:
       description: "Part of DOW, used in EnvironmentInstance schema"
       type: string


### PR DESCRIPTION
## Overview
This is the schema used for the `generateDocument` POST request.

The `DescriptionOfWork` object includes all properties needed to complete the DOW document, and separate schemas had to be
created to improve readability.

These schemas were created referencing the specific SNOW Tables needed for the DOW (See https://github.com/dod-ccpo/atat-snow/pull/48). 

[Acquisition Package Field Mapping](https://ccpo.atlassian.net/wiki/spaces/AT/pages/2282160166/Acquisition+Package+Field+Mapping) Confluence Page was used along with the actual **Draft JWCC Description of Work Template** (See slack comment for link).

In total this PR adds the following schema:

1. `DescriptionOfWork`
2. `CurrentEnvironment`
3. `EnvironmentInstance`
4. `ClassificationLevel`
5. `StorageUnit`
6. `PerformanceRequirements`
7. `RequiredService`
8. `Period`
9. `ServiceOffering`
10. `PeriodOfPerformance`
11. `GFEOverview`
12. `ContractConsiderations`
13. `TrainingCourses`
14. `SensitiveInformation`

[Ticket: AT-7341](https://ccpo.atlassian.net/browse/AT-7341)