### PR TITLE
Update HOTH specification with IGCE schema

### DIFF
--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -465,7 +465,7 @@ components:
           - "3000_OTHER"
         dow_task_number:
           type: string
-        service:
+        service_offering:
           description: "The service offering for the particular line item."  
           type: string 
         item_description_or_config_summary:

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -407,10 +407,77 @@ components:
           type: string
           enum:
             - DESCRIPTION_OF_WORK
+            - INDEPENDENT_GOVERNMENT_COST_ESTIMATE
         templatePayload:
           type: object
           oneOf:
             - $ref: "#/components/schemas/DescriptionOfWork"
+            - $ref: "#/components/schemas/IndependentGovernmentCostEstimate"
+    IndependentGovernmentCostEstimate:
+      description: "Data used for generating the Independence Government Cost Estimate (IGCE) document"
+      type: object
+      properties:
+        funding_document:
+          description: >-
+            Information related to a funding plan. Either both the GTC number and Order 
+            number or only the MIPR number. 
+          type: object
+          properties:
+            funding_type:
+              type: string
+              enum: 
+                - FS_FORM
+                - MIPR
+            gtc_number: 
+              type: string
+            order_number:
+              type: string
+            mipr_number: 
+              type: string
+        surge_capabilities:
+          type: string
+        periods_estimate:
+          type: array
+          items:
+            $ref: "#/components/schemas/PeriodEstimate"
+    PeriodEstimate:
+      description: "Information specific to a base or option period sheet in the IGCE document"
+      type: object
+      properties:
+        period:
+          description: "The period of performance for a specific period sheet."
+          $ref: "#/components/schemas/Period"
+        period_line_items:
+          type: array
+          items:
+            $ref: "#/components/schemas/PeriodLineItem"
+    PeriodLineItem:
+      description: "Line items entered for each period sheet in the IGCE document"
+      type: object
+      properties:
+        clin: 
+          type: string
+        idiq_clin:
+          type: string
+          enum: 
+          - "1000_CLOUD"
+          - "2000_CLOUD_SUPPORT"
+          - "3000_OTHER"
+        dow_task_number:
+          type: string
+        service:
+          description: "The service offering for the particular line item."  
+          type: string 
+        item_description_or_config_summary:
+          type: string
+        monthly_price:
+          type: number
+        months_in_period: 
+          description: >-
+            Months in the specified period. The days/weeks/year should be converted into
+            months and always rounded up to a whole number. Average weeks in a month 4.345.
+            Average days in a month 30.4167. Example 6 wks / 4.345 = 1.381 => 2 months.
+          type: number 
     DescriptionOfWork:
       description: "Schema used to generate DescriptionOfWork document"
       type: object


### PR DESCRIPTION
Add the IGCE schema to support document generation of the IGCE document.

Summary of the information that needs to be captured is below. See [ticket comment](https://ccpo.atlassian.net/browse/AT-7757?focusedCommentId=337288) for a more in depth explanation of the IGCE document and an example with filled in data. 
### Period Sheets 
There are multiple period sheets that contain information for each period. The information required: 
- a `period of performance` - an amount of time (e.g., 6 months)
- the `funding document number` - relates to the funding plan
  - is either the GTC and order number when using G-Invoicing and the 7600 A/B documents, OR the MIPR number when using a MIPR document. 
- one or more `CLIN line items` (various properties)

### Summary Sheet
Most of the summary sheet will be filled in based upon formulas connected to the period sheets. However, there are two fields that need to be filled in: 
- the `surge capabilities` (e.g., 1-50%)
- the `funding document number` - same as the period sheet

### Supporting Documentation
On the `Instructions` sheet towards the bottom it refers to supporting documentation used for estimates that can come from CSP calculators. It is not clear which format the supporting document will be in currently (e.g., PDF, CSV, link), and that this may help else where causing the removal of the `Supporting Information for IGCE` sheet in the IGCE document.

Ticket: AT-7757
