### PR TITLE
Add two cost queues to infrastructure

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -150,7 +150,7 @@
         "filename": "lib/atat-web-api-stack.ts",
         "hashed_secret": "e2c872ec4dc5d6d2ca8f1f22852b4670d039470a",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 38
       }
     ],
     "lib/constructs/api-user.test.ts": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2022-05-12T20:40:23Z"
+  "generated_at": "2022-06-07T12:21:36Z"
 }

--- a/lib/atat-web-api-stack.ts
+++ b/lib/atat-web-api-stack.ts
@@ -11,7 +11,7 @@ import { HttpMethod } from "./http";
 import { ProvisioningWorkflow } from "./constructs/provisioning-sfn-workflow";
 import { ApiUser } from "./constructs/api-user";
 import * as idp from "./constructs/identity-provider";
-import { Queue } from "./constructs/sqs";
+import { AtatQueue } from "./constructs/sqs";
 
 export interface AtatWebApiStackProps extends cdk.StackProps {
   environmentName: string;
@@ -101,7 +101,7 @@ export class AtatWebApiStack extends cdk.Stack {
     );
 
     // Cost Queues
-    const costRequestQueue = new Queue(this, "CostRequest", { environmentName }).sqs;
-    const costResponseQueue = new Queue(this, "CostResponse", { environmentName }).sqs;
+    const costRequestQueue = new AtatQueue(this, "CostRequest", { environmentName }).sqs;
+    const costResponseQueue = new AtatQueue(this, "CostResponse", { environmentName }).sqs;
   }
 }

--- a/lib/atat-web-api-stack.ts
+++ b/lib/atat-web-api-stack.ts
@@ -11,6 +11,7 @@ import { HttpMethod } from "./http";
 import { ProvisioningWorkflow } from "./constructs/provisioning-sfn-workflow";
 import { ApiUser } from "./constructs/api-user";
 import * as idp from "./constructs/identity-provider";
+import { Queue } from "./constructs/sqs";
 
 export interface AtatWebApiStackProps extends cdk.StackProps {
   environmentName: string;
@@ -98,5 +99,9 @@ export class AtatWebApiStack extends cdk.Stack {
       provisioningSfn.provisioningQueueConsumer.method,
       new apigw.LambdaIntegration(provisioningSfn.provisioningQueueConsumer.fn)
     );
+
+    // Cost Queues
+    const costRequestQueue = new Queue(this, "CostRequest", { environmentName }).sqs;
+    const costResponseQueue = new Queue(this, "CostResponse", { environmentName }).sqs;
   }
 }

--- a/lib/constructs/provisioning-sfn-workflow.ts
+++ b/lib/constructs/provisioning-sfn-workflow.ts
@@ -10,7 +10,7 @@ import { HttpMethod } from "../http";
 import { ApiSfnFunction } from "./api-sfn-function";
 import { IdentityProviderLambdaClient, IIdentityProvider } from "./identity-provider";
 import { mapTasks, TasksMap } from "./sfn-lambda-invoke-task";
-import { Queue } from "./sqs";
+import { AtatQueue } from "./sqs";
 import { StateMachine } from "./state-machine";
 
 /**
@@ -56,7 +56,7 @@ export class ProvisioningWorkflow extends Construct implements IProvisioningWork
     super(scope, id);
     const { environmentName } = props;
 
-    this.provisioningJobsQueue = new Queue(scope, "ProvisioningJobsQueue", { environmentName }).sqs;
+    this.provisioningJobsQueue = new AtatQueue(scope, "ProvisioningJobsQueue", { environmentName }).sqs;
 
     // Provisioning State machine functions
     const cspConfig = secrets.Secret.fromSecretNameV2(

--- a/lib/constructs/provisioning-sfn-workflow.ts
+++ b/lib/constructs/provisioning-sfn-workflow.ts
@@ -10,6 +10,7 @@ import { HttpMethod } from "../http";
 import { ApiSfnFunction } from "./api-sfn-function";
 import { IdentityProviderLambdaClient, IIdentityProvider } from "./identity-provider";
 import { mapTasks, TasksMap } from "./sfn-lambda-invoke-task";
+import { Queue } from "./sqs";
 import { StateMachine } from "./state-machine";
 
 /**
@@ -55,10 +56,7 @@ export class ProvisioningWorkflow extends Construct implements IProvisioningWork
     super(scope, id);
     const { environmentName } = props;
 
-    this.provisioningJobsQueue = new sqs.Queue(scope, "ProvisioningJobsQueue", {
-      fifo: true,
-      contentBasedDeduplication: true,
-    });
+    this.provisioningJobsQueue = new Queue(scope, "ProvisioningJobsQueue", { environmentName }).sqs;
 
     // Provisioning State machine functions
     const cspConfig = secrets.Secret.fromSecretNameV2(

--- a/lib/constructs/sqs.test.ts
+++ b/lib/constructs/sqs.test.ts
@@ -1,13 +1,13 @@
 import * as cdk from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { Queue } from "./sqs";
+import { AtatQueue } from "./sqs";
 
 describe("IFP Cost Queues", () => {
   test("Ensure Cost Request and Response Queues are created", async () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "TestStack");
-    const costRequestQueue = new Queue(stack, "TestRequest", { environmentName: "TestAt-0000" }).sqs;
-    const costResponseQueue = new Queue(stack, "TestResponse", { environmentName: "TestAt-0000" }).sqs;
+    const costRequestQueue = new AtatQueue(stack, "TestRequest", { environmentName: "TestAt-0000" }).sqs;
+    const costResponseQueue = new AtatQueue(stack, "TestResponse", { environmentName: "TestAt-0000" }).sqs;
 
     const template = Template.fromStack(stack);
     template.hasResourceProperties(

--- a/lib/constructs/sqs.test.ts
+++ b/lib/constructs/sqs.test.ts
@@ -1,0 +1,19 @@
+import * as cdk from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Queue } from "./sqs";
+
+describe("IFP Cost Queues", () => {
+  test("Ensure Cost Request and Response Queues are created", async () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack");
+    const costRequestQueue = new Queue(stack, "TestRequest", { environmentName: "TestAt-0000" }).sqs;
+    const costResponseQueue = new Queue(stack, "TestResponse", { environmentName: "TestAt-0000" }).sqs;
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties(
+      "AWS::SQS::Queue",
+      Match.objectLike({ ContentBasedDeduplication: true, FifoQueue: true })
+    );
+    template.resourceCountIs("AWS::SQS::Queue", 2);
+  });
+});

--- a/lib/constructs/sqs.ts
+++ b/lib/constructs/sqs.ts
@@ -1,0 +1,34 @@
+import * as sqs from "aws-cdk-lib/aws-sqs";
+import { QueueProps } from "aws-cdk-lib/aws-sqs";
+import { Construct } from "constructs";
+
+export interface SQSProps extends QueueProps {
+  /**
+   * Props to override the default props of the created SQS
+   */
+  overrideSqsProps?: QueueProps;
+  /**
+   * Environment name to help differentiate the queues made
+   */
+  environmentName: string;
+}
+
+/**
+ * A basic SQS queue
+ * - defaults to an FIFO queue
+ */
+export class Queue extends Construct {
+  /**
+   * The SQS resource that gets created.
+   */
+  public readonly sqs: sqs.IQueue;
+
+  constructor(scope: Construct, id: string, props: SQSProps) {
+    super(scope, id);
+    this.sqs = new sqs.Queue(scope, `${props.environmentName}${id}Queue`, {
+      fifo: true,
+      contentBasedDeduplication: true,
+      ...props.overrideSqsProps,
+    });
+  }
+}

--- a/lib/constructs/sqs.ts
+++ b/lib/constructs/sqs.ts
@@ -14,10 +14,10 @@ export interface SQSProps extends QueueProps {
 }
 
 /**
- * A basic SQS queue
+ * A basic SQS queue used in ATAT
  * - defaults to an FIFO queue
  */
-export class Queue extends Construct {
+export class AtatQueue extends Construct {
   /**
    * The SQS resource that gets created.
    */


### PR DESCRIPTION
Create new `Queue` construct.
Add two queues to the atat-web-api-stack
- `costRequestQueue`
- `costResponseQueue`
- add unit test for queue

Update the provisioning queue to use new `Queue` construct.

Ticket: AT-7453
