### PR TITLE
AT-7628: Adding proxy routes to enqueue cost API requests and dequeue responses

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -150,7 +150,7 @@
         "filename": "lib/atat-web-api-stack.ts",
         "hashed_secret": "e2c872ec4dc5d6d2ca8f1f22852b4670d039470a",
         "is_verified": false,
-        "line_number": 41
+        "line_number": 42
       }
     ],
     "lib/constructs/api-user.test.ts": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2022-06-08T22:35:12Z"
+  "generated_at": "2022-06-16T13:54:56Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -150,7 +150,7 @@
         "filename": "lib/atat-web-api-stack.ts",
         "hashed_secret": "e2c872ec4dc5d6d2ca8f1f22852b4670d039470a",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 41
       }
     ],
     "lib/constructs/api-user.test.ts": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2022-06-16T13:54:56Z"
+  "generated_at": "2022-06-16T15:21:11Z"
 }

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ correct, deploying follows similar steps to the sandbox environment!
 Start off by ensuring the changes to make look reasonable:
 
 ```bash
-cdk diff -c atat:EnvironmentId=<ENVIRONMENT_ID>
+cdk diff -c atat:EnvironmentId=<ENVIRONMENT_ID> -c atat:Sandbox=true
 ```
 
 And then once you've confirmed that they do, deploy:

--- a/api/cost/consume-cost-response.ts
+++ b/api/cost/consume-cost-response.ts
@@ -1,0 +1,18 @@
+import { CostResponse } from "../../models/cost-jobs";
+import { QueueConsumer } from "../util/queueConsumer";
+
+const COST_RESPONSE_QUEUE_URL = process.env.COST_RESPONSE_QUEUE_URL ?? "";
+
+class ConsumeCostResponse extends QueueConsumer<CostResponse> {
+  processMessage(message: string | undefined): CostResponse {
+    const { code, content } = JSON.parse(message ?? "");
+    return {
+      code,
+      content,
+    };
+  }
+}
+
+const handlerClass = new ConsumeCostResponse(COST_RESPONSE_QUEUE_URL);
+
+export const handler = handlerClass.createHandler();

--- a/api/cost/start-cost-job.test.ts
+++ b/api/cost/start-cost-job.test.ts
@@ -1,6 +1,11 @@
 import { Context } from "aws-lambda";
 import { mockClient } from "aws-sdk-client-mock";
-import { ApiSuccessResponse, OtherErrorResponse, SuccessStatusCode } from "../../utils/response";
+import {
+  ApiSuccessResponse,
+  OtherErrorResponse,
+  SuccessStatusCode,
+  ValidationErrorResponse,
+} from "../../utils/response";
 import { handler } from "./start-cost-job";
 import { sqsClient } from "../../utils/aws-sdk/sqs";
 import { SendMessageCommand } from "@aws-sdk/client-sqs";

--- a/api/cost/start-cost-job.test.ts
+++ b/api/cost/start-cost-job.test.ts
@@ -1,0 +1,88 @@
+import { Context } from "aws-lambda";
+import { mockClient } from "aws-sdk-client-mock";
+import { ApiSuccessResponse, OtherErrorResponse, SuccessStatusCode } from "../../utils/response";
+import { handler } from "./start-cost-job";
+import { sqsClient } from "../../utils/aws-sdk/sqs";
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import { CostRequest } from "../../models/cost-jobs";
+
+const sqsMock = mockClient(sqsClient);
+beforeEach(() => {
+  sqsMock.reset();
+});
+
+const validCostRequest: CostRequest = {
+  requestId: "81b31a89-e3e5-46ee-acfe-75436bd14577",
+  portfolioId: "b02e77d1-234d-4e3d-bc85-b57ca5a93952",
+  startDate: "2022-01-01",
+  endDate: "2022-12-01",
+};
+const requestContext = { identity: { sourceIp: "203.0.113.0" } };
+const baseApiRequest = {
+  headers: {
+    "Content-Type": "application/json",
+  },
+  requestContext,
+} as any;
+
+describe("Cost request operations", () => {
+  it("should return successfully if no error enqueueing message", async () => {
+    const request = {
+      ...baseApiRequest,
+      body: JSON.stringify(validCostRequest),
+    };
+    const response = await handler(request, {} as Context, () => null);
+    expect(response).toBeInstanceOf(ApiSuccessResponse);
+    expect(response).toEqual(new ApiSuccessResponse(validCostRequest, SuccessStatusCode.CREATED));
+  });
+
+  it("should attempt to send SQS message", async () => {
+    process.env.COST_REQUEST_QUEUE_URL = "my url";
+    const request = {
+      ...baseApiRequest,
+      body: JSON.stringify(validCostRequest),
+    };
+    await handler(request, {} as Context, () => null);
+
+    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(1);
+    expect(
+      sqsMock.commandCalls(
+        SendMessageCommand,
+        {
+          QueueUrl: "my url",
+          MessageBody: JSON.stringify(validCostRequest),
+          MessageGroupId: "cost-request-queue-message-group",
+        },
+        true
+      )
+    ).toHaveLength(1);
+  });
+
+  it("should throw an error if missing startDate", async () => {
+    const request = {
+      ...baseApiRequest,
+      body: JSON.stringify({
+        requestId: "81b31a89-e3e5-46ee-acfe-75436bd14577",
+        portfolioId: "b02e77d1-234d-4e3d-bc85-b57ca5a93952",
+        endDate: "2022-12-01",
+      }),
+    };
+    const response = await handler(baseApiRequest, {} as Context, () => null);
+    expect(response).toBeInstanceOf(OtherErrorResponse);
+  });
+
+  it("should throw an error if missing requestId", async () => {
+    const invalidCostRequest = {
+      jobId: "81b31a89-e3e5-46ee-acfe-75436bd14577",
+      portfolioId: "b02e77d1-234d-4e3d-bc85-b57ca5a93952",
+      startDate: "2022-01-01",
+      endDate: "2022-12-01",
+    };
+    const request = {
+      ...baseApiRequest,
+      body: JSON.stringify(invalidCostRequest),
+    };
+    const response = await handler(baseApiRequest, {} as Context, () => null);
+    expect(response).toBeInstanceOf(OtherErrorResponse);
+  });
+});

--- a/api/cost/start-cost-job.test.ts
+++ b/api/cost/start-cost-job.test.ts
@@ -67,8 +67,8 @@ describe("Cost request operations", () => {
         endDate: "2022-12-01",
       }),
     };
-    const response = await handler(baseApiRequest, {} as Context, () => null);
-    expect(response).toBeInstanceOf(OtherErrorResponse);
+    const response = await handler(request, {} as Context, () => null);
+    expect(response).toBeInstanceOf(ValidationErrorResponse);
   });
 
   it("should throw an error if missing requestId", async () => {
@@ -82,7 +82,7 @@ describe("Cost request operations", () => {
       ...baseApiRequest,
       body: JSON.stringify(invalidCostRequest),
     };
-    const response = await handler(baseApiRequest, {} as Context, () => null);
-    expect(response).toBeInstanceOf(OtherErrorResponse);
+    const response = await handler(request, {} as Context, () => null);
+    expect(response).toBeInstanceOf(ValidationErrorResponse);
   });
 });

--- a/api/cost/start-cost-job.ts
+++ b/api/cost/start-cost-job.ts
@@ -1,0 +1,54 @@
+import { injectLambdaContext } from "@aws-lambda-powertools/logger";
+import middy from "@middy/core";
+import errorLogger from "@middy/error-logger";
+import httpJsonBodyParser from "@middy/http-json-body-parser";
+import inputOutputLogger from "@middy/input-output-logger";
+import validator from "@middy/validator";
+import { APIGatewayProxyResult } from "aws-lambda";
+import JSONErrorHandlerMiddleware from "middy-middleware-json-error-handler";
+import { RequestEvent } from "../../models/document-generation";
+import { logger } from "../../utils/logging";
+import { errorHandlingMiddleware } from "../../utils/middleware/error-handling-middleware";
+import { IpCheckerMiddleware } from "../../utils/middleware/ip-logging";
+import { wrapSchema } from "../../utils/middleware/schema-wrapper";
+import xssSanitizer from "../../utils/middleware/xss-sanitizer";
+import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
+import { sqsClient } from "../../utils/aws-sdk/sqs";
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import { CostRequest, costRequestSchema } from "../../models/cost-jobs";
+
+const MESSAGE_GROUP_ID = "cost-request-queue-message-group";
+
+/**
+ * Handles requests coming from HOTH client (Service Now) to initiate a Cost Request for a given Portfolio
+ *
+ * @param event - POST request from API Gateway with cost request job properties
+ */
+export async function baseHandler(event: RequestEvent<CostRequest>): Promise<APIGatewayProxyResult> {
+  const QUEUE_URL = process.env.COST_REQUEST_QUEUE_URL ?? "";
+  logger.info("Sending cost request message to queue", {
+    messageData: {
+      queue: QUEUE_URL,
+      messageGroupId: MESSAGE_GROUP_ID,
+    },
+  });
+  await sqsClient.send(
+    new SendMessageCommand({
+      QueueUrl: QUEUE_URL,
+      MessageBody: JSON.stringify(event.body),
+      MessageGroupId: MESSAGE_GROUP_ID,
+    })
+  );
+  return new ApiSuccessResponse(event.body, SuccessStatusCode.CREATED);
+}
+
+export const handler = middy(baseHandler)
+  .use(injectLambdaContext(logger))
+  .use(inputOutputLogger({ logger: (message) => logger.info("Event/Result", message) }))
+  .use(errorLogger({ logger: (err) => logger.error("An error occurred during the request", err as Error) }))
+  .use(IpCheckerMiddleware())
+  .use(httpJsonBodyParser())
+  .use(xssSanitizer())
+  .use(validator({ eventSchema: wrapSchema(costRequestSchema) }))
+  .use(errorHandlingMiddleware())
+  .use(JSONErrorHandlerMiddleware());

--- a/api/provision/consume-provisioning-job.ts
+++ b/api/provision/consume-provisioning-job.ts
@@ -1,41 +1,14 @@
-import { injectLambdaContext } from "@aws-lambda-powertools/logger";
-import { DeleteMessageCommand, ReceiveMessageCommand, ReceiveMessageCommandInput } from "@aws-sdk/client-sqs";
-import middy from "@middy/core";
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import JSONErrorHandlerMiddleware from "middy-middleware-json-error-handler";
 import { ProvisionRequest } from "../../models/provisioning-jobs";
-import { sqsClient } from "../../utils/aws-sdk/sqs";
-import { logger } from "../../utils/logging";
-import { errorHandlingMiddleware } from "../../utils/middleware/error-handling-middleware";
-import { IpCheckerMiddleware } from "../../utils/middleware/ip-logging";
-import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
-import errorLogger from "@middy/error-logger";
-import inputOutputLogger from "@middy/input-output-logger";
+import { QueueConsumer } from "../util/queueConsumer";
 
 const PROVISIONING_QUEUE_URL = process.env.PROVISIONING_QUEUE_URL ?? "";
 
-export async function baseHandler(_event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
-  // poll messages from the queue
-  const receiveMessageInput: ReceiveMessageCommandInput = {
-    QueueUrl: PROVISIONING_QUEUE_URL,
-    MaxNumberOfMessages: 10,
-  };
-  const receiveMessageCommand = new ReceiveMessageCommand(receiveMessageInput);
-  const consumedMessages = await sqsClient.send(receiveMessageCommand);
-
-  // Messages is undefined if queue empty
-  if (!consumedMessages.Messages) {
-    return new ApiSuccessResponse([], SuccessStatusCode.OK);
-  }
-  logger.info(`Number of Messages to process ${consumedMessages.Messages?.length}`);
-
-  // transform (remove unnecessary data) and gather messages
-  const messages: ProvisionRequest[] = [];
-  for (const record of consumedMessages.Messages) {
+class ConsumeProvisioningJob extends QueueConsumer<ProvisionRequest> {
+  processMessage(message: string | undefined): ProvisionRequest {
     const { jobId, userId, portfolioId, operationType, targetCsp, payload, cspInvocation, cspResponse } = JSON.parse(
-      record.Body ?? ""
+      message ?? ""
     );
-    const provisioningRequest = {
+    return {
       jobId,
       userId,
       portfolioId,
@@ -45,25 +18,9 @@ export async function baseHandler(_event: APIGatewayProxyEvent): Promise<APIGate
       cspInvocation,
       cspResponse: cspResponse.Payload,
     };
-
-    // messages being returned to client
-    messages.push(provisioningRequest);
-
-    // deleting message after processing
-    const deleteInput = { QueueUrl: PROVISIONING_QUEUE_URL, ReceiptHandle: record.ReceiptHandle };
-    const deleteMessageCommand = new DeleteMessageCommand(deleteInput);
-    const deletedMessageResponse = await sqsClient.send(deleteMessageCommand);
-    logger.info("Message Deleted", { deletedMessageResponse } as any);
   }
-
-  logger.info(`Number of Messages processed ${messages.length}`);
-  return new ApiSuccessResponse(messages, SuccessStatusCode.OK);
 }
 
-export const handler = middy(baseHandler)
-  .use(injectLambdaContext(logger))
-  .use(inputOutputLogger({ logger: (message) => logger.info("Event/Result", message) }))
-  .use(errorLogger({ logger: (err) => logger.error("An error occurred during the request", err as Error) }))
-  .use(IpCheckerMiddleware())
-  .use(errorHandlingMiddleware())
-  .use(JSONErrorHandlerMiddleware());
+const handlerClass = new ConsumeProvisioningJob(PROVISIONING_QUEUE_URL);
+
+export const handler = handlerClass.createHandler();

--- a/api/util/queueConsumer.test.ts
+++ b/api/util/queueConsumer.test.ts
@@ -1,0 +1,15 @@
+import { mockClient } from "aws-sdk-client-mock";
+import { sqsClient } from "../../utils/aws-sdk/sqs";
+import { QueueConsumer } from "./queueConsumer";
+
+const sqsMock = mockClient(sqsClient);
+beforeEach(() => {
+  sqsMock.reset();
+});
+
+// TODO: break out common tests to here using this (or similar) mock implementation
+class MockConsumer extends QueueConsumer<string> {
+  processMessage(message: string | undefined): string {
+    return "processed";
+  }
+}

--- a/api/util/queueConsumer.test.ts
+++ b/api/util/queueConsumer.test.ts
@@ -7,6 +7,12 @@ beforeEach(() => {
   sqsMock.reset();
 });
 
+describe("QueueConsumer Tests", () => {
+  it("Replace this once we break out common tests from start-provisioning-job.test.ts", async () => {
+    const queueConsumer = new MockConsumer("a url");
+  });
+});
+
 // TODO: break out common tests to here using this (or similar) mock implementation
 class MockConsumer extends QueueConsumer<string> {
   processMessage(message: string | undefined): string {

--- a/api/util/queueConsumer.ts
+++ b/api/util/queueConsumer.ts
@@ -1,0 +1,62 @@
+import { injectLambdaContext } from "@aws-lambda-powertools/logger";
+import { DeleteMessageCommand, ReceiveMessageCommand, ReceiveMessageCommandInput } from "@aws-sdk/client-sqs";
+import middy from "@middy/core";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import JSONErrorHandlerMiddleware from "middy-middleware-json-error-handler";
+import { sqsClient } from "../../utils/aws-sdk/sqs";
+import { logger } from "../../utils/logging";
+import { errorHandlingMiddleware } from "../../utils/middleware/error-handling-middleware";
+import { IpCheckerMiddleware } from "../../utils/middleware/ip-logging";
+import { ApiSuccessResponse, SuccessStatusCode } from "../../utils/response";
+import errorLogger from "@middy/error-logger";
+import inputOutputLogger from "@middy/input-output-logger";
+
+export abstract class QueueConsumer<T> {
+  readonly handler: (event: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult>;
+
+  constructor(queueUrl: string) {
+    this.handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+      // poll messages from the queue
+      const receiveMessageInput: ReceiveMessageCommandInput = {
+        QueueUrl: queueUrl,
+        MaxNumberOfMessages: 10,
+      };
+      const receiveMessageCommand = new ReceiveMessageCommand(receiveMessageInput);
+      const consumedMessages = await sqsClient.send(receiveMessageCommand);
+
+      // Messages is undefined if queue empty
+      if (!consumedMessages.Messages) {
+        return new ApiSuccessResponse([], SuccessStatusCode.OK);
+      }
+      logger.info(`Number of Messages to process ${consumedMessages.Messages?.length}`);
+
+      // transform (remove unnecessary data) and gather messages
+      const messages: T[] = [];
+      for (const record of consumedMessages.Messages) {
+        // messages being returned to client
+        messages.push(this.processMessage(record.Body));
+
+        // deleting message after processing
+        const deleteInput = { QueueUrl: queueUrl, ReceiptHandle: record.ReceiptHandle };
+        const deleteMessageCommand = new DeleteMessageCommand(deleteInput);
+        const deletedMessageResponse = await sqsClient.send(deleteMessageCommand);
+        logger.debug("Message Deleted", { deletedMessageResponse } as any);
+      }
+
+      logger.info(`Number of Messages processed ${messages.length}`);
+      return new ApiSuccessResponse(messages, SuccessStatusCode.OK);
+    };
+  }
+
+  abstract processMessage(message: string | undefined): T;
+
+  createHandler() {
+    return middy(this.handler)
+      .use(injectLambdaContext(logger))
+      .use(inputOutputLogger({ logger: (message) => logger.info("Event/Result", message) }))
+      .use(errorLogger({ logger: (err) => logger.error("An error occurred during the request", err as Error) }))
+      .use(IpCheckerMiddleware())
+      .use(errorHandlingMiddleware())
+      .use(JSONErrorHandlerMiddleware());
+  }
+}

--- a/api/util/queueConsumer.ts
+++ b/api/util/queueConsumer.ts
@@ -15,7 +15,7 @@ export abstract class QueueConsumer<T> {
   readonly handler: (event: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult>;
 
   constructor(queueUrl: string) {
-    this.handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    this.handler = async (_event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
       // poll messages from the queue
       const receiveMessageInput: ReceiveMessageCommandInput = {
         QueueUrl: queueUrl,

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -91,6 +91,51 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/CorsHeaders"
+  /cost-jobs:
+    get:
+      tags:
+        - cost
+      description: Consumes and returns up to ten of the most recently completed Cost Responses from the eponymous Queue
+      operationId: consumeCostJobs
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CostResponse"
+    post:
+      tags:
+        - cost
+      description: Starts a new Cost Request to the specified CSP
+      operationId: startCostJob
+      responses:
+        "201":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CostRequest"
+        "400":
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CostRequest"
+    options:
+      tags:
+        - cors
+      description: CORS headers
+      responses:
+        "200":
+          $ref: "#/components/responses/CorsHeaders"
 components:
   responses:
     CorsHeaders:

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -96,7 +96,7 @@ paths:
       tags:
         - cost
       description: Consumes and returns up to ten of the most recently completed Cost Responses from the eponymous Queue
-      operationId: consumeCostJobs
+      operationId: consumeCostResponses
       responses:
         "200":
           description: Successful operation

--- a/lib/atat-web-api-stack.ts
+++ b/lib/atat-web-api-stack.ts
@@ -14,6 +14,7 @@ import { ProvisioningWorkflow } from "./constructs/provisioning-sfn-workflow";
 import { ApiUser } from "./constructs/api-user";
 import * as idp from "./constructs/identity-provider";
 import { AtatQueue } from "./constructs/sqs";
+import { CostApiImplementation } from "./constructs/cost-api-implementation";
 
 export interface AtatWebApiStackProps extends cdk.StackProps {
   environmentName: string;
@@ -121,8 +122,7 @@ export class AtatWebApiStack extends cdk.Stack {
     });
     generateDocumentResource.addMethod(HttpMethod.POST, new apigw.LambdaIntegration(generateDocumentFn));
 
-    // Cost Queues
-    const costRequestQueue = new AtatQueue(this, "CostRequest", { environmentName }).sqs;
-    const costResponseQueue = new AtatQueue(this, "CostResponse", { environmentName }).sqs;
+    // Build all Cost Resources
+    new CostApiImplementation(this, { environmentName, api, vpc: props?.network?.vpc });
   }
 }

--- a/lib/atat-web-api-stack.ts
+++ b/lib/atat-web-api-stack.ts
@@ -123,6 +123,6 @@ export class AtatWebApiStack extends cdk.Stack {
     generateDocumentResource.addMethod(HttpMethod.POST, new apigw.LambdaIntegration(generateDocumentFn));
 
     // Build all Cost Resources
-    new CostApiImplementation(this, { environmentName, api, vpc: props?.network?.vpc });
+    const costApi = new CostApiImplementation(this, { environmentName, api, vpc: props?.network?.vpc });
   }
 }

--- a/lib/atat-web-api-stack.ts
+++ b/lib/atat-web-api-stack.ts
@@ -123,6 +123,10 @@ export class AtatWebApiStack extends cdk.Stack {
     generateDocumentResource.addMethod(HttpMethod.POST, new apigw.LambdaIntegration(generateDocumentFn));
 
     // Build all Cost Resources
-    const costApi = new CostApiImplementation(this, { environmentName, api, vpc: props?.network?.vpc });
+    const costApi = new CostApiImplementation(this, {
+      environmentName,
+      apiParent: api.restApi.root,
+      vpc: props?.network?.vpc,
+    });
   }
 }

--- a/lib/atat-web-api-stack.ts
+++ b/lib/atat-web-api-stack.ts
@@ -13,7 +13,6 @@ import { HttpMethod } from "./http";
 import { ProvisioningWorkflow } from "./constructs/provisioning-sfn-workflow";
 import { ApiUser } from "./constructs/api-user";
 import * as idp from "./constructs/identity-provider";
-import { AtatQueue } from "./constructs/sqs";
 import { CostApiImplementation } from "./constructs/cost-api-implementation";
 
 export interface AtatWebApiStackProps extends cdk.StackProps {

--- a/lib/constructs/api-route.ts
+++ b/lib/constructs/api-route.ts
@@ -1,5 +1,7 @@
 import * as apigw from "aws-cdk-lib/aws-apigateway";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { HttpMethod } from "../http";
+import { Method } from "aws-cdk-lib/aws-apigateway";
 
 export interface ApiRouteProps {
   readonly environmentName: string;
@@ -9,5 +11,5 @@ export interface ApiRouteProps {
 
 export interface IApiRoute {
   readonly path: apigw.IResource;
-  // readonly methods: { [key in HttpMethod]: apigw.Method };
+  readonly methods: Record<HttpMethod, Method>;
 }

--- a/lib/constructs/api-route.ts
+++ b/lib/constructs/api-route.ts
@@ -1,4 +1,3 @@
-import { HttpMethod } from "../http";
 import * as apigw from "aws-cdk-lib/aws-apigateway";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 
@@ -6,7 +5,6 @@ export interface ApiRouteProps {
   readonly environmentName: string;
   readonly vpc?: ec2.IVpc;
   readonly apiParent: apigw.IResource;
-  readonly name: string;
 }
 
 export interface IApiRoute {

--- a/lib/constructs/api-route.ts
+++ b/lib/constructs/api-route.ts
@@ -1,0 +1,15 @@
+import { HttpMethod } from "../http";
+import * as apigw from "aws-cdk-lib/aws-apigateway";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+
+export interface ApiRouteProps {
+  readonly environmentName: string;
+  readonly vpc?: ec2.IVpc;
+  readonly apiParent: apigw.IResource;
+  readonly name: string;
+}
+
+export interface IApiRoute {
+  readonly path: apigw.IResource;
+  // readonly methods: { [key in HttpMethod]: apigw.Method };
+}

--- a/lib/constructs/cost-api-implementation.test.ts
+++ b/lib/constructs/cost-api-implementation.test.ts
@@ -1,0 +1,65 @@
+import * as cdk from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+import { CostApiImplementation } from "./cost-api-implementation";
+import { AtatRestApi, AtatRestApiProps } from "./apigateway";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+
+describe("Cost API Implementation Tests", () => {
+  let stack: cdk.Stack;
+  let template: Template;
+  let costApiImplementation: CostApiImplementation;
+
+  // Create the stack once and then run different tests against it
+  beforeAll(() => {
+    // GIVEN
+    const app = new cdk.App();
+    stack = new cdk.Stack(app, "TestStack");
+    const vpc = new ec2.Vpc(stack, "TestAtatVpc");
+    const apiProps: AtatRestApiProps = {
+      restApiName: `TestHothApi`,
+      binaryMediaTypes: ["application/json", "application/pdf"],
+    };
+    const api = new AtatRestApi(stack, "HothApi", apiProps);
+    // WHEN
+    costApiImplementation = new CostApiImplementation(stack, { environmentName: "testEnv", api, vpc });
+    template = Template.fromStack(stack);
+  });
+
+  test("Ensure SQS (FIFO) Queues are created", async () => {
+    template.hasResourceProperties(
+      "AWS::SQS::Queue",
+      Match.objectLike({ ContentBasedDeduplication: true, FifoQueue: true })
+    );
+    expect(costApiImplementation.costRequestQueue).not.toEqual(undefined);
+    expect(costApiImplementation.costResponseQueue).not.toEqual(undefined);
+  });
+
+  test("Ensure Result Lambda is created & has queue URL", async () => {
+    template.hasResourceProperties(
+      "AWS::Lambda::Function",
+      Match.objectLike({
+        Environment: {
+          Variables: {
+            COST_REQUEST_QUEUE_URL: Match.anyValue(),
+          },
+        },
+        Role: stack.resolve((costApiImplementation.startCostJobFn.role?.node.defaultChild as CfnRole).attrArn),
+      })
+    );
+  });
+
+  test("Ensure Consumer Lambda is created & has queue URL", async () => {
+    template.hasResourceProperties(
+      "AWS::Lambda::Function",
+      Match.objectLike({
+        Environment: {
+          Variables: {
+            COST_RESPONSE_QUEUE_URL: Match.anyValue(),
+          },
+        },
+        Role: stack.resolve((costApiImplementation.consumeCostResponseFn.role?.node.defaultChild as CfnRole).attrArn),
+      })
+    );
+  });
+});

--- a/lib/constructs/cost-api-implementation.test.ts
+++ b/lib/constructs/cost-api-implementation.test.ts
@@ -22,7 +22,12 @@ describe("Cost API Implementation Tests", () => {
     };
     const api = new AtatRestApi(stack, "HothApi", apiProps);
     // WHEN
-    costApiImplementation = new CostApiImplementation(stack, { environmentName: "testEnv", api, vpc });
+    costApiImplementation = new CostApiImplementation(stack, {
+      environmentName: "testEnv",
+      apiParent: api.restApi.root,
+      vpc,
+    });
+
     template = Template.fromStack(stack);
   });
 

--- a/lib/constructs/cost-api-implementation.ts
+++ b/lib/constructs/cost-api-implementation.ts
@@ -19,8 +19,8 @@ export interface CostResourcesProps {
 export interface ICostApiImplementation extends IApiRoute {
   readonly costRequestQueue: AtatQueue;
   readonly costResponseQueue: AtatQueue;
-  readonly startCostJobFn: lambdaNodeJs.NodejsFunction;
-  readonly consumeCostResponseFn: lambdaNodeJs.NodejsFunction;
+  readonly startCostJobFn: lambda.IFunction;
+  readonly consumeCostResponseFn: lambda.IFunction;
 }
 
 export class CostApiImplementation extends Construct implements ICostApiImplementation {
@@ -56,7 +56,7 @@ export class CostApiImplementation extends Construct implements ICostApiImplemen
     function constructNodejsFunction(
       id: string,
       entry: string,
-      functionPropsOverride: object
+      environmentOverride: Record<string,string>
     ): lambdaNodeJs.NodejsFunction {
       return new lambdaNodeJs.NodejsFunction(scope, id, {
         entry,

--- a/lib/constructs/cost-api-implementation.ts
+++ b/lib/constructs/cost-api-implementation.ts
@@ -2,19 +2,11 @@ import { Construct } from "constructs";
 import * as lambdaNodeJs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Duration } from "aws-cdk-lib";
-import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { AtatQueue } from "./sqs";
-import { AtatRestApi } from "./apigateway";
 import { HttpMethod } from "../http";
 import * as apigw from "aws-cdk-lib/aws-apigateway";
-import { IApiRoute } from "./api-route";
-import { IResource, Method } from "aws-cdk-lib/aws-apigateway";
-
-export interface CostResourcesProps {
-  readonly environmentName: string;
-  readonly vpc?: ec2.IVpc;
-  readonly api: AtatRestApi;
-}
+import { IResource } from "aws-cdk-lib/aws-apigateway";
+import { ApiRouteProps, IApiRoute } from "./api-route";
 
 export interface ICostApiImplementation extends IApiRoute {
   readonly costRequestQueue: AtatQueue;
@@ -30,44 +22,52 @@ export class CostApiImplementation extends Construct implements ICostApiImplemen
   readonly costResponseQueue: AtatQueue;
   readonly startCostJobFn: lambdaNodeJs.NodejsFunction;
   readonly consumeCostResponseFn: lambdaNodeJs.NodejsFunction;
+  readonly props: ApiRouteProps;
 
-  constructor(scope: Construct, props: CostResourcesProps) {
+  constructor(scope: Construct, props: ApiRouteProps) {
     super(scope, "CostResources");
+    this.props = props;
 
     // Cost Queues
     this.costRequestQueue = new AtatQueue(this, "CostRequest", { environmentName: props.environmentName });
     this.costResponseQueue = new AtatQueue(this, "CostResponse", { environmentName: props.environmentName });
 
     // Cost Functions
-    this.startCostJobFn = constructNodejsFunction("StartCostRequestJob", "api/cost/start-cost-job.ts", {
+    this.startCostJobFn = this.constructNodejsFunction(scope, "StartCostRequestJob", "api/cost/start-cost-job.ts", {
       COST_REQUEST_QUEUE_URL: this.costRequestQueue.sqs.queueUrl,
     });
-    this.consumeCostResponseFn = constructNodejsFunction("ConsumeCostResponse", "api/cost/consume-cost-response.ts", {
-      COST_RESPONSE_QUEUE_URL: this.costResponseQueue.sqs.queueUrl,
-    });
+    this.consumeCostResponseFn = this.constructNodejsFunction(
+      scope,
+      "ConsumeCostResponse",
+      "api/cost/consume-cost-response.ts",
+      {
+        COST_RESPONSE_QUEUE_URL: this.costResponseQueue.sqs.queueUrl,
+      }
+    );
 
     this.costRequestQueue.sqs.grantSendMessages(this.startCostJobFn);
     this.costResponseQueue.sqs.grantConsumeMessages(this.consumeCostResponseFn);
 
-    this.path = props.api.restApi.root.addResource("cost-jobs");
+    this.path = props.apiParent.addResource("cost-jobs");
     this.path.addMethod(HttpMethod.POST, new apigw.LambdaIntegration(this.startCostJobFn));
     this.path.addMethod(HttpMethod.GET, new apigw.LambdaIntegration(this.consumeCostResponseFn));
+  }
 
-    function constructNodejsFunction(
-      id: string,
-      entry: string,
-      environmentOverride: Record<string,string>
-    ): lambdaNodeJs.NodejsFunction {
-      return new lambdaNodeJs.NodejsFunction(scope, id, {
-        entry,
-        runtime: lambda.Runtime.NODEJS_16_X,
-        vpc: props.vpc,
-        memorySize: 256,
-        timeout: Duration.seconds(5),
-        environment: {
-          ...functionPropsOverride,
-        },
-      });
-    }
+  private constructNodejsFunction(
+    scope: Construct,
+    id: string,
+    entry: string,
+    functionPropsOverride: object
+  ): lambdaNodeJs.NodejsFunction {
+    return new lambdaNodeJs.NodejsFunction(scope, id, {
+      entry,
+      runtime: lambda.Runtime.NODEJS_16_X,
+      vpc: this.props.vpc,
+      memorySize: 256,
+      timeout: Duration.seconds(5),
+      environment: {
+        ...functionPropsOverride,
+      },
+    });
   }
 }

--- a/lib/constructs/cost-api-implementation.ts
+++ b/lib/constructs/cost-api-implementation.ts
@@ -1,0 +1,73 @@
+import { Construct } from "constructs";
+import * as lambdaNodeJs from "aws-cdk-lib/aws-lambda-nodejs";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { Duration } from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { AtatQueue } from "./sqs";
+import { AtatRestApi } from "./apigateway";
+import { HttpMethod } from "../http";
+import * as apigw from "aws-cdk-lib/aws-apigateway";
+import { IApiRoute } from "./api-route";
+import { IResource, Method } from "aws-cdk-lib/aws-apigateway";
+
+export interface CostResourcesProps {
+  readonly environmentName: string;
+  readonly vpc?: ec2.IVpc;
+  readonly api: AtatRestApi;
+}
+
+export interface ICostApiImplementation extends IApiRoute {
+  readonly costRequestQueue: AtatQueue;
+  readonly costResponseQueue: AtatQueue;
+  readonly startCostJobFn: lambdaNodeJs.NodejsFunction;
+  readonly consumeCostResponseFn: lambdaNodeJs.NodejsFunction;
+}
+
+export class CostApiImplementation extends Construct implements ICostApiImplementation {
+  // readonly methods: { [key in HttpMethod]: Method };
+  readonly path: IResource;
+  readonly costRequestQueue: AtatQueue;
+  readonly costResponseQueue: AtatQueue;
+  readonly startCostJobFn: lambdaNodeJs.NodejsFunction;
+  readonly consumeCostResponseFn: lambdaNodeJs.NodejsFunction;
+
+  constructor(scope: Construct, props: CostResourcesProps) {
+    super(scope, "CostResources");
+
+    // Cost Queues
+    this.costRequestQueue = new AtatQueue(this, "CostRequest", { environmentName: props.environmentName });
+    this.costResponseQueue = new AtatQueue(this, "CostResponse", { environmentName: props.environmentName });
+
+    // Cost Functions
+    this.startCostJobFn = constructNodejsFunction("StartCostRequestJob", "api/cost/start-cost-job.ts", {
+      COST_REQUEST_QUEUE_URL: this.costRequestQueue.sqs.queueUrl,
+    });
+    this.consumeCostResponseFn = constructNodejsFunction("ConsumeCostResponse", "api/cost/consume-cost-response.ts", {
+      COST_RESPONSE_QUEUE_URL: this.costResponseQueue.sqs.queueUrl,
+    });
+
+    this.costRequestQueue.sqs.grantSendMessages(this.startCostJobFn);
+    this.costResponseQueue.sqs.grantConsumeMessages(this.consumeCostResponseFn);
+
+    this.path = props.api.restApi.root.addResource("cost-jobs");
+    this.path.addMethod(HttpMethod.POST, new apigw.LambdaIntegration(this.startCostJobFn));
+    this.path.addMethod(HttpMethod.GET, new apigw.LambdaIntegration(this.consumeCostResponseFn));
+
+    function constructNodejsFunction(
+      id: string,
+      entry: string,
+      functionPropsOverride: object
+    ): lambdaNodeJs.NodejsFunction {
+      return new lambdaNodeJs.NodejsFunction(scope, id, {
+        entry,
+        runtime: lambda.Runtime.NODEJS_16_X,
+        vpc: props.vpc,
+        memorySize: 256,
+        timeout: Duration.seconds(5),
+        environment: {
+          ...functionPropsOverride,
+        },
+      });
+    }
+  }
+}

--- a/models/cost-jobs.ts
+++ b/models/cost-jobs.ts
@@ -1,0 +1,21 @@
+import { CspResponse } from "./provisioning-jobs";
+
+export type CostResponse = CspResponse;
+
+export interface CostRequest {
+  requestId: string;
+  portfolioId: string;
+  startDate: string;
+  endDate: string;
+}
+
+export const costRequestSchema = {
+  type: "object",
+  required: ["requestId", "portfolioId", "startDate", "endDate"],
+  properties: {
+    requestId: { type: "string" },
+    portfolioId: { type: "string" },
+    startDate: { type: "string" },
+    endDate: { type: "string" },
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
     "outDir": "build/"
   },
   "exclude": [
+    "build",
     "node_modules",
     "cdk.out"
   ]

--- a/utils/middleware/common.ts
+++ b/utils/middleware/common.ts
@@ -1,0 +1,8 @@
+import { GenerateDocumentRequest, RequestEvent } from "../../models/document-generation";
+import { ProvisionRequest } from "../../models/provisioning-jobs";
+import { CostRequest, CostResponse } from "../../models/cost-jobs";
+import { APIGatewayProxyEvent } from "aws-lambda";
+
+export type CommonMiddlewareInputs =
+  | RequestEvent<ProvisionRequest | CostRequest | CostResponse | GenerateDocumentRequest>
+  | APIGatewayProxyEvent;

--- a/utils/middleware/error-handling-middleware.ts
+++ b/utils/middleware/error-handling-middleware.ts
@@ -1,10 +1,9 @@
 import middy from "@middy/core";
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { APIGatewayProxyResult } from "aws-lambda";
 import { serializeError } from "serialize-error";
 import { ValidationErrorResponse } from "../response";
 import { INTERNAL_SERVER_ERROR, REQUEST_BODY_INVALID } from "../errors";
 import { CspInvocation, CspResponse, ProvisionRequest } from "../../models/provisioning-jobs";
-import { GenerateDocumentRequest, RequestEvent } from "../../models/document-generation";
 import { logger } from "../logging";
 import { CommonMiddlewareInputs } from "./common";
 

--- a/utils/middleware/error-handling-middleware.ts
+++ b/utils/middleware/error-handling-middleware.ts
@@ -6,13 +6,9 @@ import { INTERNAL_SERVER_ERROR, REQUEST_BODY_INVALID } from "../errors";
 import { CspInvocation, CspResponse, ProvisionRequest } from "../../models/provisioning-jobs";
 import { GenerateDocumentRequest, RequestEvent } from "../../models/document-generation";
 import { logger } from "../logging";
+import { CommonMiddlewareInputs } from "./common";
 
-export type MiddlewareInputs =
-  | RequestEvent<ProvisionRequest>
-  | CspInvocation
-  | ProvisionRequest
-  | APIGatewayProxyEvent
-  | RequestEvent<GenerateDocumentRequest>;
+export type MiddlewareInputs = CommonMiddlewareInputs | CspInvocation | ProvisionRequest;
 export type MiddlewareOutputs = APIGatewayProxyResult | CspResponse | ValidationErrorResponse | ProvisionRequest;
 
 // A central place to catch and handle errors that occur before,

--- a/utils/middleware/ip-logging.ts
+++ b/utils/middleware/ip-logging.ts
@@ -1,13 +1,8 @@
 import middy from "@middy/core";
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { GenerateDocumentRequest, RequestEvent } from "../../models/document-generation";
-import { ProvisionRequest } from "../../models/provisioning-jobs";
+import { APIGatewayProxyResult } from "aws-lambda";
+import { CommonMiddlewareInputs } from "./common";
 
 // Create the middleware and export it
-export type CommonMiddlewareInputs =
-  | RequestEvent<ProvisionRequest>
-  | APIGatewayProxyEvent
-  | RequestEvent<GenerateDocumentRequest>;
 export const IpCheckerMiddleware = (): middy.MiddlewareObj<CommonMiddlewareInputs, APIGatewayProxyResult> => {
   // Set up a before check, this will run before the handler
   const before: middy.MiddlewareFn<CommonMiddlewareInputs, APIGatewayProxyResult> = async (request): Promise<void> => {

--- a/utils/middleware/xss-sanitizer.ts
+++ b/utils/middleware/xss-sanitizer.ts
@@ -1,8 +1,7 @@
 import middy from "@middy/core";
 import xss from "xss";
 import { APIGatewayProxyResult } from "aws-lambda";
-import { CommonMiddlewareInputs } from "./ip-logging";
-
+import { CommonMiddlewareInputs } from "./common";
 // keep plain text only
 const xssOptions = {
   allowList: {}, // empty means remove all tags


### PR DESCRIPTION
Added /cost-jobs resource + GET and POST routes
Tweaked middleware slightly to make it easier to add new types
Abstracted consume-provisioning-job.ts into a generic Queue Consumer class and used it to create consume-cost-response.ts.

Ticket: AT-7628