### PR TITLE
AT-7454: Added CostRequest & CostResponse schema objects

### DIFF
--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -315,6 +315,35 @@ components:
         content:
           type: object
           additionalProperties: true
+    CostRequest:
+      description: >-
+        Represents a request for Cost data to be fulfilled by the ATAT Orchestrator by invoking the appropriate /costs
+        API for a given Cloud Service Provider
+      properties:
+        request_id:
+          description: ID to enable correlating Cost reqeusts with responses
+          type: string
+          format: uuid
+        portfolio_id:
+          type: string
+        target_csp:
+          $ref: "#/components/schemas/TargetCloudServiceProvider"
+        start_date:
+          description: Start date of Cost query
+          type: string
+          format: date
+          example: "2021-07-01"
+        end_date:
+          description: End date of Cost query
+          type: string
+          format: date
+          example: "2022-07-01"
+    CostResponse:
+      description: >-
+        Represents a response for Cost data which will have been fulfilled by the ATAT Orchestrator. Will contain the
+        results of the invocation of the matching Cloud Service Provider's /costs API.
+      allOf:
+        - $ref: "#/components/schemas/CspResponse"
     GenerateDocumentRequest:
       oneOf:
         - $ref: "#/components/schemas/DescriptionOfWork"

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -319,6 +319,7 @@ components:
       description: >-
         Represents a request for Cost data to be fulfilled by the ATAT Orchestrator by invoking the appropriate /costs
         API for a given Cloud Service Provider
+      type: object
       properties:
         request_id:
           description: ID to enable correlating Cost reqeusts with responses
@@ -342,6 +343,7 @@ components:
       description: >-
         Represents a response for Cost data which will have been fulfilled by the ATAT Orchestrator. Will contain the
         results of the invocation of the matching Cloud Service Provider's /costs API.
+      type: object
       allOf:
         - $ref: "#/components/schemas/CspResponse"
     GenerateDocumentRequest:


### PR DESCRIPTION
This PR simply defines the schema to be used in other tickets. Ended up re-using `CspResponse` rather than recreating the wheel for `CostResponse`. 