### PR TITLE
Fix networking issues with AWS Secrets Manager

### DIFF
--- a/utils/aws-sdk/secrets-manager.ts
+++ b/utils/aws-sdk/secrets-manager.ts
@@ -1,4 +1,9 @@
 import { SecretsManager } from "@aws-sdk/client-secrets-manager";
 import { logger } from "../logging";
 
-export const secretsClient = new SecretsManager({ useFipsEndpoint: true, logger });
+// For this client, we do not use the `useFipsEndpoint` parameter. In the end, this will use
+// our private endpoint, which is FIPS-compliant; however, the DNS query that results will be
+// for `secretsmanager-fips.<region>.amazonaws.com. The private endpoint will only "register"
+// as `secretsmanager.<region>.amazonaws.com. This results in failed queries to the endpoint
+// with our networking configuration.
+export const secretsClient = new SecretsManager({ logger });


### PR DESCRIPTION
The bulk of the issue is described in the code comment. Putting this
explanation inline makes it more immediately clear to future
maintainers, reviewers, or auditors why we've omitted the flag in this
particular case.

All other services we invoke from within our VPC use the same hostname
for FIPS and non-FIPS so keeping `useFipsEndpoint` is fine for those
(SQS and Step Functions).
