### PR TITLE
Update Security Group rules for API Gateway

### DIFF
--- a/lib/atat-net.test.ts
+++ b/lib/atat-net.test.ts
@@ -18,7 +18,7 @@ describe("ATAT network creation", () => {
     });
   });
 
-  test("DNS Query logging enabled", async () => {
+  test.skip("DNS Query logging enabled", async () => {
     // GIVEN
     const app = new cdk.App();
     // WHEN


### PR DESCRIPTION
This also disables VPC DNS Query Logs for now until we work out some IAM
and resource policy issues.
