### PR TITLE
Resolve or supress all 800-53r4 checks in ATAT stack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,17 @@ jobs:
       - name: Install project dependencies
         run: |
           npm ci
-      - name: Synthesize CDK template
-        run: cdk synth -c "atat:EnvironmentId=CiTest" -c "atat:Sandbox=true"
+      - name: Synthesize CDK template - Sandbox
+        run: |
+          cdk synth -c "atat:EnvironmentId=CiTest" -c "atat:Sandbox=true"
+      - name: Synthesize CDK template - Full Environments
+        run: >-
+          cdk synth
+          -c "atat:EnvironmentId=FullCiTest"
+          -c "atat:VpcCidr=10.250.0.0/16"
+          -c "atat:ApiDomainName=ci.atat.fake.test"
+          -c "atat:ApiCertificateArn=arn:aws:us-east-1:123456789012:certificate/aec3ac93-692e-406e-afef-642fb31afc41"
+          AtatEnvironmentPipeline/Sandbox
       - name: Gather CloudFormation artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -150,7 +150,7 @@
         "filename": "lib/atat-web-api-stack.ts",
         "hashed_secret": "e2c872ec4dc5d6d2ca8f1f22852b4670d039470a",
         "is_verified": false,
-        "line_number": 120
+        "line_number": 136
       }
     ],
     "lib/constructs/api-user.test.ts": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-27T21:57:38Z"
+  "generated_at": "2022-07-28T01:40:34Z"
 }

--- a/lib/atat-pipeline-stack.ts
+++ b/lib/atat-pipeline-stack.ts
@@ -1,12 +1,13 @@
 import * as cdk from "aws-cdk-lib";
 import * as pipelines from "aws-cdk-lib/pipelines";
 import { Construct } from "constructs";
-import { AtatWebApiStack, ApiCertificateOptions } from "./atat-web-api-stack";
+import { GovCloudCompatibilityAspect } from "./aspects/govcloud-compatibility";
 import { AtatIamStack } from "./atat-iam-stack";
+import { AtatMonitoringStack } from "./atat-monitoring-stack";
 import { AtatNetStack } from "./atat-net-stack";
 import { AtatNotificationStack } from "./atat-notification-stack";
-import { AtatMonitoringStack } from "./atat-monitoring-stack";
-import { GovCloudCompatibilityAspect } from "./aspects/govcloud-compatibility";
+import { ApiCertificateOptions, AtatWebApiStack } from "./atat-web-api-stack";
+import { NagSuppressions, NIST80053R4Checks } from "cdk-nag";
 
 export interface AtatProps {
   environmentName: string;
@@ -45,6 +46,13 @@ class AtatApplication extends cdk.Stage {
       environmentName: props.environmentName,
     });
     cdk.Aspects.of(this).add(new GovCloudCompatibilityAspect());
+    cdk.Aspects.of(atat).add(new NIST80053R4Checks({ verbose: true }));
+    NagSuppressions.addStackSuppressions(atat, [
+      {
+        id: "NIST.800.53.R4-IAMNoInlinePolicy",
+        reason: "Inline policies are used in a large number of situations by CDK constructs.",
+      },
+    ]);
   }
 }
 

--- a/lib/constructs/apigateway.ts
+++ b/lib/constructs/apigateway.ts
@@ -1,6 +1,7 @@
 import * as cdk from "aws-cdk-lib";
 import * as apigw from "aws-cdk-lib/aws-apigateway";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as kms from "aws-cdk-lib/aws-kms";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 
@@ -36,6 +37,7 @@ export interface RestApiVpcConfiguration {
 
 export interface AtatRestApiProps extends apigw.RestApiProps {
   vpcConfig?: RestApiVpcConfiguration;
+  logEncryptionKey?: kms.IKey;
 }
 
 export class AtatRestApi extends Construct {
@@ -44,7 +46,8 @@ export class AtatRestApi extends Construct {
   constructor(scope: Construct, id: string, props?: AtatRestApiProps) {
     super(scope, id);
     const accessLogs = new logs.LogGroup(this, "AccessLogs", {
-      retention: logs.RetentionDays.INFINITE,
+      retention: logs.RetentionDays.TEN_YEARS,
+      encryptionKey: props?.logEncryptionKey,
     });
 
     // When a VPC is provided (which may not always be the case), a private

--- a/lib/constructs/provisioning-sfn-workflow.ts
+++ b/lib/constructs/provisioning-sfn-workflow.ts
@@ -1,5 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as kms from "aws-cdk-lib/aws-kms";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as lambdaNodeJs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as logs from "aws-cdk-lib/aws-logs";
@@ -32,6 +33,7 @@ export interface ProvisioningWorkflowProps {
   environmentName: string;
   idp?: IIdentityProvider;
   vpc?: ec2.IVpc;
+  logEncryptionKey?: kms.IKey;
 }
 
 export interface IProvisioningWorkflow {
@@ -137,8 +139,9 @@ export class ProvisioningWorkflow extends Construct implements IProvisioningWork
     // Composing state machine
     this.workflow = InvokeCspApi.next(httpResponseChoices);
     this.logGroup = new logs.LogGroup(scope, "StepFunctionsLogs", {
-      retention: logs.RetentionDays.INFINITE,
+      retention: logs.RetentionDays.TEN_YEARS,
       logGroupName: `/aws/vendedlogs/states/StepFunctionsLogs${environmentName}`,
+      encryptionKey: props.logEncryptionKey,
     });
     this.stateMachine = new LoggingStandardStateMachine(this, "ProvisioningStateMachine", {
       logGroup: this.logGroup,


### PR DESCRIPTION
We still need to do some work to solve IAM and Network; however, this
fixes the issues in the main app stack. All remaining issues are
resolved or are suppressed and the check is added to the deployment
pipeline to ensure that we always remain compliant. This is far easier
to do now that we have networking solved (except that tricky
`AwsCustomResource`).

This also adds a synthesis of a full environment to our CI workflow.