### PR TITLE
Bundle puppeteer-core with the generate-document fn

### DIFF
--- a/lib/atat-web-api-stack.ts
+++ b/lib/atat-web-api-stack.ts
@@ -114,7 +114,7 @@ export class AtatWebApiStack extends cdk.Stack {
       runtime: lambda.Runtime.NODEJS_16_X,
       memorySize: 512,
       bundling: {
-        nodeModules: ["@sparticuz/chrome-aws-lambda"],
+        nodeModules: ["@sparticuz/chrome-aws-lambda", "puppeteer-core"],
       },
       layers: [documentGenerationLayer],
       timeout: cdk.Duration.seconds(60),


### PR DESCRIPTION
Add `puppeteer-core` as dependency in the bundling of the generate
document lambda, due to the below error. The error causes the
`ATAT Generate Description of Work` subflow to error.
```
Cannot find module 'puppeteer-core/lib/cjs/puppeteer/common/Browser.js'
```

**Note:** This was not included previously, because it did not appear to be required and worked in sandbox without the addition of `puppeteer-core` being bundled.