### PR TITLE
Support configurable CIDR blocks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           npm ci
       - name: Synthesize CDK template
-        run: cdk synth -c "atat:EnvironmentId=CiTest"
+        run: cdk synth -c "atat:EnvironmentId=CiTest" -c "atat:Sandbox=true"
       - name: Gather CloudFormation artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/bin/app.test.ts
+++ b/bin/app.test.ts
@@ -1,0 +1,126 @@
+import { createApp } from "./app";
+
+const cidrError =
+  "A VpcCidr must be provided for non-Sandbox environments (use the atat:VpcCidr context key) and it must be" +
+  " a valid CIDR block";
+
+describe("Validation tests", () => {
+  const validCidr = "10.0.255.0/16";
+
+  it("should throw error if not EnvironmentId", async () => {
+    expect(() => {
+      createApp({
+        context: {
+          "atat:Sandbox": true,
+          "atat:VpcCidr": validCidr,
+        },
+      });
+    }).toThrow("An EnvironmentId must be provided (use the atat:EnvironmentId context key)");
+  });
+
+  it("should not have ViprCidr if Sandbox", async () => {
+    expect(() => {
+      createApp({
+        context: {
+          "atat:EnvironmentId": "myEnvironment",
+          "atat:Sandbox": true,
+          "atat:VpcCidr": validCidr,
+        },
+      });
+    }).toThrow("A VpcCidr must NOT be provided for Sandbox environments.");
+  });
+
+  it("should have ViprCidr if not Sandbox", async () => {
+    expect(() => {
+      createApp({
+        context: {
+          "atat:EnvironmentId": "myEnvironment",
+          "atat:Sandbox": false,
+        },
+      });
+    }).toThrow(cidrError);
+  });
+
+  it("should not throw Error if all inputs valid for Sandbox environment", async () => {
+    expect(() => {
+      createApp({
+        context: {
+          "atat:EnvironmentId": "myEnvironment",
+          "atat:Sandbox": true,
+        },
+      });
+    }).not.toThrow(cidrError);
+  });
+
+  it("should not throw Error if all inputs valid for non-Sandbox environment", async () => {
+    expect(() => {
+      createApp({
+        context: {
+          "atat:EnvironmentId": "myEnvironment",
+          "atat:Sandbox": false,
+          "atat:VpcCidr": validCidr,
+        },
+      });
+    }).not.toThrow(cidrError);
+  });
+});
+
+describe("CIDR tests", () => {
+  let context: Record<string, unknown> = {};
+
+  beforeEach(() => {
+    context = {
+      "atat:EnvironmentId": "myEnvironment",
+      "atat:Sandbox": false,
+    };
+  });
+
+  it("should throw if VpcCidr arbitrary string", async () => {
+    context["atat:VpcCidr"] = "not a CIDR block";
+    expect(() => {
+      createApp({ context });
+    }).toThrow(cidrError);
+  });
+
+  it("should throw if VpcCidr has too few octets", async () => {
+    context["atat:VpcCidr"] = "10.0.0/24";
+    expect(() => {
+      createApp({ context });
+    }).toThrow(cidrError);
+  });
+
+  it("should throw if VpcCidr has too many octets", async () => {
+    context["atat:VpcCidr"] = "10.1.2.3.4/24";
+    expect(() => {
+      createApp({ context });
+    }).toThrow(cidrError);
+  });
+
+  it("should throw if VpcCidr octet out of range", async () => {
+    context["atat:VpcCidr"] = "10.0.500.0/20";
+    expect(() => {
+      createApp({ context });
+    }).toThrow(cidrError);
+  });
+
+  it("should throw if VpcCidr missing netmask", async () => {
+    context["atat:VpcCidr"] = "10.0.0.0";
+    expect(() => {
+      createApp({ context });
+    }).toThrow(cidrError);
+  });
+
+  it("should throw if VpcCidr netmask too small", async () => {
+    context["atat:VpcCidr"] = "10.0.0.0/14";
+    expect(() => {
+      createApp({ context });
+    }).toThrow(cidrError);
+  });
+
+  it("should throw if VpcCidr netmask too large", async () => {
+    context["atat:VpcCidr"] = "10.0.0.0/30";
+    expect(() => {
+      createApp({ context });
+    }).toThrow(cidrError);
+  });
+});

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -1,0 +1,92 @@
+import * as cdk from "aws-cdk-lib";
+import * as utils from "../lib/util";
+import { AtatWebApiStack } from "../lib/atat-web-api-stack";
+import { RemovalPolicySetter } from "../lib/aspects/removal-policy";
+import { GovCloudCompatibilityAspect } from "../lib/aspects/govcloud-compatibility";
+import { AtatPipelineStack } from "../lib/atat-pipeline-stack";
+
+export function createApp(props?: cdk.AppProps): cdk.App {
+  const app = new cdk.App(props);
+
+  const environmentParam = app.node.tryGetContext("atat:EnvironmentId");
+  const sandboxParam = app.node.tryGetContext("atat:Sandbox");
+  const vpcCidrParam = app.node.tryGetContext("atat:VpcCidr");
+
+  if (!utils.isString(environmentParam)) {
+    const err = "An EnvironmentId must be provided (use the atat:EnvironmentId context key)";
+    console.error(err);
+    throw new Error(err);
+  }
+
+  const environmentName = utils.normalizeEnvironmentName(environmentParam);
+  // We need to be able to handle the value being undefined or some unexpected type.
+  // Because "false" (as a string) is truthy, we need to allow specific values.
+  const isSandbox = ["true", "1", "yes"].includes(String(sandboxParam).toLowerCase());
+
+  // For a sandbox environment, developers are allowed to deploy just the API stack
+  // (and in fact, that is preferred). Aspects get applied directly to ensure that
+  // resources are torn down and that the stack will work in GovCloud (which is where
+  // most/all development occurs). Within the pipeline, applying aspects and choosing
+  // the specific stacks to deploy happens within the Stage resource. In fact, within
+  // the pipeline, things that we do to the app here have no effect. Any Aspects
+  // applied here will impact _only_ the pipeline stack itself (but should take effect
+  // either through a manual deployment or the automatic self-mutation step).
+  if (isSandbox) {
+    // Sandbox environments (which do NOT have a VPC) must NOT have a VpcCidr parameter
+    if (utils.isString(vpcCidrParam) || validateCidr(vpcCidrParam)) {
+      const err = "A VpcCidr must NOT be provided for Sandbox environments.";
+      console.error(err);
+      throw new Error(err);
+    }
+    const apiStack = new AtatWebApiStack(app, `${environmentName}WebApi`, {
+      environmentName,
+    });
+    cdk.Aspects.of(app).add(new RemovalPolicySetter({ globalRemovalPolicy: cdk.RemovalPolicy.DESTROY }));
+    cdk.Aspects.of(app).add(new GovCloudCompatibilityAspect());
+  } else {
+    // Non Sandbox environments (which have a VPC) must have a VpcCidr parameter
+    if (!utils.isString(vpcCidrParam) || !validateCidr(vpcCidrParam)) {
+      const err =
+        "A VpcCidr must be provided for non-Sandbox environments (use the atat:VpcCidr context key) " +
+        "and it must be a valid CIDR block.";
+      console.error(err);
+      throw new Error(err);
+    }
+
+    // Context values can not be supplied via the CLI during self-mutation; therefore, we
+    // cannot include the environment name in the stack at this time. This does limit
+    // us to having a single pipeline per account until we come up with a more thorough
+    // solution (but that is likely okay for now). A workaround to this is that if you
+    // do need to perform integration testing for the pipeline (by building a test stack),
+    // you can just temporarily change the `id` parameter from "Pipeline" to another
+    // static value.
+    const pipelineStack = new AtatPipelineStack(app, "AtatEnvironmentPipeline", {
+      environmentName,
+      vpcCidr: vpcCidrParam,
+      repository: app.node.tryGetContext("atat:VersionControlRepo"),
+      branch: app.node.tryGetContext("atat:VersionControlBranch"),
+      githubPatName: app.node.tryGetContext("atat:GitHubPatName"),
+    });
+  }
+  return app;
+}
+
+// Ensure that we have a CIDR block that will be allowed by AWS VPC
+function validateCidr(cidr: string): boolean {
+  const AWS_MIN_NETMASK = 16;
+  const AWS_MAX_NETMASK = 28;
+  try {
+    const [address, prefix] = cidr.split("/");
+    const prefixInt = parseInt(prefix);
+    if (!prefixInt || prefixInt < AWS_MIN_NETMASK || prefixInt > AWS_MAX_NETMASK) {
+      return false;
+    }
+    const octets = address
+      .split(".")
+      .map((oct) => parseInt(oct))
+      .filter((oct) => oct >= 0 && oct <= 255);
+    return octets.length === 4;
+  } catch (err) {
+    return false;
+  }
+}

--- a/bin/atat-web-api.ts
+++ b/bin/atat-web-api.ts
@@ -1,63 +1,7 @@
 #!/usr/bin/env node
 import "source-map-support/register";
-import * as cdk from "aws-cdk-lib";
-import { AtatWebApiStack } from "../lib/atat-web-api-stack";
-import { AtatPipelineStack } from "../lib/atat-pipeline-stack";
-import { GovCloudCompatibilityAspect } from "../lib/aspects/govcloud-compatibility";
-import { RemovalPolicySetter } from "../lib/aspects/removal-policy";
-import * as utils from "../lib/util";
+import { createApp } from "./app";
 
-const app = new cdk.App();
-
-const environmentParam = app.node.tryGetContext("atat:EnvironmentId");
-const sandboxParam = app.node.tryGetContext("atat:Sandbox");
-const vpcCidrParam = app.node.tryGetContext("atat:VpcCidr");
-
-if (!utils.isString(environmentParam)) {
-  console.error("An EnvironmentId must be provided (use the atat:EnvironmentId context key)");
-  process.exit(1);
-}
-
-const cidrRegex = /^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$/;
-if (!utils.isString(vpcCidrParam) || !cidrRegex.test(vpcCidrParam)) {
-  console.error("A VpcCidr must be provided (use the atat:VpcCidr context key) and it must be a valid CIDR block.");
-  process.exit(1);
-}
-
-const environmentName = utils.normalizeEnvironmentName(environmentParam);
-// We need to be able to handle the value being undefined or some unexpected type.
-// Because "false" (as a string) is truthy, we need to allow specific values.
-const isSandbox = ["true", "1", "yes"].includes(String(sandboxParam).toLowerCase());
-
-// For a sandbox environment, developers are allowed to deploy just the API stack
-// (and in fact, that is preferred). Aspects get applied directly to ensure that
-// resources are torn down and that the stack will work in GovCloud (which is where
-// most/all development occurs). Within the pipeline, applying aspects and choosing
-// the specific stacks to deploy happens within the Stage resource. In fact, within
-// the pipeline, things that we do to the app here have no effect. Any Aspects
-// applied here will impact _only_ the pipeline stack itself (but should take effect
-// either through a manual deployment or the automatic self-mutation step).
-if (isSandbox) {
-  const apiStack = new AtatWebApiStack(app, `${environmentName}WebApi`, {
-    environmentName,
-  });
-  cdk.Aspects.of(app).add(new RemovalPolicySetter({ globalRemovalPolicy: cdk.RemovalPolicy.DESTROY }));
-  cdk.Aspects.of(app).add(new GovCloudCompatibilityAspect());
-} else {
-  // Context values can not be supplied via the CLI during self-mutation; therefore, we
-  // cannot include the environment name in the stack at this time. This does limit
-  // us to having a single pipeline per account until we come up with a more thorough
-  // solution (but that is likely okay for now). A workaround to this is that if you
-  // do need to perform integration testing for the pipeline (by building a test stack),
-  // you can just temporarily change the `id` parameter from "Pipeline" to another
-  // static value.
-  const pipelineStack = new AtatPipelineStack(app, "AtatEnvironmentPipeline", {
-    environmentName,
-    vpcCidr: vpcCidrParam,
-    repository: app.node.tryGetContext("atat:VersionControlRepo"),
-    branch: app.node.tryGetContext("atat:VersionControlBranch"),
-    githubPatName: app.node.tryGetContext("atat:GitHubPatName"),
-  });
-}
-
+// Externalized the logic to set up our App so that we can perform proper unit tests on it
+const app = createApp();
 app.synth();

--- a/bin/atat-web-api.ts
+++ b/bin/atat-web-api.ts
@@ -11,9 +11,16 @@ const app = new cdk.App();
 
 const environmentParam = app.node.tryGetContext("atat:EnvironmentId");
 const sandboxParam = app.node.tryGetContext("atat:Sandbox");
+const vpcCidrParam = app.node.tryGetContext("atat:VpcCidr");
 
 if (!utils.isString(environmentParam)) {
   console.error("An EnvironmentId must be provided (use the atat:EnvironmentId context key)");
+  process.exit(1);
+}
+
+const cidrRegex = /^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$/;
+if (!utils.isString(vpcCidrParam) || !cidrRegex.test(vpcCidrParam)) {
+  console.error("A VpcCidr must be provided (use the atat:VpcCidr context key) and it must be a valid CIDR block.");
   process.exit(1);
 }
 
@@ -46,6 +53,7 @@ if (isSandbox) {
   // static value.
   const pipelineStack = new AtatPipelineStack(app, "AtatEnvironmentPipeline", {
     environmentName,
+    vpcCidr: vpcCidrParam,
     repository: app.node.tryGetContext("atat:VersionControlRepo"),
     branch: app.node.tryGetContext("atat:VersionControlBranch"),
     githubPatName: app.node.tryGetContext("atat:GitHubPatName"),

--- a/bin/atat-web-api.ts
+++ b/bin/atat-web-api.ts
@@ -3,5 +3,4 @@ import "source-map-support/register";
 import { createApp } from "./app";
 
 // Externalized the logic to set up our App so that we can perform proper unit tests on it
-const app = createApp();
-app.synth();
+createApp();

--- a/cdk.json
+++ b/cdk.json
@@ -32,7 +32,7 @@
 
     "atat:CspConfigurationName": "config/csp/integration",
     "atat:GitHubPatName": "auth/github/pat",
-    "atat:VersionControlBranch": "feature/AT-7448",
+    "atat:VersionControlBranch": "develop",
     "atat:VersionControlRepo": "dod-ccpo/atat-web-api"
   }
 }

--- a/cdk.json
+++ b/cdk.json
@@ -32,7 +32,7 @@
 
     "atat:CspConfigurationName": "config/csp/integration",
     "atat:GitHubPatName": "auth/github/pat",
-    "atat:VersionControlBranch": "develop",
+    "atat:VersionControlBranch": "feature/AT-7448",
     "atat:VersionControlRepo": "dod-ccpo/atat-web-api"
   }
 }

--- a/lib/atat-pipeline-stack.ts
+++ b/lib/atat-pipeline-stack.ts
@@ -39,10 +39,19 @@ export class AtatPipelineStack extends cdk.Stack {
         input: pipelines.CodePipelineSource.gitHub(props.repository, props.branch, {
           authentication: cdk.SecretValue.secretsManager(props.githubPatName),
         }),
-        commands: ["npm ci", "npm run build", `npm run -- cdk synth -c atat:EnvironmentId=${props.environmentName}`],
+        commands: [
+          "npm ci",
+          "npm run build",
+          `npm run -- cdk synth -c atat:EnvironmentId=${props.environmentName} -c atat:VpcCidr=${props.vpcCidr}`,
+        ],
       }),
     });
 
-    pipeline.addStage(new AtatApplication(this, props.environmentName, { environmentName: props.environmentName }));
+    pipeline.addStage(
+      new AtatApplication(this, props.environmentName, {
+        vpcCidr: props.vpcCidr,
+        environmentName: props.environmentName,
+      })
+    );
   }
 }


### PR DESCRIPTION
This PR satisfies AT-7448 by adding a `VpcCidr` context parameter to our CDK config. This parameter has the following rules:

1. If the given Environment is a Sandbox, `VpcCidr` must NOT be defined.
2.If the given Environment is NOT a Sandbox, `VpcCidr` must be a valid CIDR block such as `10.100.0.0/20`.

I also moved the majority of the logic out of `bin/atat-web-api.ts` to `bin/app.ts` so that we could unit test it without invoking `app.synth()`. In doing so I changed the `process.exit()` calls to throw Errors instead. I added a number of test cases for input validation but did not include any CDK level validations (e.g. of generated CloudFormation templates).