### PR TITLE
DOW Schema Improvements

### DIFF
--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -388,8 +388,6 @@ components:
           format: date
         incumbent_contractor_name:
           type: string
-        task_order_number:
-          type: string
         previous_task_order_number:
           type: string
     CurrentEnvironment:
@@ -599,7 +597,9 @@ components:
         contractor_required_training:
           type: boolean
         required_training_services:
-          $ref: "#/components/schemas/TrainingCourses"
+          type: array
+          items:
+            $ref: "#/components/schemas/TrainingCourses"
     TrainingCourses:
       description: "Part of DOW, part of schema for ContractConsiderations, includes training courses name and value"
       type: object


### PR DESCRIPTION
## Overview
There were several uncaught DOW schema incompatibilities, this PR's intention is to fix those problems and refine the schema to better serve the `generateDocument` API.

See the following comments for the reason for the changes:
https://github.com/dod-ccpo/atat-snow/pull/67#issuecomment-1139022297
https://github.com/dod-ccpo/atat-snow/pull/67#issuecomment-1139043489

### Changes
`required_training_services` is now an array of training courses, to
better reflect the expected SNOW input

Remove `task_order_number`, this field is completed by the KO and
isn't required to be passed to the DOW