### PR TITLE
Refactor CDK constructs

### DIFF
--- a/lib/constructs/sfn-lambda-invoke-task.ts
+++ b/lib/constructs/sfn-lambda-invoke-task.ts
@@ -2,39 +2,11 @@ import { Construct } from "constructs";
 import { Duration } from "aws-cdk-lib";
 import * as sfnTasks from "aws-cdk-lib/aws-stepfunctions-tasks";
 
-export interface SfnTasksProps {
-  /**
-   * The props for a Lambda invoking task
-   */
-  readonly sfnTask: sfnTasks.LambdaInvokeProps;
-}
-
-/**
- * Creates a Lambda invoking Task that represents a State in the workflow of a
- * State Machine once execution starts.
- */
-export class SfnLambdaInvokeTask extends Construct {
-  /**
-   * A Step Function Lambda invoking Task used within a State Machine
-   */
-  readonly sfnTask: sfnTasks.LambdaInvoke;
-
-  constructor(scope: Construct, id: string, props: SfnTasksProps) {
-    super(scope, id);
-    const sfnTask = new sfnTasks.LambdaInvoke(this, id, {
-      timeout: Duration.seconds(20),
-      ...props.sfnTask,
-    });
-
-    this.sfnTask = sfnTask;
-  }
-}
-
 type TaskProps = {
   id: string;
   props: sfnTasks.LambdaInvokeProps;
 };
-export type TasksMap = { [name: string]: SfnLambdaInvokeTask };
+export type TasksMap = { [name: string]: sfnTasks.LambdaInvoke };
 
 /**
  * Creates a mapping from an array of tasks, where each task is used for
@@ -45,9 +17,14 @@ export type TasksMap = { [name: string]: SfnLambdaInvokeTask };
  * @returns - an sfnTasks object with all tasks mapped by the id provided
  */
 export function mapTasks(scope: Construct, tasks: Array<TaskProps>): TasksMap {
-  const mappedSfnTasks: TasksMap = {};
-  for (const task of tasks) {
-    mappedSfnTasks[task.id] = new SfnLambdaInvokeTask(scope, task.id, { sfnTask: task.props });
-  }
-  return mappedSfnTasks;
+  return tasks.reduce(
+    (mappedTasks, task) => ({
+      ...mappedTasks,
+      [task.id]: new sfnTasks.LambdaInvoke(scope, task.id, {
+        timeout: Duration.seconds(20),
+        ...task.props,
+      }),
+    }),
+    {}
+  );
 }

--- a/lib/constructs/sqs.test.ts
+++ b/lib/constructs/sqs.test.ts
@@ -1,13 +1,13 @@
 import * as cdk from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { AtatQueue } from "./sqs";
+import { FifoQueue } from "./sqs";
 
 describe("IFP Cost Queues", () => {
   test("Ensure Cost Request and Response Queues are created", async () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "TestStack");
-    const costRequestQueue = new AtatQueue(stack, "TestRequest", { environmentName: "TestAt-0000" }).sqs;
-    const costResponseQueue = new AtatQueue(stack, "TestResponse", { environmentName: "TestAt-0000" }).sqs;
+    const costRequestQueue = new FifoQueue(stack, "TestRequest");
+    const costResponseQueue = new FifoQueue(stack, "TestResponse");
 
     const template = Template.fromStack(stack);
     template.hasResourceProperties(

--- a/lib/constructs/sqs.ts
+++ b/lib/constructs/sqs.ts
@@ -1,34 +1,24 @@
 import * as sqs from "aws-cdk-lib/aws-sqs";
-import { QueueProps } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
 
-export interface SQSProps extends QueueProps {
-  /**
-   * Props to override the default props of the created SQS
-   */
-  overrideSqsProps?: QueueProps;
-  /**
-   * Environment name to help differentiate the queues made
-   */
-  environmentName: string;
-}
-
 /**
- * A basic SQS queue used in ATAT
- * - defaults to an FIFO queue
+ * An SQS Queue configured as a FIFO queue.
+ *
+ * This is appropriate for the general use-case within the ATAT application.
+ * Encryption-at-rest is enabled by default for the queue.
+ *
+ * The following properties will be overriden if set via `props`:
+ *   - `fifo` will be set to `true`,
+ *   - `contentBasedDeduplication` will be set to `true`
+ *   - `encryption` will be set to `KMS_MANAGED`
  */
-export class AtatQueue extends Construct {
-  /**
-   * The SQS resource that gets created.
-   */
-  public readonly sqs: sqs.IQueue;
-
-  constructor(scope: Construct, id: string, props: SQSProps) {
-    super(scope, id);
-    this.sqs = new sqs.Queue(scope, `${props.environmentName}${id}Queue`, {
+export class FifoQueue extends sqs.Queue {
+  constructor(scope: Construct, id: string, props?: sqs.QueueProps) {
+    super(scope, id, {
+      ...props,
       fifo: true,
       contentBasedDeduplication: true,
-      ...props.overrideSqsProps,
+      encryption: sqs.QueueEncryption.KMS_MANAGED,
     });
   }
 }

--- a/lib/constructs/state-machine.ts
+++ b/lib/constructs/state-machine.ts
@@ -3,13 +3,10 @@ import * as sfn from "aws-cdk-lib/aws-stepfunctions";
 import * as logs from "aws-cdk-lib/aws-logs";
 import { Construct } from "constructs";
 
-export interface StateMachineProps {
+export interface StateMachineProps extends sfn.StateMachineProps {
   /**
-   * Props to define a State Machine
-   */
-  readonly stateMachineProps: sfn.StateMachineProps;
-  /**
-   * Props to define the State Machine log group
+   * The CloudWatch Log Group where logs from the State Machine will
+   * be sent.
    */
   readonly logGroup: logs.ILogGroup;
 }
@@ -19,16 +16,15 @@ export interface StateMachineProps {
  * - uses a Standard State Machine Type (default)
  * - 180 seconds timeout (default)
  */
-export class StateMachine extends Construct {
-  readonly stateMachine: sfn.IStateMachine;
+export class LoggingStandardStateMachine extends sfn.StateMachine {
   constructor(scope: Construct, id: string, props: StateMachineProps) {
-    super(scope, id);
-    const stateMachine = new sfn.StateMachine(this, id, {
+    const { logGroup, ...otherProps } = props;
+    super(scope, id, {
       // defaults that can be overridden
       timeout: Duration.seconds(10),
       stateMachineType: sfn.StateMachineType.STANDARD,
       // configuration passed in
-      ...props.stateMachineProps,
+      ...otherProps,
       // defaults that cannot be overridden
       tracingEnabled: true,
       logs: {
@@ -36,6 +32,5 @@ export class StateMachine extends Construct {
         destination: props.logGroup,
       },
     });
-    this.stateMachine = stateMachine;
   }
 }


### PR DESCRIPTION
This refactors a pretty significant chunk of constructs within the
application to just directly extend other components rather than build
compositions based on them. For a few things, we're basically just
creating pre-configured variants of another construct type (SQS Queue,
State Machine, etc) and we can handle that pretty trivially and remove
some need to make wonky `.foo` attribute accesses. This also makes them
easier to just pass around within the CDK app.

Notably, the API Gateway REST API is not refactored. That adds a few
methods and my worry there is that we actually use some names that may
eventually conflict with the underlying resource (not likely but
possible) and so I kinda tried to avoid that.

Because the `SfnLambdaInvokeTask` was only ever created in one place, we
can also just get rid of it entirely. It wasn't doing a whole lot for
us. I think it made sense in a time where its use case was uncertain and
where we had more constructs with that pattern; today, I think we can
clean it up a bit.

This **will** result in resource replacement in already-deployed
environments as constuct paths (and therefore CloudFormation resource
logical IDs) will change. I feel that because these are mostly Queues
and connecting resources this is safe but there's a chance this will gum
up the pipeline and we'll either need to make some additional fixes or
revert.
