### PR TITLE
Remove linting from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-  - repo: local
-    hooks:
-      - id: npm-lint
-        name: npm-lint
-        entry: npm run lint:fix
-        language: system
-        types_or: [ts, javascript, json]
-        require_serial: true
-        pass_filenames: false
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.2.0
     hooks:


### PR DESCRIPTION
For some team members, running `npm run lint` is remarkably slow (on the
order of minutes) when run across the full codebase. Because most
developers have ESLint run as part of the save process in their IDEs and
because we catch problems with linting in the CI pipeline; we can safely
remove it from the pre-commit configuration and be sure that unlinted
code does not make it to the `develop` branch. Once we've resolved
issues with linting being slow, we can potentially add this back.
