### PR TITLE
Implement CostRequest function

### DIFF
--- a/api/cost/cost-request-fn.test.ts
+++ b/api/cost/cost-request-fn.test.ts
@@ -1,0 +1,107 @@
+import { handler } from "./cost-request-fn";
+import { requestContext } from "../provision/start-provisioning-job.test";
+import { APIGatewayProxyEvent, Context, SQSEvent } from "aws-lambda";
+import * as crypto from "crypto";
+import { mockClient } from "aws-sdk-client-mock";
+import { sqsClient } from "../../utils/aws-sdk/sqs";
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import { mockReceiveMessageResponse } from "../provision/consume-provisioning-job.test";
+
+const validRequestBody = {
+  requestId: "5e1ec388-4a04-47ec-a3c9-6775f2a82d28",
+  portfolioId: "1c071937-0a4d-4bc0-98f0-48c0e79bb972",
+  targetCsp: {
+    uri: "https://cspA.com/",
+    name: "CSP_A",
+    network: "NETWORK_1",
+  },
+  startDate: "2019-03-03",
+};
+const validRequest = {
+  body: JSON.stringify(validRequestBody),
+  requestContext,
+} as any;
+
+const handlerSpy = jest.spyOn(console, "log");
+const sqsMock = mockClient(sqsClient);
+beforeEach(() => {
+  handlerSpy.mockReset();
+  sqsMock.reset();
+});
+
+describe("Happy path", () => {
+  it("should return 201", async () => {
+    // GIVEN
+    const queueEvent = generateTestEvent(validRequest.body);
+    const mockResponse = generateMockMessageResponses([validRequest.body]);
+    sqsMock.on(SendMessageCommand).resolves(mockResponse);
+    // WHEN
+    await handler(queueEvent, {} as Context, () => null);
+    // THEN
+    expect(handlerSpy).toBeCalledWith(queueEvent.Records);
+  });
+});
+
+describe("Sad path", () => {
+  it.skip("should return error", async () => {
+    // GIVEN
+    const badRequest = { ...validRequest, body: JSON.stringify(validRequestBody.targetCsp) };
+    const queueEvent = generateTestEvent(badRequest);
+    // WHEN
+    await handler(queueEvent, {} as Context, () => null);
+    // THEN
+    expect(handlerSpy).toBeCalledWith(queueEvent.Records);
+  });
+});
+
+function generateTestEvent(body: string): SQSEvent {
+  return {
+    Records: [
+      {
+        body,
+        messageId: "0",
+        messageAttributes: {},
+        receiptHandle: "",
+        eventSource: "",
+        eventSourceARN: "",
+        awsRegion: "us-east-1",
+        attributes: {
+          ApproximateFirstReceiveTimestamp: "",
+          ApproximateReceiveCount: "0",
+          SentTimestamp: "",
+          SenderId: "",
+        },
+        // The use of MD5 here is not for any cryptographic purpose. It is
+        // to mock a field of a Lambda event. This is only used for the
+        // purposes of a basic validation (much like CRC).
+        md5OfBody: crypto.createHash("md5").update(body).digest("hex"),
+      },
+    ],
+  };
+}
+
+function generateMockMessageResponses(messageBodies: any[]) {
+  const messages = messageBodies.map((body) => {
+    return {
+      MessageId: "b5353c",
+      ReceiptHandle: "AQC0e6b=",
+      MD5OfBody: "b03",
+      Body: JSON.stringify(body),
+      Attributes: undefined,
+      MD5OfMessageAttributes: undefined,
+      MessageAttributes: undefined,
+    };
+  });
+
+  return {
+    $metadata: {
+      httpStatusCode: 200,
+      requestId: "74b3f95",
+      extendedRequestId: undefined,
+      cfId: undefined,
+      attempts: 1,
+      totalRetryDelay: 0,
+    },
+    Messages: messages,
+  };
+}

--- a/api/cost/cost-request-fn.test.ts
+++ b/api/cost/cost-request-fn.test.ts
@@ -76,9 +76,9 @@ describe("Cost Request Fn", () => {
     const secondSentMessage: any = commandCalls[1].firstArg.input;
 
     // THEN
-    expect(JSON.parse(firstSentMessage.MessageBody).content.requestBody).toEqual(validMessages[0]);
+    expect(JSON.parse(firstSentMessage.MessageBody).content.request).toEqual(validMessages[0]);
     expect(firstSentMessage.MessageGroupId).toEqual(MESSAGE_GROUP_ID);
-    expect(JSON.parse(secondSentMessage.MessageBody).content.requestBody).toEqual(validMessages[1]);
+    expect(JSON.parse(secondSentMessage.MessageBody).content.request).toEqual(validMessages[1]);
     expect(secondSentMessage.MessageGroupId).toEqual(MESSAGE_GROUP_ID);
   });
 });

--- a/api/cost/cost-request-fn.test.ts
+++ b/api/cost/cost-request-fn.test.ts
@@ -1,31 +1,13 @@
 import { handler, MESSAGE_GROUP_ID } from "./cost-request-fn";
-import { requestContext } from "../provision/start-provisioning-job.test";
-import { Context, SQSEvent } from "aws-lambda";
+import { Context } from "aws-lambda";
 import { mockClient } from "aws-sdk-client-mock";
 import { sqsClient } from "../../utils/aws-sdk/sqs";
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { Network } from "../../models/cloud-service-providers";
-import { CostRequest } from "../../models/cost-jobs";
 import axios from "axios";
 import * as idpClient from "../../idp/client";
 import * as cspConfig from "../provision/csp-configuration";
-import * as crypto from "crypto";
-
-export const validRequestBody = {
-  requestId: "5e1ec388-4a04-47ec-a3c9-6775f2a82d28",
-  portfolioId: "1c071937-0a4d-4bc0-98f0-48c0e79bb972",
-  targetCsp: {
-    uri: "https://cspA.com/",
-    name: "CSP_A",
-    network: Network.NETWORK_1,
-  },
-  startDate: "2019-03-03",
-  endDate: "2020-04-30",
-};
-const validRequest = {
-  body: JSON.stringify(validRequestBody),
-  requestContext,
-} as any;
+import { validCostRequest, generateMockMessageResponses, generateTestSQSEvent } from "../util/common-test-fixtures";
 
 // Mocks
 jest.mock("../provision/csp-configuration");
@@ -45,9 +27,9 @@ describe("Cost Request Fn", () => {
   it("poll messages from request queue and send to response queue", async () => {
     // GIVEN
     const validMessages = [
-      validRequestBody,
+      validCostRequest,
       {
-        ...validRequestBody,
+        ...validCostRequest,
         requestId: "7w1er266-4a04-47ec-a3c9-6775f2a82d28",
         targetCsp: {
           uri: "https://cspMock.com/",
@@ -56,7 +38,7 @@ describe("Cost Request Fn", () => {
         },
       },
     ];
-    const queueEvent = generateTestEvent(validMessages);
+    const queueEvent = generateTestSQSEvent(validMessages);
     const mockResponse = generateMockMessageResponses(validMessages);
     mockedConfig.mockResolvedValue({ uri: "https://mockcsp.cspa/atat/" });
     mockedAxios.post.mockResolvedValue({
@@ -82,58 +64,3 @@ describe("Cost Request Fn", () => {
     expect(secondSentMessage.MessageGroupId).toEqual(MESSAGE_GROUP_ID);
   });
 });
-
-function generateTestEvent(recordBodies: CostRequest[]): SQSEvent {
-  const records = recordBodies.map((body) => {
-    const recordBody = JSON.stringify(body);
-    return {
-      body: recordBody,
-      messageId: "0",
-      messageAttributes: {},
-      receiptHandle: "",
-      eventSource: "",
-      eventSourceARN: "",
-      awsRegion: "us-east-1",
-      attributes: {
-        ApproximateFirstReceiveTimestamp: "",
-        ApproximateReceiveCount: "0",
-        SentTimestamp: "",
-        SenderId: "",
-      },
-      // The use of MD5 here is not for any cryptographic purpose. It is
-      // to mock a field of a Lambda event. This is only used for the
-      // purposes of a basic validation (much like CRC).
-      md5OfBody: crypto.createHash("md5").update(recordBody).digest("hex"),
-    };
-  });
-  return {
-    Records: records,
-  };
-}
-
-function generateMockMessageResponses(messageBodies: any[]) {
-  const messages = messageBodies.map((body) => {
-    const messageBody = JSON.stringify(body);
-    return {
-      MessageId: "b5353c",
-      ReceiptHandle: "AQC0e6b=",
-      MD5OfBody: crypto.createHash("md5").update(messageBody).digest("hex"),
-      Body: messageBody,
-      Attributes: undefined,
-      MD5OfMessageAttributes: undefined,
-      MessageAttributes: undefined,
-    };
-  });
-
-  return {
-    $metadata: {
-      httpStatusCode: 200,
-      requestId: "74b3f95",
-      extendedRequestId: undefined,
-      cfId: undefined,
-      attempts: 1,
-      totalRetryDelay: 0,
-    },
-    Messages: messages,
-  };
-}

--- a/api/cost/cost-request-fn.test.ts
+++ b/api/cost/cost-request-fn.test.ts
@@ -6,39 +6,41 @@ import { mockClient } from "aws-sdk-client-mock";
 import { sqsClient } from "../../utils/aws-sdk/sqs";
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { mockReceiveMessageResponse } from "../provision/consume-provisioning-job.test";
+import { Network } from "../../models/cloud-service-providers";
+import { SuccessStatusCode } from "../../utils/response";
 
-const validRequestBody = {
+export const validRequestBody = {
   requestId: "5e1ec388-4a04-47ec-a3c9-6775f2a82d28",
   portfolioId: "1c071937-0a4d-4bc0-98f0-48c0e79bb972",
   targetCsp: {
     uri: "https://cspA.com/",
     name: "CSP_A",
-    network: "NETWORK_1",
+    network: Network.NETWORK_1,
   },
   startDate: "2019-03-03",
+  endDate: "2020-04-30",
 };
 const validRequest = {
   body: JSON.stringify(validRequestBody),
   requestContext,
 } as any;
 
-const handlerSpy = jest.spyOn(console, "log");
 const sqsMock = mockClient(sqsClient);
 beforeEach(() => {
-  handlerSpy.mockReset();
   sqsMock.reset();
 });
 
 describe("Happy path", () => {
-  it("should return 201", async () => {
+  it("message sent to request queue", async () => {
     // GIVEN
     const queueEvent = generateTestEvent(validRequest.body);
     const mockResponse = generateMockMessageResponses([validRequest.body]);
     sqsMock.on(SendMessageCommand).resolves(mockResponse);
     // WHEN
-    await handler(queueEvent, {} as Context, () => null);
+    await handler(queueEvent, {} as Context);
+    const sentMessage: any = sqsMock.call(0).args[0].input;
     // THEN
-    expect(handlerSpy).toBeCalledWith(queueEvent.Records);
+    expect(JSON.parse(sentMessage.MessageBody).content.requestBody).toEqual(JSON.parse(validRequest.body));
   });
 });
 
@@ -48,9 +50,9 @@ describe("Sad path", () => {
     const badRequest = { ...validRequest, body: JSON.stringify(validRequestBody.targetCsp) };
     const queueEvent = generateTestEvent(badRequest);
     // WHEN
-    await handler(queueEvent, {} as Context, () => null);
+    await handler(queueEvent, {} as Context);
     // THEN
-    expect(handlerSpy).toBeCalledWith(queueEvent.Records);
+    // expect(handlerSpy).toBeCalledWith(queueEvent.Records);
   });
 });
 

--- a/api/cost/cost-request-fn.test.ts
+++ b/api/cost/cost-request-fn.test.ts
@@ -1,13 +1,15 @@
-import { handler } from "./cost-request-fn";
+import { handler, MESSAGE_GROUP_ID } from "./cost-request-fn";
 import { requestContext } from "../provision/start-provisioning-job.test";
-import { APIGatewayProxyEvent, Context, SQSEvent } from "aws-lambda";
-import * as crypto from "crypto";
+import { Context, SQSEvent } from "aws-lambda";
 import { mockClient } from "aws-sdk-client-mock";
 import { sqsClient } from "../../utils/aws-sdk/sqs";
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
-import { mockReceiveMessageResponse } from "../provision/consume-provisioning-job.test";
 import { Network } from "../../models/cloud-service-providers";
-import { SuccessStatusCode } from "../../utils/response";
+import { CostRequest } from "../../models/cost-jobs";
+import axios from "axios";
+import * as idpClient from "../../idp/client";
+import * as cspConfig from "../provision/csp-configuration";
+import * as crypto from "crypto";
 
 export const validRequestBody = {
   requestId: "5e1ec388-4a04-47ec-a3c9-6775f2a82d28",
@@ -25,70 +27,98 @@ const validRequest = {
   requestContext,
 } as any;
 
+// Mocks
+jest.mock("../provision/csp-configuration");
+const mockedConfig = cspConfig.getConfiguration as jest.MockedFn<typeof cspConfig.getConfiguration>;
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+jest.mock("../../idp/client");
+const mockedGetToken = idpClient.getToken as jest.MockedFn<typeof idpClient.getToken>;
 const sqsMock = mockClient(sqsClient);
+
 beforeEach(() => {
+  jest.resetAllMocks();
   sqsMock.reset();
 });
 
-describe("Happy path", () => {
-  it("message sent to request queue", async () => {
+describe("Cost Request Fn", () => {
+  it("poll messages from request queue and send to response queue", async () => {
     // GIVEN
-    const queueEvent = generateTestEvent(validRequest.body);
-    const mockResponse = generateMockMessageResponses([validRequest.body]);
-    sqsMock.on(SendMessageCommand).resolves(mockResponse);
-    // WHEN
-    await handler(queueEvent, {} as Context);
-    const sentMessage: any = sqsMock.call(0).args[0].input;
-    // THEN
-    expect(JSON.parse(sentMessage.MessageBody).content.requestBody).toEqual(JSON.parse(validRequest.body));
-  });
-});
-
-describe("Sad path", () => {
-  it.skip("should return error", async () => {
-    // GIVEN
-    const badRequest = { ...validRequest, body: JSON.stringify(validRequestBody.targetCsp) };
-    const queueEvent = generateTestEvent(badRequest);
-    // WHEN
-    await handler(queueEvent, {} as Context);
-    // THEN
-    // expect(handlerSpy).toBeCalledWith(queueEvent.Records);
-  });
-});
-
-function generateTestEvent(body: string): SQSEvent {
-  return {
-    Records: [
+    const validMessages = [
+      validRequestBody,
       {
-        body,
-        messageId: "0",
-        messageAttributes: {},
-        receiptHandle: "",
-        eventSource: "",
-        eventSourceARN: "",
-        awsRegion: "us-east-1",
-        attributes: {
-          ApproximateFirstReceiveTimestamp: "",
-          ApproximateReceiveCount: "0",
-          SentTimestamp: "",
-          SenderId: "",
+        ...validRequestBody,
+        requestId: "7w1er266-4a04-47ec-a3c9-6775f2a82d28",
+        targetCsp: {
+          uri: "https://cspMock.com/",
+          name: "CSP_Mock",
+          network: Network.NETWORK_1,
         },
-        // The use of MD5 here is not for any cryptographic purpose. It is
-        // to mock a field of a Lambda event. This is only used for the
-        // purposes of a basic validation (much like CRC).
-        md5OfBody: crypto.createHash("md5").update(body).digest("hex"),
       },
-    ],
+    ];
+    const queueEvent = generateTestEvent(validMessages);
+    const mockResponse = generateMockMessageResponses(validMessages);
+    mockedConfig.mockResolvedValue({ uri: "https://mockcsp.cspa/atat/" });
+    mockedAxios.post.mockResolvedValue({
+      data: { code: 200, content: "something" },
+      status: 200,
+      statusText: "OK",
+      headers: { "Content-Type": "application/json" },
+      config: {},
+    });
+    mockedGetToken.mockResolvedValue({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
+    sqsMock.on(SendMessageCommand).resolves(mockResponse);
+
+    // WHEN
+    await handler(queueEvent, {} as Context);
+    const commandCalls = sqsMock.commandCalls(SendMessageCommand);
+    const firstSentMessage: any = commandCalls[0].firstArg.input;
+    const secondSentMessage: any = commandCalls[1].firstArg.input;
+
+    // THEN
+    expect(JSON.parse(firstSentMessage.MessageBody).content.requestBody).toEqual(validMessages[0]);
+    expect(firstSentMessage.MessageGroupId).toEqual(MESSAGE_GROUP_ID);
+    expect(JSON.parse(secondSentMessage.MessageBody).content.requestBody).toEqual(validMessages[1]);
+    expect(secondSentMessage.MessageGroupId).toEqual(MESSAGE_GROUP_ID);
+  });
+});
+
+function generateTestEvent(recordBodies: CostRequest[]): SQSEvent {
+  const records = recordBodies.map((body) => {
+    const recordBody = JSON.stringify(body);
+    return {
+      body: recordBody,
+      messageId: "0",
+      messageAttributes: {},
+      receiptHandle: "",
+      eventSource: "",
+      eventSourceARN: "",
+      awsRegion: "us-east-1",
+      attributes: {
+        ApproximateFirstReceiveTimestamp: "",
+        ApproximateReceiveCount: "0",
+        SentTimestamp: "",
+        SenderId: "",
+      },
+      // The use of MD5 here is not for any cryptographic purpose. It is
+      // to mock a field of a Lambda event. This is only used for the
+      // purposes of a basic validation (much like CRC).
+      md5OfBody: crypto.createHash("md5").update(recordBody).digest("hex"),
+    };
+  });
+  return {
+    Records: records,
   };
 }
 
 function generateMockMessageResponses(messageBodies: any[]) {
   const messages = messageBodies.map((body) => {
+    const messageBody = JSON.stringify(body);
     return {
       MessageId: "b5353c",
       ReceiptHandle: "AQC0e6b=",
-      MD5OfBody: "b03",
-      Body: JSON.stringify(body),
+      MD5OfBody: crypto.createHash("md5").update(messageBody).digest("hex"),
+      Body: messageBody,
       Attributes: undefined,
       MD5OfMessageAttributes: undefined,
       MessageAttributes: undefined,

--- a/api/cost/cost-request-fn.test.ts
+++ b/api/cost/cost-request-fn.test.ts
@@ -7,7 +7,12 @@ import { Network } from "../../models/cloud-service-providers";
 import axios from "axios";
 import * as idpClient from "../../idp/client";
 import * as cspConfig from "../provision/csp-configuration";
-import { validCostRequest, generateMockMessageResponses, generateTestSQSEvent } from "../util/common-test-fixtures";
+import {
+  validCostRequest,
+  generateMockMessageResponses,
+  generateTestSQSEvent,
+  constructCspTarget,
+} from "../util/common-test-fixtures";
 
 // Mocks
 jest.mock("../provision/csp-configuration");
@@ -23,6 +28,7 @@ beforeEach(() => {
   sqsMock.reset();
 });
 
+const cspMock = constructCspTarget("CSP_Mock", Network.NETWORK_1);
 describe("Cost Request Fn", () => {
   it("poll messages from request queue and send to response queue", async () => {
     // GIVEN
@@ -31,16 +37,12 @@ describe("Cost Request Fn", () => {
       {
         ...validCostRequest,
         requestId: "7w1er266-4a04-47ec-a3c9-6775f2a82d28",
-        targetCsp: {
-          uri: "https://cspMock.com/",
-          name: "CSP_Mock",
-          network: Network.NETWORK_1,
-        },
+        targetCsp: cspMock,
       },
     ];
     const queueEvent = generateTestSQSEvent(validMessages);
     const mockResponse = generateMockMessageResponses(validMessages);
-    mockedConfig.mockResolvedValue({ uri: "https://mockcsp.cspa/atat/" });
+    mockedConfig.mockResolvedValue({ uri: cspMock.uri });
     mockedAxios.post.mockResolvedValue({
       data: { code: 200, content: "something" },
       status: 200,

--- a/api/cost/cost-request-fn.ts
+++ b/api/cost/cost-request-fn.ts
@@ -1,0 +1,58 @@
+import middy from "@middy/core";
+import { sqsClient } from "../../utils/aws-sdk/sqs";
+import { SQSEvent, SQSRecord } from "aws-lambda";
+import { logger } from "../../utils/logging";
+import { CostRequest } from "../../models/cost-jobs";
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import { injectLambdaContext } from "@aws-lambda-powertools/logger";
+import inputOutputLogger from "@middy/input-output-logger";
+import errorLogger from "@middy/error-logger";
+import { cspRequest } from "../util/csp-request";
+import { IpCheckerMiddleware } from "../../utils/middleware/ip-logging";
+import { errorHandlingMiddleware } from "../../utils/middleware/error-handling-middleware";
+import JSONErrorHandlerMiddleware from "middy-middleware-json-error-handler";
+
+const COST_RESPONSE_QUEUE_URL = process.env.COST_RESPONSE_QUEUE_URL ?? "";
+const MESSAGE_GROUP_ID = "cost-response-queue-message-group";
+
+async function baseHandler(event: SQSEvent): Promise<void> {
+  const processedMessages = [];
+  if (event.Records) {
+    const records = event.Records.map((record: SQSRecord) => record.body);
+    for (const record of records) {
+      logger.info("Record Body: ", { record });
+      processedMessages.push(record);
+
+      // get csp response back (using mock)
+      const requestBody: CostRequest = JSON.parse(record ?? "");
+      const cspResponse = await cspRequest(requestBody);
+      logger.info("CSP RESPONSE: ", { cspResponse }); // remove
+
+      // sendMessage to response queue with CSP response
+      const response = await sqsClient.send(
+        new SendMessageCommand({
+          QueueUrl: COST_RESPONSE_QUEUE_URL,
+          MessageBody: JSON.stringify({
+            code: cspResponse.code,
+            content: { requestBody, response: cspResponse.content },
+          }),
+          MessageGroupId: MESSAGE_GROUP_ID,
+        })
+      );
+      logger.info("Sent Message: ", { response });
+    }
+  }
+  logger.info("Records processed: ", { processedMessages });
+}
+
+export const handler = middy(baseHandler)
+  .use(injectLambdaContext(logger)) // TODO: add clearState and logEvent
+  .use(inputOutputLogger({ logger: (message) => logger.info("Event/Result", message) }))
+  .use(errorLogger({ logger: (err) => logger.error("An error occurred during the request", err as Error) }));
+// .use(IpCheckerMiddleware())
+// .use(errorHandlingMiddleware())
+// .use(JSONErrorHandlerMiddleware());
+
+// .use(httpJsonBodyParser())
+// .use(xssSanitizer())
+// .use(validator({ eventSchema: wrapSchema(costRequestSchema) }))

--- a/api/cost/cost-request-fn.ts
+++ b/api/cost/cost-request-fn.ts
@@ -7,7 +7,7 @@ import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { injectLambdaContext } from "@aws-lambda-powertools/logger";
 import inputOutputLogger from "@middy/input-output-logger";
 import errorLogger from "@middy/error-logger";
-import { cspRequest } from "../util/csp-request";
+import { CspRequest, cspRequest } from "../util/csp-request";
 import { IpCheckerMiddleware } from "../../utils/middleware/ip-logging";
 import { errorHandlingMiddleware } from "../../utils/middleware/error-handling-middleware";
 import JSONErrorHandlerMiddleware from "middy-middleware-json-error-handler";
@@ -25,7 +25,8 @@ async function baseHandler(event: SQSEvent): Promise<void> {
 
       // get csp response back (using mock)
       const requestBody: CostRequest = JSON.parse(record ?? "");
-      const cspResponse = await cspRequest(requestBody);
+      const cspResponse = await cspRequest({ requestType: CspRequest.COST, body: requestBody });
+
       logger.info("CSP RESPONSE: ", { cspResponse }); // remove
 
       // sendMessage to response queue with CSP response

--- a/api/cost/cost-request-fn.ts
+++ b/api/cost/cost-request-fn.ts
@@ -40,7 +40,7 @@ async function baseHandler(event: SQSEvent): Promise<void> {
 }
 
 export const handler = middy(baseHandler)
-  .use(injectLambdaContext(logger))
+  .use(injectLambdaContext(logger, { clearState: true }))
   .use(inputOutputLogger({ logger: (message) => logger.info("Event/Result", message) }))
   .use(errorLogger({ logger: (err) => logger.error("An error occurred during the request", err as Error) }))
   .use(errorHandlingMiddleware())

--- a/api/cost/cost-request-fn.ts
+++ b/api/cost/cost-request-fn.ts
@@ -19,23 +19,17 @@ async function baseHandler(event: SQSEvent): Promise<void> {
   if (event.Records) {
     const records = event.Records.map((record: SQSRecord) => record.body);
     for (const record of records) {
-      logger.info("Record Body: ", { record });
       processedMessages.push(record);
 
       // get csp response back (using mock)
       const requestBody: CostRequest = JSON.parse(record ?? "");
       const cspResponse = await cspRequest({ requestType: CspRequest.COST, body: requestBody });
 
-      logger.info("CSP RESPONSE: ", { cspResponse }); // remove
-
       // sendMessage to response queue with CSP response
       const response = await sqsClient.send(
         new SendMessageCommand({
           QueueUrl: COST_RESPONSE_QUEUE_URL,
-          MessageBody: JSON.stringify({
-            code: cspResponse.code,
-            content: { requestBody, response: cspResponse.content },
-          }),
+          MessageBody: JSON.stringify(cspResponse),
           MessageGroupId: MESSAGE_GROUP_ID,
         })
       );

--- a/api/cost/cost-request-fn.ts
+++ b/api/cost/cost-request-fn.ts
@@ -16,7 +16,7 @@ export const MESSAGE_GROUP_ID = "cost-response-queue-message-group";
 
 async function baseHandler(event: SQSEvent): Promise<void> {
   const processedMessages = [];
-  if (event.Records) {
+  if (event.Records && event.Records.length > 0) {
     const records = event.Records.map((record: SQSRecord) => record.body);
     for (const record of records) {
       processedMessages.push(record);

--- a/api/cost/start-cost-job.test.ts
+++ b/api/cost/start-cost-job.test.ts
@@ -5,7 +5,7 @@ import { handler } from "./start-cost-job";
 import { sqsClient } from "../../utils/aws-sdk/sqs";
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { Network } from "../../models/cloud-service-providers";
-import { validCostRequest, baseApiRequest } from "../util/common-test-fixtures";
+import { validCostRequest, baseApiRequest, cspA } from "../util/common-test-fixtures";
 
 const sqsMock = mockClient(sqsClient);
 beforeEach(() => {
@@ -51,11 +51,7 @@ describe("Cost request operations", () => {
       body: JSON.stringify({
         requestId: "81b31a89-e3e5-46ee-acfe-75436bd14577",
         portfolioId: "b02e77d1-234d-4e3d-bc85-b57ca5a93952",
-        targetCsp: {
-          name: "CSP_A",
-          uri: "http://www.somecspvendor.com/api/atat",
-          network: Network.NETWORK_1,
-        },
+        targetCsp: cspA,
         endDate: "2022-12-01",
       }),
     };

--- a/api/cost/start-cost-job.test.ts
+++ b/api/cost/start-cost-job.test.ts
@@ -4,32 +4,13 @@ import { ApiSuccessResponse, SuccessStatusCode, ValidationErrorResponse } from "
 import { handler } from "./start-cost-job";
 import { sqsClient } from "../../utils/aws-sdk/sqs";
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
-import { CostRequest } from "../../models/cost-jobs";
 import { Network } from "../../models/cloud-service-providers";
+import { validCostRequest, baseApiRequest } from "../util/common-test-fixtures";
 
 const sqsMock = mockClient(sqsClient);
 beforeEach(() => {
   sqsMock.reset();
 });
-
-const validCostRequest: CostRequest = {
-  requestId: "81b31a89-e3e5-46ee-acfe-75436bd14577",
-  portfolioId: "b02e77d1-234d-4e3d-bc85-b57ca5a93952",
-  targetCsp: {
-    name: "CSP_A",
-    uri: "http://www.somecspvendor.com/api/atat",
-    network: Network.NETWORK_1,
-  },
-  startDate: "2022-01-01",
-  endDate: "2022-12-01",
-};
-const requestContext = { identity: { sourceIp: "203.0.113.0" } };
-const baseApiRequest = {
-  headers: {
-    "Content-Type": "application/json",
-  },
-  requestContext,
-} as any;
 
 describe("Cost request operations", () => {
   it("should return successfully if no error enqueueing message", async () => {

--- a/api/provision/consume-provisioning-job.test.ts
+++ b/api/provision/consume-provisioning-job.test.ts
@@ -3,45 +3,20 @@ import { APIGatewayProxyEvent, Context } from "aws-lambda";
 import { mockClient } from "aws-sdk-client-mock";
 import { sqsClient } from "../../utils/aws-sdk/sqs";
 import { ApiSuccessResponse, ErrorStatusCode, OtherErrorResponse, SuccessStatusCode } from "../../utils/response";
+import { generateMockMessageResponses, requestContext } from "../util/common-test-fixtures";
 import { handler } from "./consume-provisioning-job";
-import { requestContext } from "./start-provisioning-job.test";
 
-export const mockReceiveMessageResponse = {
-  $metadata: {
-    httpStatusCode: 200,
-    requestId: "74b3f95",
-    extendedRequestId: undefined,
-    cfId: undefined,
-    attempts: 1,
-    totalRetryDelay: 0,
+const messageBodies = [
+  {
+    jobId: "81b31",
+    cspResponse: { ExecutedVersion: "$LATEST", Payload: { code: 200, content: { some: "good content" } } },
   },
-  Messages: [
-    {
-      MessageId: "b5353c",
-      ReceiptHandle: "AQC0e6b=",
-      MD5OfBody: "b03",
-      Body: JSON.stringify({
-        jobId: "81b31",
-        cspResponse: { ExecutedVersion: "$LATEST", Payload: { code: 200, content: { some: "good content" } } },
-      }),
-      Attributes: undefined,
-      MD5OfMessageAttributes: undefined,
-      MessageAttributes: undefined,
-    },
-    {
-      MessageId: "330d3d",
-      ReceiptHandle: "AQECbOFf=",
-      MD5OfBody: "3ae8",
-      Body: JSON.stringify({
-        jobId: "81b317",
-        cspResponse: { ExecutedVersion: "$LATEST", Payload: { code: 400, content: { some: "bad content" } } },
-      }),
-      Attributes: undefined,
-      MD5OfMessageAttributes: undefined,
-      MessageAttributes: undefined,
-    },
-  ],
-};
+  {
+    jobId: "81b317",
+    cspResponse: { ExecutedVersion: "$LATEST", Payload: { code: 400, content: { some: "bad content" } } },
+  },
+];
+const mockReceiveMessageResponse = generateMockMessageResponses(messageBodies);
 
 const sqsMock = mockClient(sqsClient);
 beforeEach(() => {

--- a/api/provision/csp-configuration.test.ts
+++ b/api/provision/csp-configuration.test.ts
@@ -4,13 +4,13 @@ import { mockClient } from "aws-sdk-client-mock";
 
 const fakeCspConfig = {
   CSP_A: {
-    uri: "https://foo.cspa/atat",
+    uri: "https://cspa.example.com/cspa/atat",
   },
   CSP_B: {
-    uri: "https://foo.cspa/atat",
+    uri: "https://cspb.example.com/cspb/atat",
   },
   CSP_C: {
-    uri: "https://foo.cspa/atat",
+    uri: "https://cspc.example.com/cspc/atat",
   },
 };
 

--- a/api/provision/csp-write-portfolio.test.ts
+++ b/api/provision/csp-write-portfolio.test.ts
@@ -77,7 +77,7 @@ describe("Failed invocation operations", () => {
     expect(response).toEqual({
       code: 400,
       content: {
-        details: "Invalid CSP provided",
+        response: { details: "Invalid CSP provided" },
         request,
       },
     });
@@ -143,7 +143,7 @@ describe("Failed invocation operations", () => {
     expect(async () => await handler(request, {} as Context)).rejects.toThrow(
       JSON.stringify({
         code: ErrorStatusCode.INTERNAL_SERVER_ERROR,
-        content: { some: "internal error" },
+        content: { response: { some: "internal error" }, request },
       })
     );
   });

--- a/api/provision/csp-write-portfolio.test.ts
+++ b/api/provision/csp-write-portfolio.test.ts
@@ -154,7 +154,7 @@ describe("Failed invocation operations", () => {
   });
 });
 
-function constructProvisionRequestForCsp(csp: string): ProvisionRequest {
+export function constructProvisionRequestForCsp(csp: string): ProvisionRequest {
   const body = {
     ...provisioningBodyWithPayload,
     targetCsp: {

--- a/api/provision/csp-write-portfolio.test.ts
+++ b/api/provision/csp-write-portfolio.test.ts
@@ -1,7 +1,6 @@
 import { Context } from "aws-lambda";
 import axios from "axios";
 import * as idpClient from "../../idp/client";
-import { Network } from "../../models/cloud-service-providers";
 import { ProvisionRequest } from "../../models/provisioning-jobs";
 import { ErrorStatusCode, SuccessStatusCode, ValidationErrorResponse } from "../../utils/response";
 import * as cspConfig from "./csp-configuration";
@@ -12,6 +11,7 @@ import {
   provisioningBodyWithPayload,
   fundingSources,
   operators,
+  cspA,
 } from "../util/common-test-fixtures";
 
 // Reused mocks
@@ -37,7 +37,7 @@ describe("Successful invocation of mock CSP function", () => {
       csp: "response",
     };
     mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
-    mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
+    mockedConfig.mockResolvedValueOnce({ uri: cspA.uri });
     mockedAxios.post.mockResolvedValueOnce({
       data: expectedResponse,
       status: 200,
@@ -90,7 +90,7 @@ describe("Failed invocation operations", () => {
       csp: "response",
     };
     mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
-    mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
+    mockedConfig.mockResolvedValueOnce({ uri: cspA.uri });
     mockedAxios.post.mockResolvedValueOnce({
       data: expectedResponse,
       status: 400,
@@ -124,11 +124,7 @@ describe("Failed invocation operations", () => {
         fundingSources,
         operators,
       },
-      targetCsp: {
-        name: "CSP_A",
-        uri: "http://www.somecspvendor.com/api/atat",
-        network: Network.NETWORK_1,
-      },
+      targetCsp: cspA,
     };
     const response = await handler(
       {
@@ -157,9 +153,8 @@ export function constructProvisionRequestForCsp(csp: string): ProvisionRequest {
   const body = {
     ...provisioningBodyWithPayload,
     targetCsp: {
+      ...cspA,
       name: csp,
-      uri: "http://www.somecspvendor.com/api/atat",
-      network: Network.NETWORK_1,
     },
   };
   return {

--- a/api/provision/csp-write-portfolio.test.ts
+++ b/api/provision/csp-write-portfolio.test.ts
@@ -7,7 +7,12 @@ import { ErrorStatusCode, SuccessStatusCode, ValidationErrorResponse } from "../
 import * as cspConfig from "./csp-configuration";
 import { handler } from "./csp-write-portfolio";
 import { transformProvisionRequest } from "./start-provisioning-job";
-import { provisioningBodyNoPayload, provisioningBodyWithPayload } from "./start-provisioning-job.test";
+import {
+  provisioningBodyNoPayload,
+  provisioningBodyWithPayload,
+  fundingSources,
+  operators,
+} from "../util/common-test-fixtures";
 
 // Reused mocks
 jest.mock("./csp-configuration");
@@ -16,16 +21,6 @@ jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 jest.mock("../../idp/client");
 const mockedGetToken = idpClient.getToken as jest.MockedFn<typeof idpClient.getToken>;
-
-const fundingSources = [
-  {
-    taskOrderNumber: "1234567890123",
-    clin: "9999",
-    popStartDate: "2021-07-01",
-    popEndDate: "2022-07-01",
-  },
-];
-const operators = ["admin1@mail.mil", "superAdmin@mail.mil"];
 
 describe("Successful invocation of mock CSP function", () => {
   it("should return 200 when CSP A provided in the request", async () => {

--- a/api/provision/csp-write-portfolio.test.ts
+++ b/api/provision/csp-write-portfolio.test.ts
@@ -36,6 +36,7 @@ describe("Successful invocation of mock CSP function", () => {
   });
   it("should basically just return a reformatted CSP response", async () => {
     // GIVEN
+    const request = constructProvisionRequestForCsp("CSP_E");
     const expectedResponse = {
       totally: "fake",
       csp: "response",
@@ -51,12 +52,12 @@ describe("Successful invocation of mock CSP function", () => {
     });
 
     // WHEN
-    const response = await handler(constructProvisionRequestForCsp("CSP_E"), {} as Context);
+    const response = await handler(request, {} as Context);
 
     // THEN
     expect(response).toEqual({
       code: 200,
-      content: expectedResponse,
+      content: { response: expectedResponse, request },
     });
   });
 });
@@ -73,19 +74,22 @@ describe("Failed invocation operations", () => {
 
   it("should return a 400 when the CSP's configuration is unknown", async () => {
     // GIVEN
+    const request = constructProvisionRequestForCsp("CSP_DNE");
     mockedConfig.mockResolvedValueOnce(undefined);
     // WHEN
-    const response = await handler(constructProvisionRequestForCsp("CSP_DNE"), {} as Context);
+    const response = await handler(request, {} as Context);
     // THEN
     expect(response).toEqual({
       code: 400,
       content: {
         details: "Invalid CSP provided",
+        request,
       },
     });
   });
   it("should basically just return a reformatted CSP response", async () => {
     // GIVEN
+    const request = constructProvisionRequestForCsp("CSP_E");
     const expectedResponse = {
       totally: "fake",
       csp: "response",
@@ -101,12 +105,12 @@ describe("Failed invocation operations", () => {
     });
 
     // WHEN
-    const response = await handler(constructProvisionRequestForCsp("CSP_E"), {} as Context);
+    const response = await handler(request, {} as Context);
 
     // THEN
     expect(response).toEqual({
       code: 400,
-      content: expectedResponse,
+      content: { response: expectedResponse, request },
     });
   });
 

--- a/api/provision/csp-write-portfolio.ts
+++ b/api/provision/csp-write-portfolio.ts
@@ -4,16 +4,13 @@ import errorLogger from "@middy/error-logger";
 import inputOutputLogger from "@middy/input-output-logger";
 import validator from "@middy/validator";
 import { Context } from "aws-lambda";
-import axios from "axios";
 import JSONErrorHandlerMiddleware from "middy-middleware-json-error-handler";
-import { getToken } from "../../idp/client";
 import { CspRequest } from "../../models/cost-jobs";
 import { CspResponse, ProvisionRequest, provisionRequestSchema } from "../../models/provisioning-jobs";
 import { logger } from "../../utils/logging";
 import { errorHandlingMiddleware } from "../../utils/middleware/error-handling-middleware";
 import { ValidationErrorResponse } from "../../utils/response";
 import { cspRequest } from "../util/csp-request";
-import { getConfiguration } from "./csp-configuration";
 
 /**
  * Mock invocation of CSP and returns a CSP Response based on CSP

--- a/api/provision/csp-write-portfolio.ts
+++ b/api/provision/csp-write-portfolio.ts
@@ -6,11 +6,11 @@ import validator from "@middy/validator";
 import { Context } from "aws-lambda";
 import JSONErrorHandlerMiddleware from "middy-middleware-json-error-handler";
 import { CspRequest } from "../../models/cost-jobs";
-import { CspResponse, ProvisionRequest, provisionRequestSchema } from "../../models/provisioning-jobs";
+import { ProvisionRequest, provisionRequestSchema } from "../../models/provisioning-jobs";
 import { logger } from "../../utils/logging";
 import { errorHandlingMiddleware } from "../../utils/middleware/error-handling-middleware";
 import { ValidationErrorResponse } from "../../utils/response";
-import { cspRequest } from "../util/csp-request";
+import { cspRequest, CspResponse } from "../util/csp-request";
 
 /**
  * Mock invocation of CSP and returns a CSP Response based on CSP
@@ -53,7 +53,8 @@ export async function createCspResponse(request: ProvisionRequest): Promise<CspR
       response = {
         code: 200,
         content: {
-          some: "good content",
+          response: { some: "good content" },
+          request,
         },
       };
       logger.info("Success response", { response: response as any });
@@ -62,7 +63,8 @@ export async function createCspResponse(request: ProvisionRequest): Promise<CspR
       response = {
         code: 400,
         content: {
-          some: "bad content",
+          response: { some: "bad content" },
+          request,
         },
       };
       logger.error("Failed response", { response: response as any });
@@ -72,7 +74,8 @@ export async function createCspResponse(request: ProvisionRequest): Promise<CspR
       response = {
         code: 500,
         content: {
-          some: "internal error",
+          response: { some: "internal error" },
+          request,
         },
       };
       logger.error("Internal error response", { response: response as any });

--- a/api/provision/result-fn.test.ts
+++ b/api/provision/result-fn.test.ts
@@ -4,7 +4,7 @@ import { mockClient } from "aws-sdk-client-mock";
 import { ValidationErrorResponse } from "../../utils/response";
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { sqsClient } from "../../utils/aws-sdk/sqs";
-import { provisioningBodyWithPayload } from "./start-provisioning-job.test";
+import { provisioningBodyWithPayload } from "../util/common-test-fixtures";
 
 const sqsMock = mockClient(sqsClient);
 

--- a/api/provision/result-fn.test.ts
+++ b/api/provision/result-fn.test.ts
@@ -12,7 +12,10 @@ const withResponse = {
   ...provisioningBodyWithPayload,
   cspResponse: {
     code: 200,
-    content: {},
+    content: {
+      response: { success: "request" },
+      request: provisioningBodyWithPayload,
+    },
   },
 };
 

--- a/api/provision/start-provisioning-job.test.ts
+++ b/api/provision/start-provisioning-job.test.ts
@@ -1,52 +1,18 @@
 import { Context } from "aws-lambda";
 import { mockClient } from "aws-sdk-client-mock";
-import { Network } from "../../models/cloud-service-providers";
 import { ProvisionRequestType } from "../../models/provisioning-jobs";
 import { sfnClient } from "../../utils/aws-sdk/step-functions";
 import { ApiSuccessResponse, ValidationErrorResponse } from "../../utils/response";
+import {
+  fundingSources,
+  provisioningBodyNoPayload,
+  validRequest,
+  // requestContext,
+  operators,
+} from "../util/common-test-fixtures";
 import { handler } from "./start-provisioning-job";
 
-export const fundingSources = [
-  {
-    taskOrderNumber: "1234567890123",
-    clin: "9999",
-    popStartDate: "2021-07-01",
-    popEndDate: "2022-07-01",
-  },
-];
-export const operators = ["admin1@mail.mil", "superAdmin@mail.mil"];
-export const provisioningBodyNoPayload = {
-  jobId: "81b31a89-e3e5-46ee-acfe-75436bd14577",
-  userId: "21d18790-bf3e-4529-a361-460ee6d16e0b",
-  portfolioId: "b02e77d1-234d-4e3d-bc85-b57ca5a93952",
-  operationType: ProvisionRequestType.ADD_OPERATORS,
-  targetCsp: {
-    name: "CSP_A",
-    uri: "http://www.somecspvendor.com/api/atat",
-    network: Network.NETWORK_1,
-  },
-  cspInvocation: undefined,
-  cspResponse: undefined,
-};
-
-export const provisioningBodyWithPayload = {
-  ...provisioningBodyNoPayload,
-  payload: {
-    name: "Sample Portfolio",
-    fundingSources,
-    operators,
-  },
-};
 export const requestContext = { identity: { sourceIp: "203.0.113.0" } };
-
-export const validRequest = {
-  body: JSON.stringify(provisioningBodyWithPayload),
-  headers: {
-    "Content-Type": "application/json",
-  },
-  requestContext,
-} as any;
-
 const sfnMock = mockClient(sfnClient);
 beforeEach(() => {
   sfnMock.reset();

--- a/api/util/common-test-fixtures.ts
+++ b/api/util/common-test-fixtures.ts
@@ -15,17 +15,26 @@ export const fundingSources = [
 ];
 
 export const operators = ["admin1@mail.mil", "superAdmin@mail.mil"];
+export const cspA = {
+  name: "CSP_A",
+  uri: "https://cspa.example.com/api/atat",
+  network: Network.NETWORK_1,
+};
+
+export function constructCspTarget(csp: string, network: Network) {
+  return {
+    name: csp,
+    uri: `https://${csp.toLocaleLowerCase()}.example/com/api/atat`,
+    network,
+  };
+}
 
 export const provisioningBodyNoPayload = {
   jobId: "81b31a89-e3e5-46ee-acfe-75436bd14577",
   userId: "21d18790-bf3e-4529-a361-460ee6d16e0b",
   portfolioId: "b02e77d1-234d-4e3d-bc85-b57ca5a93952",
   operationType: ProvisionRequestType.ADD_OPERATORS,
-  targetCsp: {
-    name: "CSP_A",
-    uri: "http://www.somecspvendor.com/api/atat",
-    network: Network.NETWORK_1,
-  },
+  targetCsp: cspA,
   cspInvocation: undefined,
   cspResponse: undefined,
 };
@@ -53,11 +62,7 @@ export const validRequest = {
 export const validCostRequest: CostRequest = {
   requestId: "81b31a89-e3e5-46ee-acfe-75436bd14577",
   portfolioId: "b02e77d1-234d-4e3d-bc85-b57ca5a93952",
-  targetCsp: {
-    name: "CSP_A",
-    uri: "http://www.somecspvendor.com/api/atat",
-    network: Network.NETWORK_1,
-  },
+  targetCsp: cspA,
   startDate: "2022-01-01",
   endDate: "2022-12-01",
 };

--- a/api/util/common-test-fixtures.ts
+++ b/api/util/common-test-fixtures.ts
@@ -1,0 +1,124 @@
+import { SQSEvent } from "aws-lambda";
+import { Network } from "../../models/cloud-service-providers";
+import { CostRequest } from "../../models/cost-jobs";
+import { ProvisionRequestType } from "../../models/provisioning-jobs";
+import * as crypto from "crypto";
+
+// provisioning fixtures
+export const fundingSources = [
+  {
+    taskOrderNumber: "1234567890123",
+    clin: "9999",
+    popStartDate: "2021-07-01",
+    popEndDate: "2022-07-01",
+  },
+];
+
+export const operators = ["admin1@mail.mil", "superAdmin@mail.mil"];
+
+export const provisioningBodyNoPayload = {
+  jobId: "81b31a89-e3e5-46ee-acfe-75436bd14577",
+  userId: "21d18790-bf3e-4529-a361-460ee6d16e0b",
+  portfolioId: "b02e77d1-234d-4e3d-bc85-b57ca5a93952",
+  operationType: ProvisionRequestType.ADD_OPERATORS,
+  targetCsp: {
+    name: "CSP_A",
+    uri: "http://www.somecspvendor.com/api/atat",
+    network: Network.NETWORK_1,
+  },
+  cspInvocation: undefined,
+  cspResponse: undefined,
+};
+
+export const provisioningBodyWithPayload = {
+  ...provisioningBodyNoPayload,
+  payload: {
+    name: "Sample Portfolio",
+    fundingSources,
+    operators,
+  },
+};
+
+export const requestContext = { identity: { sourceIp: "203.0.113.0" } };
+
+export const validRequest = {
+  body: JSON.stringify(provisioningBodyWithPayload),
+  headers: {
+    "Content-Type": "application/json",
+  },
+  requestContext,
+} as any;
+
+// cost fixtures
+export const validCostRequest: CostRequest = {
+  requestId: "81b31a89-e3e5-46ee-acfe-75436bd14577",
+  portfolioId: "b02e77d1-234d-4e3d-bc85-b57ca5a93952",
+  targetCsp: {
+    name: "CSP_A",
+    uri: "http://www.somecspvendor.com/api/atat",
+    network: Network.NETWORK_1,
+  },
+  startDate: "2022-01-01",
+  endDate: "2022-12-01",
+};
+
+export const baseApiRequest = {
+  headers: {
+    "Content-Type": "application/json",
+  },
+  requestContext,
+} as any;
+
+export function generateTestSQSEvent(recordBodies: any[]): SQSEvent {
+  const records = recordBodies.map((body) => {
+    const recordBody = JSON.stringify(body);
+    return {
+      body: recordBody,
+      messageId: "0",
+      messageAttributes: {},
+      receiptHandle: "",
+      eventSource: "",
+      eventSourceARN: "",
+      awsRegion: "us-east-1",
+      attributes: {
+        ApproximateFirstReceiveTimestamp: "",
+        ApproximateReceiveCount: "0",
+        SentTimestamp: "",
+        SenderId: "",
+      },
+      // The use of MD5 here is not for any cryptographic purpose. It is
+      // to mock a field of a Lambda event. This is only used for the
+      // purposes of a basic validation (much like CRC).
+      md5OfBody: crypto.createHash("md5").update(recordBody).digest("hex"),
+    };
+  });
+  return {
+    Records: records,
+  };
+}
+export function generateMockMessageResponses(messageBodies: any[]) {
+  const messages = messageBodies.map((body) => {
+    const messageBody = JSON.stringify(body);
+    return {
+      MessageId: "b5353c",
+      ReceiptHandle: "AQC0e6b=",
+      MD5OfBody: crypto.createHash("md5").update(messageBody).digest("hex"),
+      Body: messageBody,
+      Attributes: undefined,
+      MD5OfMessageAttributes: undefined,
+      MessageAttributes: undefined,
+    };
+  });
+
+  return {
+    $metadata: {
+      httpStatusCode: 200,
+      requestId: "74b3f95",
+      extendedRequestId: undefined,
+      cfId: undefined,
+      attempts: 1,
+      totalRetryDelay: 0,
+    },
+    Messages: messages,
+  };
+}

--- a/api/util/csp-request.test.ts
+++ b/api/util/csp-request.test.ts
@@ -85,7 +85,7 @@ describe("Failed CSP invocation operations", () => {
       expect(response).toEqual({
         code: 400,
         content: {
-          details: "Invalid CSP provided",
+          response: { details: "Invalid CSP provided" },
           request: request.body,
         },
       });

--- a/api/util/csp-request.test.ts
+++ b/api/util/csp-request.test.ts
@@ -34,7 +34,7 @@ describe("Successful invocation of mock CSP function", () => {
     // WHEN
     const response = await cspRequest(request);
     // THEN
-    expect(response.content).toBe(fakeGoodResponse);
+    expect(response.content).toEqual({ response: fakeGoodResponse, request: request.body });
     expect(response.code).toBe(SuccessStatusCode.OK);
   });
   it("should return 200 when PROVISION csp request", async () => {
@@ -53,7 +53,7 @@ describe("Successful invocation of mock CSP function", () => {
     // WHEN
     const response = await cspRequest(request);
     // THEN
-    expect(response.content).toBe(fakeGoodResponse);
+    expect(response.content).toEqual({ response: fakeGoodResponse, request: provisioningRequest });
     expect(response.code).toBe(SuccessStatusCode.OK);
   });
 });
@@ -71,20 +71,22 @@ describe("Failed CSP invocation operations", () => {
     "should return a 400 when the CSP's configuration is unknown",
     async (requestType) => {
       // GIVEN
-      mockedConfig.mockResolvedValueOnce(undefined);
-      // WHEN
-      const response = await cspRequest({
+      const request = {
         requestType,
         body: {
           ...validRequestBody,
           targetCsp: { name: "CSP_BAD", uri: "https://csp.com", network: Network.NETWORK_1 },
         },
-      } as any);
+      } as any;
+      mockedConfig.mockResolvedValueOnce(undefined);
+      // WHEN
+      const response = await cspRequest(request);
       // THEN
       expect(response).toEqual({
         code: 400,
         content: {
           details: "Invalid CSP provided",
+          request: request.body,
         },
       });
     }
@@ -109,7 +111,7 @@ describe("Failed CSP invocation operations", () => {
       // THEN
       expect(response).toEqual({
         code: 400,
-        content: fakeBadResponse,
+        content: { response: fakeBadResponse, request: request.body },
       });
     }
   );
@@ -130,7 +132,7 @@ describe("Failed CSP invocation operations", () => {
       const response = await cspRequest(request);
       expect(response).toEqual({
         code: ErrorStatusCode.INTERNAL_SERVER_ERROR,
-        content: internalErrorResponse,
+        content: { response: internalErrorResponse, request: request.body },
       });
     }
   );

--- a/api/util/csp-request.test.ts
+++ b/api/util/csp-request.test.ts
@@ -7,7 +7,7 @@ import { ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
 import { constructProvisionRequestForCsp } from "../provision/csp-write-portfolio.test";
 import { cspRequest } from "./csp-request";
 import { ProvisionRequest } from "../../models/provisioning-jobs";
-import { validCostRequest } from "../util/common-test-fixtures";
+import { cspA, validCostRequest } from "../util/common-test-fixtures";
 
 // Reused mocks
 jest.mock("../provision/csp-configuration");
@@ -22,7 +22,7 @@ describe("Successful invocation of mock CSP function", () => {
   it("should return 200 when COST csp request", async () => {
     // GIVEN
     const request: CspRequestType<CostRequest> = { requestType: CspRequest.COST, body: validCostRequest };
-    mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
+    mockedConfig.mockResolvedValueOnce({ uri: cspA.uri });
     mockedAxios.post.mockResolvedValueOnce({
       data: fakeGoodResponse,
       status: 200,
@@ -42,7 +42,7 @@ describe("Successful invocation of mock CSP function", () => {
     const provisioningRequest = constructProvisionRequestForCsp("CSP_A");
     const request: CspRequestType<ProvisionRequest> = { requestType: CspRequest.PROVISION, body: provisioningRequest };
     mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
-    mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
+    mockedConfig.mockResolvedValueOnce({ uri: cspA.uri });
     mockedAxios.post.mockResolvedValueOnce({
       data: fakeGoodResponse,
       status: 200,
@@ -75,7 +75,7 @@ describe("Failed CSP invocation operations", () => {
         requestType,
         body: {
           ...validCostRequest,
-          targetCsp: { name: "CSP_BAD", uri: "https://csp.com", network: Network.NETWORK_1 },
+          targetCsp: { name: "CSP_BAD", uri: cspA.uri, network: Network.NETWORK_1 },
         },
       } as any;
       mockedConfig.mockResolvedValueOnce(undefined);
@@ -98,7 +98,7 @@ describe("Failed CSP invocation operations", () => {
       const fakeBadResponse = { bad: "fake csp response" };
       const request = { requestType, body: validCostRequest };
       mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
-      mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
+      mockedConfig.mockResolvedValueOnce({ uri: cspA.uri });
       mockedAxios.post.mockResolvedValueOnce({
         data: fakeBadResponse,
         status: 400,
@@ -121,7 +121,7 @@ describe("Failed CSP invocation operations", () => {
       const internalErrorResponse = { some: "internal error" };
       const request = { requestType, body: validCostRequest };
       mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
-      mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
+      mockedConfig.mockResolvedValueOnce({ uri: cspA.uri });
       mockedAxios.post.mockResolvedValueOnce({
         data: internalErrorResponse,
         status: 500,

--- a/api/util/csp-request.test.ts
+++ b/api/util/csp-request.test.ts
@@ -4,10 +4,10 @@ import * as cspConfig from "../provision/csp-configuration";
 import { Network } from "../../models/cloud-service-providers";
 import { CostRequest, CspRequest, CspRequestType } from "../../models/cost-jobs";
 import { ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
-import { validRequestBody } from "../cost/cost-request-fn.test";
 import { constructProvisionRequestForCsp } from "../provision/csp-write-portfolio.test";
 import { cspRequest } from "./csp-request";
 import { ProvisionRequest } from "../../models/provisioning-jobs";
+import { validCostRequest } from "../util/common-test-fixtures";
 
 // Reused mocks
 jest.mock("../provision/csp-configuration");
@@ -21,7 +21,7 @@ describe("Successful invocation of mock CSP function", () => {
   const fakeGoodResponse = { fake: "csp response" };
   it("should return 200 when COST csp request", async () => {
     // GIVEN
-    const request: CspRequestType<CostRequest> = { requestType: CspRequest.COST, body: validRequestBody };
+    const request: CspRequestType<CostRequest> = { requestType: CspRequest.COST, body: validCostRequest };
     mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
     mockedAxios.post.mockResolvedValueOnce({
       data: fakeGoodResponse,
@@ -74,7 +74,7 @@ describe("Failed CSP invocation operations", () => {
       const request = {
         requestType,
         body: {
-          ...validRequestBody,
+          ...validCostRequest,
           targetCsp: { name: "CSP_BAD", uri: "https://csp.com", network: Network.NETWORK_1 },
         },
       } as any;
@@ -96,7 +96,7 @@ describe("Failed CSP invocation operations", () => {
     async (requestType) => {
       // GIVEN
       const fakeBadResponse = { bad: "fake csp response" };
-      const request = { requestType, body: validRequestBody };
+      const request = { requestType, body: validCostRequest };
       mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
       mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
       mockedAxios.post.mockResolvedValueOnce({
@@ -119,7 +119,7 @@ describe("Failed CSP invocation operations", () => {
     "should throw a 500 error when a CSP internal error occurs",
     async (requestType) => {
       const internalErrorResponse = { some: "internal error" };
-      const request = { requestType, body: validRequestBody };
+      const request = { requestType, body: validCostRequest };
       mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
       mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
       mockedAxios.post.mockResolvedValueOnce({

--- a/api/util/csp-request.test.ts
+++ b/api/util/csp-request.test.ts
@@ -1,12 +1,13 @@
 import axios from "axios";
 import * as idpClient from "../../idp/client";
+import * as cspConfig from "../provision/csp-configuration";
 import { Network } from "../../models/cloud-service-providers";
-import { CostRequest } from "../../models/cost-jobs";
+import { CostRequest, CspRequest, CspRequestType } from "../../models/cost-jobs";
 import { ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
 import { validRequestBody } from "../cost/cost-request-fn.test";
-import * as cspConfig from "../provision/csp-configuration";
 import { constructProvisionRequestForCsp } from "../provision/csp-write-portfolio.test";
-import { CspRequest, cspRequest, CostRequestType, ProvisionRequestType } from "./csp-request";
+import { cspRequest } from "./csp-request";
+import { ProvisionRequest } from "../../models/provisioning-jobs";
 
 // Reused mocks
 jest.mock("../provision/csp-configuration");
@@ -20,7 +21,7 @@ describe("Successful invocation of mock CSP function", () => {
   const fakeGoodResponse = { fake: "csp response" };
   it("should return 200 when COST csp request", async () => {
     // GIVEN
-    const request: CostRequestType = { requestType: CspRequest.COST, body: validRequestBody };
+    const request: CspRequestType<CostRequest> = { requestType: CspRequest.COST, body: validRequestBody };
     mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
     mockedAxios.post.mockResolvedValueOnce({
       data: fakeGoodResponse,
@@ -39,7 +40,7 @@ describe("Successful invocation of mock CSP function", () => {
   it("should return 200 when PROVISION csp request", async () => {
     // GIVEN
     const provisioningRequest = constructProvisionRequestForCsp("CSP_A");
-    const request: ProvisionRequestType = { requestType: CspRequest.PROVISION, body: provisioningRequest };
+    const request: CspRequestType<ProvisionRequest> = { requestType: CspRequest.PROVISION, body: provisioningRequest };
     mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
     mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
     mockedAxios.post.mockResolvedValueOnce({
@@ -93,7 +94,7 @@ describe("Failed CSP invocation operations", () => {
     async (requestType) => {
       // GIVEN
       const fakeBadResponse = { bad: "fake csp response" };
-      const request: any = { requestType, body: validRequestBody };
+      const request = { requestType, body: validRequestBody };
       mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
       mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
       mockedAxios.post.mockResolvedValueOnce({
@@ -116,7 +117,7 @@ describe("Failed CSP invocation operations", () => {
     "should throw a 500 error when a CSP internal error occurs",
     async (requestType) => {
       const internalErrorResponse = { some: "internal error" };
-      const request: any = { requestType, body: validRequestBody };
+      const request = { requestType, body: validRequestBody };
       mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
       mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
       mockedAxios.post.mockResolvedValueOnce({

--- a/api/util/csp-request.test.ts
+++ b/api/util/csp-request.test.ts
@@ -1,0 +1,136 @@
+import axios from "axios";
+import * as idpClient from "../../idp/client";
+import { Network } from "../../models/cloud-service-providers";
+import { CostRequest } from "../../models/cost-jobs";
+import { ErrorStatusCode, SuccessStatusCode } from "../../utils/response";
+import { validRequestBody } from "../cost/cost-request-fn.test";
+import * as cspConfig from "../provision/csp-configuration";
+import { constructProvisionRequestForCsp } from "../provision/csp-write-portfolio.test";
+import { CspRequest, cspRequest, CostRequestType, ProvisionRequestType } from "./csp-request";
+
+// Reused mocks
+jest.mock("../provision/csp-configuration");
+const mockedConfig = cspConfig.getConfiguration as jest.MockedFn<typeof cspConfig.getConfiguration>;
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+jest.mock("../../idp/client");
+const mockedGetToken = idpClient.getToken as jest.MockedFn<typeof idpClient.getToken>;
+
+describe("Successful invocation of mock CSP function", () => {
+  const fakeGoodResponse = { fake: "csp response" };
+  it("should return 200 when COST csp request", async () => {
+    // GIVEN
+    const request: CostRequestType = { requestType: CspRequest.COST, body: validRequestBody };
+    mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
+    mockedAxios.post.mockResolvedValueOnce({
+      data: fakeGoodResponse,
+      status: 200,
+      statusText: "OK",
+      headers: { "Content-Type": "application/json" },
+      config: {},
+    });
+    mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
+    // WHEN
+    const response = await cspRequest(request);
+    // THEN
+    expect(response.content).toBe(fakeGoodResponse);
+    expect(response.code).toBe(SuccessStatusCode.OK);
+  });
+  it("should return 200 when PROVISION csp request", async () => {
+    // GIVEN
+    const provisioningRequest = constructProvisionRequestForCsp("CSP_A");
+    const request: ProvisionRequestType = { requestType: CspRequest.PROVISION, body: provisioningRequest };
+    mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
+    mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
+    mockedAxios.post.mockResolvedValueOnce({
+      data: fakeGoodResponse,
+      status: 200,
+      statusText: "Bad Request",
+      headers: { "Content-Type": "application/json" },
+      config: {},
+    });
+    // WHEN
+    const response = await cspRequest(request);
+    // THEN
+    expect(response.content).toBe(fakeGoodResponse);
+    expect(response.code).toBe(SuccessStatusCode.OK);
+  });
+});
+
+describe("Failed CSP invocation operations", () => {
+  it.each([
+    { desc: "empty", request: {} },
+    { desc: "undefined", request: undefined },
+    { desc: "missing endpoint", request: { cspInvocation: {} } },
+  ])("should return a 400 when the request body is $desc", async ({ request }) => {
+    const response = await cspRequest({ requestType: CspRequest.COST, body: request as CostRequest });
+    expect(response.code).toBe(ErrorStatusCode.BAD_REQUEST);
+  });
+  it.each([CspRequest.COST, CspRequest.PROVISION])(
+    "should return a 400 when the CSP's configuration is unknown",
+    async (requestType) => {
+      // GIVEN
+      mockedConfig.mockResolvedValueOnce(undefined);
+      // WHEN
+      const response = await cspRequest({
+        requestType,
+        body: {
+          ...validRequestBody,
+          targetCsp: { name: "CSP_BAD", uri: "https://csp.com", network: Network.NETWORK_1 },
+        },
+      } as any);
+      // THEN
+      expect(response).toEqual({
+        code: 400,
+        content: {
+          details: "Invalid CSP provided",
+        },
+      });
+    }
+  );
+  it.each([CspRequest.COST, CspRequest.PROVISION])(
+    "should basically return an error from the CSP",
+    async (requestType) => {
+      // GIVEN
+      const fakeBadResponse = { bad: "fake csp response" };
+      const request: any = { requestType, body: validRequestBody };
+      mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
+      mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
+      mockedAxios.post.mockResolvedValueOnce({
+        data: fakeBadResponse,
+        status: 400,
+        statusText: "Bad Request",
+        headers: { "Content-Type": "application/json" },
+        config: {},
+      });
+      // WHEN
+      const response = await cspRequest(request);
+      // THEN
+      expect(response).toEqual({
+        code: 400,
+        content: fakeBadResponse,
+      });
+    }
+  );
+  it.each([CspRequest.COST, CspRequest.PROVISION])(
+    "should throw a 500 error when a CSP internal error occurs",
+    async (requestType) => {
+      const internalErrorResponse = { some: "internal error" };
+      const request: any = { requestType, body: validRequestBody };
+      mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
+      mockedConfig.mockResolvedValueOnce({ uri: "https://mockcsp.cspa/atat/" });
+      mockedAxios.post.mockResolvedValueOnce({
+        data: internalErrorResponse,
+        status: 500,
+        statusText: "Bad Request",
+        headers: { "Content-Type": "application/json" },
+        config: {},
+      });
+      const response = await cspRequest(request);
+      expect(response).toEqual({
+        code: ErrorStatusCode.INTERNAL_SERVER_ERROR,
+        content: internalErrorResponse,
+      });
+    }
+  );
+});

--- a/api/util/csp-request.ts
+++ b/api/util/csp-request.ts
@@ -1,0 +1,59 @@
+import { CostRequest } from "../../models/cost-jobs";
+import { CspResponse } from "../../models/provisioning-jobs";
+import { getConfiguration } from "../provision/csp-configuration";
+import { getToken } from "../../idp/client";
+import { logger } from "../../utils/logging";
+import axios from "axios";
+
+/**
+ * Make a request to an actual CSP implementation of the ATAT API
+ *
+ * @param request The input provisioning request
+ * @returns the response from the CSP
+ */
+export async function cspRequest(request: CostRequest): Promise<CspResponse> {
+  const baseUrl = (await getConfiguration(request.targetCsp.name))?.uri;
+  const url = `${baseUrl}/portfolios/${request.portfolioId}/cost`;
+  if (!baseUrl || !baseUrl.startsWith("https://")) {
+    logger.error("Invalid CSP configuration (Demo)", {
+      input: {
+        csp: request.targetCsp.name,
+      },
+      resolvedUrl: url,
+      configSecretPath: process.env.CSP_CONFIG_SECRET_NAME,
+    });
+    return {
+      code: 400,
+      content: {
+        details: "Invalid CSP provided",
+      },
+    };
+  }
+
+  const response = await axios.post(url, request, {
+    headers: {
+      Authorization: `Bearer ${(await getToken()).access_token}`,
+      "User-Agent": "ATAT v0.2.0 client",
+    },
+    // Don't throw an error on non-2xx/3xx status code (let us handle it)
+    validateStatus() {
+      return true;
+    },
+  });
+
+  if (response.status !== 200 && response.status !== 202) {
+    logger.error("Request to CSP failed", {
+      csp: request.targetCsp.name,
+      request: {
+        csp: request.targetCsp.name,
+        url,
+      },
+      response: { statusCode: response.status, body: response.data },
+    });
+  }
+
+  return {
+    code: response.status,
+    content: response.data,
+  };
+}

--- a/api/util/csp-request.ts
+++ b/api/util/csp-request.ts
@@ -23,6 +23,7 @@ export async function cspRequest(request: CspRequestType<CostRequest | Provision
       code: 400,
       content: {
         details: "No Target CSP or the Portfolio Id is not provided.",
+        request: request.body,
       },
     };
   }
@@ -50,6 +51,7 @@ export async function cspRequest(request: CspRequestType<CostRequest | Provision
       code: 400,
       content: {
         details: "Invalid CSP provided",
+        request: request.body,
       },
     };
   }
@@ -78,6 +80,6 @@ export async function cspRequest(request: CspRequestType<CostRequest | Provision
 
   return {
     code: response.status,
-    content: response.data,
+    content: { response: response.data, request: request.body },
   };
 }

--- a/api/util/csp-request.ts
+++ b/api/util/csp-request.ts
@@ -54,7 +54,7 @@ export async function cspRequest(request: CspRequestType<CostRequest | Provision
   }
 
   if (!baseUrl || !baseUrl.startsWith("https://")) {
-    logger.error("Invalid CSP configuration (Demo)", {
+    logger.error("Invalid CSP configuration", {
       input: {
         csp: targetCsp.name,
       },
@@ -81,7 +81,7 @@ export async function cspRequest(request: CspRequestType<CostRequest | Provision
     },
   });
 
-  if (response.status !== 200 && response.status !== 202) {
+  if (![200, 202].includes(response.status)) {
     logger.error("Request to CSP failed", {
       csp: targetCsp.name,
       request: {

--- a/api/util/csp-request.ts
+++ b/api/util/csp-request.ts
@@ -1,9 +1,17 @@
 import { CostRequest, CspRequestType, CspRequest } from "../../models/cost-jobs";
-import { CspResponse, ProvisionRequest } from "../../models/provisioning-jobs";
+import { ProvisionRequest } from "../../models/provisioning-jobs";
 import { getConfiguration } from "../provision/csp-configuration";
 import { getToken } from "../../idp/client";
 import { logger } from "../../utils/logging";
 import axios from "axios";
+
+export interface CspResponse {
+  code: number;
+  content: {
+    response: object;
+    request: CostRequest | ProvisionRequest;
+  };
+}
 
 /**
  * Make a request to an actual CSP implementation of the ATAT API
@@ -13,7 +21,13 @@ import axios from "axios";
  */
 export async function cspRequest(request: CspRequestType<CostRequest | ProvisionRequest>): Promise<CspResponse> {
   if (!request.body) {
-    return { code: 400, content: { details: "No request body provided" } };
+    return {
+      code: 400,
+      content: {
+        response: { details: "No request body provided" },
+        request: request.body,
+      },
+    };
   }
   const { targetCsp, portfolioId } = request.body;
 
@@ -22,7 +36,7 @@ export async function cspRequest(request: CspRequestType<CostRequest | Provision
     return {
       code: 400,
       content: {
-        details: "No Target CSP or the Portfolio Id is not provided.",
+        response: { details: "No Target CSP or the Portfolio Id is not provided." },
         request: request.body,
       },
     };
@@ -50,7 +64,7 @@ export async function cspRequest(request: CspRequestType<CostRequest | Provision
     return {
       code: 400,
       content: {
-        details: "Invalid CSP provided",
+        response: { details: "Invalid CSP provided" },
         request: request.body,
       },
     };

--- a/api/util/csp-request.ts
+++ b/api/util/csp-request.ts
@@ -1,23 +1,9 @@
-import { CostRequest } from "../../models/cost-jobs";
+import { CostRequest, CspRequestType, CspRequest } from "../../models/cost-jobs";
 import { CspResponse, ProvisionRequest } from "../../models/provisioning-jobs";
 import { getConfiguration } from "../provision/csp-configuration";
 import { getToken } from "../../idp/client";
 import { logger } from "../../utils/logging";
 import axios from "axios";
-
-export enum CspRequest {
-  PROVISION = "PROVISION",
-  COST = "COST",
-}
-export type ProvisionRequestType = {
-  requestType: CspRequest.PROVISION;
-  body: ProvisionRequest;
-};
-export type CostRequestType = {
-  requestType: CspRequest.COST;
-  body: CostRequest;
-};
-export type CspRequestTypes = ProvisionRequestType | CostRequestType;
 
 /**
  * Make a request to an actual CSP implementation of the ATAT API
@@ -25,7 +11,7 @@ export type CspRequestTypes = ProvisionRequestType | CostRequestType;
  * @param request The input request (e.g., provisioning, cost)
  * @returns the response from the CSP
  */
-export async function cspRequest(request: CspRequestTypes): Promise<CspResponse> {
+export async function cspRequest(request: CspRequestType<CostRequest | ProvisionRequest>): Promise<CspResponse> {
   if (!request.body) {
     return { code: 400, content: { details: "No request body provided" } };
   }
@@ -42,7 +28,6 @@ export async function cspRequest(request: CspRequestTypes): Promise<CspResponse>
   }
   const baseUrl = (await getConfiguration(targetCsp.name))?.uri;
   let url: string;
-  logger.info("URL: ", { baseUrl });
 
   switch (request.requestType) {
     case CspRequest.PROVISION:

--- a/document-generation/generate-document.test.ts
+++ b/document-generation/generate-document.test.ts
@@ -1,8 +1,8 @@
+import fs from "fs";
 import { Context } from "aws-lambda";
-import { requestContext } from "../api/provision/start-provisioning-job.test";
+import { requestContext } from "../api/util/common-test-fixtures";
 import { handler } from "./generate-document";
 import { sampleDowRequest } from "./handlebarUtils/sampleTestData";
-import fs from "fs";
 import { SuccessBase64Response, ValidationErrorResponse } from "../utils/response";
 import { DocumentType } from "../models/document-generation";
 
@@ -20,7 +20,8 @@ jest.mock("./chromium", () => {
     generateDocument: jest.fn().mockImplementation(() => Buffer.from("generateDocument")),
   };
 });
-const fnSpy = jest.spyOn(fs, "readFileSync");
+jest.mock("fs");
+const mockedFs = fs as jest.Mocked<typeof fs>;
 
 describe("Successful generate-document handler", () => {
   it("should return successful response", async () => {
@@ -35,9 +36,9 @@ describe("Successful generate-document handler", () => {
     }`;
 
     // WHEN / ACT
-    fnSpy.mockImplementationOnce(() => html);
-    fnSpy.mockImplementationOnce(() => css);
-    const response = await handler(validRequest, {} as Context, () => null);
+    mockedFs.readFileSync.mockImplementationOnce(() => html);
+    mockedFs.readFileSync.mockImplementationOnce(() => css);
+    const response = await handler(validRequest, {} as Context);
 
     // THEN / ASSERT
     expect(response).toBeInstanceOf(SuccessBase64Response);
@@ -55,7 +56,7 @@ describe("Invalid requests for generate-document handler", () => {
       }),
     };
     // WHEN / ACT
-    const response = await handler(invalidRequest, {} as Context, () => null);
+    const response = await handler(invalidRequest, {} as Context);
     const responseBody = JSON.parse(response?.body ?? "");
     // THEN / ASSERT
     expect(response).toBeInstanceOf(ValidationErrorResponse);
@@ -71,7 +72,7 @@ describe("Invalid requests for generate-document handler", () => {
       }),
     };
     // WHEN / ACT
-    const response = await handler(invalidRequest, {} as Context, () => null);
+    const response = await handler(invalidRequest, {} as Context);
     const responseBody = JSON.parse(response?.body ?? "");
     // THEN / ASSERT
     expect(response).toBeInstanceOf(ValidationErrorResponse);

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -359,6 +359,14 @@ components:
           type: integer
         content:
           type: object
+          required:
+           - response
+           - request
+          properties:
+            response:
+              type: object
+            request:
+              type: object
           additionalProperties: true
     CostRequest:
       description: >-

--- a/lib/atat-web-api-stack.ts
+++ b/lib/atat-web-api-stack.ts
@@ -133,6 +133,7 @@ export class AtatWebApiStack extends cdk.Stack {
       environmentName,
       apiParent: api.restApi.root,
       vpc: props?.network?.vpc,
+      idp: atatIdp,
     });
   }
 }

--- a/lib/constructs/api-route.ts
+++ b/lib/constructs/api-route.ts
@@ -2,11 +2,13 @@ import * as apigw from "aws-cdk-lib/aws-apigateway";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { HttpMethod } from "../http";
 import { Method } from "aws-cdk-lib/aws-apigateway";
+import * as idp from "../constructs/identity-provider";
 
 export interface ApiRouteProps {
   readonly environmentName: string;
   readonly vpc?: ec2.IVpc;
   readonly apiParent: apigw.IResource;
+  readonly idp?: idp.CognitoIdentityProvider;
 }
 
 export interface IApiRoute {

--- a/lib/constructs/cost-api-implementation.test.ts
+++ b/lib/constructs/cost-api-implementation.test.ts
@@ -4,6 +4,7 @@ import { CfnRole } from "aws-cdk-lib/aws-iam";
 import { CostApiImplementation } from "./cost-api-implementation";
 import { AtatRestApi, AtatRestApiProps } from "./apigateway";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as idp from "./identity-provider";
 
 describe("Cost API Implementation Tests", () => {
   let stack: cdk.Stack;
@@ -21,11 +22,13 @@ describe("Cost API Implementation Tests", () => {
       binaryMediaTypes: ["application/json", "application/pdf"],
     };
     const api = new AtatRestApi(stack, "HothApi", apiProps);
+    const testIdp = new idp.CognitoIdentityProvider(stack, "TestIdp");
     // WHEN
     costApiImplementation = new CostApiImplementation(stack, {
       environmentName: "testEnv",
       apiParent: api.restApi.root,
       vpc,
+      idp: testIdp,
     });
 
     template = Template.fromStack(stack);
@@ -64,6 +67,24 @@ describe("Cost API Implementation Tests", () => {
           },
         },
         Role: stack.resolve((costApiImplementation.consumeCostResponseFn.role?.node.defaultChild as CfnRole).attrArn),
+      })
+    );
+  });
+
+  test("Ensure Cost Request Fn is created & has necessary env for requests", async () => {
+    template.hasResourceProperties(
+      "AWS::Lambda::Function",
+      Match.objectLike({
+        Environment: {
+          Variables: {
+            COST_RESPONSE_QUEUE_URL: Match.anyValue(),
+            CSP_CONFIG_SECRET_NAME: Match.anyValue(),
+            IDP_BASE_URL: Match.anyValue(),
+            IDP_CLIENT_ID: Match.anyValue(),
+            IDP_CLIENT_SECRET_NAME: Match.anyValue(),
+          },
+        },
+        Role: stack.resolve((costApiImplementation.costRequestFn.role?.node.defaultChild as CfnRole).attrArn),
       })
     );
   });

--- a/models/cost-jobs.ts
+++ b/models/cost-jobs.ts
@@ -1,5 +1,6 @@
-import { CspResponse, provisionRequestSchema } from "./provisioning-jobs";
+import { provisionRequestSchema } from "./provisioning-jobs";
 import { CloudServiceProvider } from "./cloud-service-providers";
+import { CspResponse } from "../api/util/csp-request";
 
 export type CostResponse = CspResponse;
 

--- a/models/cost-jobs.ts
+++ b/models/cost-jobs.ts
@@ -11,6 +11,16 @@ export interface CostRequest {
   endDate: string;
 }
 
+export enum CspRequest {
+  PROVISION = "PROVISION",
+  COST = "COST",
+}
+
+export type CspRequestType<T> = {
+  requestType: CspRequest;
+  body: T;
+};
+
 export const costRequestSchema = {
   type: "object",
   required: ["requestId", "portfolioId", "targetCsp", "startDate", "endDate"],

--- a/models/provisioning-jobs.ts
+++ b/models/provisioning-jobs.ts
@@ -1,5 +1,6 @@
 import { HttpMethod } from "../lib/http";
 import { CloudServiceProvider, Network } from "./cloud-service-providers";
+import { CspResponse } from "../api/util/csp-request";
 
 export enum ProvisionRequestType {
   ADD_PORTFOLIO = "ADD_PORTFOLIO",
@@ -26,11 +27,6 @@ export interface FundingSourcePayload {
 
 export interface OperatorPayload {
   operators: Array<string>;
-}
-
-export interface CspResponse {
-  code: number;
-  content: object;
 }
 
 export interface CspInvocation {

--- a/utils/middleware/error-handling-middleware.ts
+++ b/utils/middleware/error-handling-middleware.ts
@@ -1,5 +1,5 @@
 import middy from "@middy/core";
-import { APIGatewayProxyResult } from "aws-lambda";
+import { APIGatewayProxyResult, SQSEvent } from "aws-lambda";
 import { serializeError } from "serialize-error";
 import { ValidationErrorResponse } from "../response";
 import { INTERNAL_SERVER_ERROR, REQUEST_BODY_INVALID } from "../errors";
@@ -7,8 +7,8 @@ import { CspInvocation, CspResponse, ProvisionRequest } from "../../models/provi
 import { logger } from "../logging";
 import { CommonMiddlewareInputs } from "./common";
 
-export type MiddlewareInputs = CommonMiddlewareInputs | CspInvocation | ProvisionRequest;
-export type MiddlewareOutputs = APIGatewayProxyResult | CspResponse | ValidationErrorResponse | ProvisionRequest;
+export type MiddlewareInputs = CommonMiddlewareInputs | CspInvocation | ProvisionRequest | SQSEvent;
+export type MiddlewareOutputs = APIGatewayProxyResult | CspResponse | ValidationErrorResponse | ProvisionRequest | void;
 
 // A central place to catch and handle errors that occur before,
 // during, and after the execution of the lambda

--- a/utils/middleware/error-handling-middleware.ts
+++ b/utils/middleware/error-handling-middleware.ts
@@ -3,7 +3,8 @@ import { APIGatewayProxyResult, SQSEvent } from "aws-lambda";
 import { serializeError } from "serialize-error";
 import { ValidationErrorResponse } from "../response";
 import { INTERNAL_SERVER_ERROR, REQUEST_BODY_INVALID } from "../errors";
-import { CspInvocation, CspResponse, ProvisionRequest } from "../../models/provisioning-jobs";
+import { CspInvocation, ProvisionRequest } from "../../models/provisioning-jobs";
+import { CspResponse } from "../../api/util/csp-request";
 import { logger } from "../logging";
 import { CommonMiddlewareInputs } from "./common";
 


### PR DESCRIPTION
Implement cost invocation function to make external CSP request for cost data. 

Create `cost-request-fn` that makes a CSP request
- add `costRequestFn` to `cost-api-implementation` (infrastructure)
  - add secrets and grant permissions for making requests
  - consumes messages from `CostRequestQueue` as an event source
  - send messages to `CostResponseQueue`
- extract `makeARealRequest` into `cspRequest` for reuse
  - remove `makeARealRequest`
- Add unit tests
  - functions `cost-request-fn` and `csp-request`
  - infrastructure `cost-api-implementation`

Ticket: AT-7457