### PR TITLE
Temporarily don't encrypt log groups

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -150,7 +150,7 @@
         "filename": "lib/atat-web-api-stack.ts",
         "hashed_secret": "e2c872ec4dc5d6d2ca8f1f22852b4670d039470a",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 140
       }
     ],
     "lib/constructs/api-user.test.ts": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-28T01:40:34Z"
+  "generated_at": "2022-07-28T17:50:33Z"
 }


### PR DESCRIPTION
This is a missing feature in CloudFormation in us-gov-west-1. Coordinate
internally for questions about the status of the related support case.
