### PR TITLE
Add required notifications to be sent via email

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -67,6 +67,9 @@ export function createApp(props?: cdk.AppProps): cdk.App {
       repository: app.node.tryGetContext("atat:VersionControlRepo"),
       branch: app.node.tryGetContext("atat:VersionControlBranch"),
       githubPatName: app.node.tryGetContext("atat:GitHubPatName"),
+      // Set the notification email address, unless we're building the account where
+      // sandbox environments live because our inboxes would never recover.
+      notificationEmail: environmentName === "Sandbox" ? undefined : app.node.tryGetContext("atat:NotificationEmail"),
     });
   }
   return app;

--- a/cdk.json
+++ b/cdk.json
@@ -33,6 +33,7 @@
     "atat:CspConfigurationName": "config/csp/integration",
     "atat:GitHubPatName": "auth/github/pat",
     "atat:VersionControlBranch": "develop",
-    "atat:VersionControlRepo": "dod-ccpo/atat-web-api"
+    "atat:VersionControlRepo": "dod-ccpo/atat-web-api",
+    "atat:NotificationEmail": "atat-dev+infrastructure-notif@ccpo.mil"
   }
 }

--- a/lib/atat-notification-stack.test.ts
+++ b/lib/atat-notification-stack.test.ts
@@ -1,0 +1,52 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { AtatNotificationStack, IamChangeRule } from "./atat-notification-stack";
+
+describe("IAM Change Notifications", () => {
+  it("should match the schema created in the AWS Events console", async () => {
+    // GIVEN
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack");
+
+    // WHEN
+    const eventRule = new IamChangeRule(stack, "IamRule");
+    const template = Template.fromStack(stack);
+
+    // THEN
+    template.hasResourceProperties("AWS::Events::Rule", {
+      EventPattern: {
+        source: ["aws.iam"],
+        "detail-type": ["AWS API Call via CloudTrail"],
+        detail: {
+          eventSource: ["iam.amazonaws.com"],
+          eventName: [
+            "CreateUser",
+            "CreateLoginProfile",
+            "CreateAccessKey",
+            "UpdateUser",
+            "UpdateLoginProfile",
+            "UpdateAccessKey",
+            "DeleteLoginProfile",
+            "DeleteUser",
+          ],
+        },
+      },
+    });
+  });
+});
+
+describe("Atat Notification Stack", () => {
+  it("should contain an SNS topic", async () => {
+    // GIVEN
+    const app = new cdk.App();
+    const stack = new AtatNotificationStack(app, "TestStack", {
+      notificationEmail: "foo@example.com",
+    });
+
+    // WHEN
+    const template = Template.fromStack(stack);
+
+    // THEN
+    template.hasResourceProperties("AWS::SNS::Topic", {});
+  });
+});

--- a/lib/atat-notification-stack.ts
+++ b/lib/atat-notification-stack.ts
@@ -1,0 +1,55 @@
+import * as cdk from "aws-cdk-lib";
+import * as events from "aws-cdk-lib/aws-events";
+import * as eventTargets from "aws-cdk-lib/aws-events-targets";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as subscriptions from "aws-cdk-lib/aws-sns-subscriptions";
+import { Construct } from "constructs";
+
+export interface AtatNotificationStackProps {
+  /**
+   * The system ISSO/ISSM-approved email address to which relevant notifications
+   * must be sent.
+   */
+  notificationEmail: string;
+}
+
+export class IamChangeRule extends events.Rule {
+  constructor(scope: Construct, id: string, props?: events.RuleProps) {
+    super(scope, id, {
+      ...props,
+      eventPattern: {
+        source: ["aws.iam"],
+        detailType: ["AWS API Call via CloudTrail"],
+        detail: {
+          eventSource: ["iam.amazonaws.com"],
+          eventName: [
+            // AC-2(4).5,AC-2(4).11 - Account Creation/Enabling Actions
+            "CreateUser",
+            "CreateLoginProfile",
+            "CreateAccessKey",
+            // AC-2(4).6 - Account Modification Actions
+            "UpdateUser",
+            "UpdateLoginProfile",
+            // AC-2(4).7 - Account Disabling Actions
+            "UpdateAccessKey",
+            "DeleteLoginProfile",
+            // AC-2(4).8
+            "DeleteUser",
+          ],
+        },
+      },
+    });
+  }
+}
+
+export class AtatNotificationStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: AtatNotificationStackProps) {
+    super(scope, id);
+    const topic = new sns.Topic(this, "AtatNotifications");
+    topic.addSubscription(new subscriptions.EmailSubscription(props.notificationEmail));
+    const topicTarget = new eventTargets.SnsTopic(topic);
+
+    const iamChanges = new IamChangeRule(this, "IamChanges");
+    iamChanges.addTarget(topicTarget);
+  }
+}

--- a/lib/atat-pipeline-stack.ts
+++ b/lib/atat-pipeline-stack.ts
@@ -4,11 +4,13 @@ import { Construct } from "constructs";
 import { AtatWebApiStack } from "./atat-web-api-stack";
 import { AtatIamStack } from "./atat-iam-stack";
 import { AtatNetStack } from "./atat-net-stack";
+import { AtatNotificationStack } from "./atat-notification-stack";
 import { GovCloudCompatibilityAspect } from "./aspects/govcloud-compatibility";
 
 export interface AtatProps {
   environmentName: string;
   vpcCidr?: string;
+  notificationEmail?: string;
 }
 
 export interface AtatPipelineStackProps extends cdk.StackProps, AtatProps {
@@ -26,6 +28,11 @@ class AtatApplication extends cdk.Stage {
       environmentName: props.environmentName,
       network: net,
     });
+    if (props.notificationEmail) {
+      const notifications = new AtatNotificationStack(this, "AtatNotifications", {
+        notificationEmail: props.notificationEmail,
+      });
+    }
     cdk.Aspects.of(this).add(new GovCloudCompatibilityAspect());
   }
 }


### PR DESCRIPTION
Similar to the currently-open monitoring PR, this adds a base for
setting up notifications everywhere except our sandbox account. These
notifications are required under the STIGs and help ensure we meet some
requirements under 800-53.

We ignore Sandbox because we build IAM stuff there all the day and we'll
never see a real email; it'd just be notifications.
