### PR TITLE
Fix allowed scopes for Cost Request Function

### DIFF
--- a/api/util/csp-request.ts
+++ b/api/util/csp-request.ts
@@ -86,6 +86,7 @@ export async function cspRequest(request: CspRequestType<CostRequest | Provision
       csp: targetCsp.name,
       request: {
         csp: targetCsp.name,
+        body: request.body,
         url,
       },
       response: { statusCode: response.status, body: response.data },

--- a/lib/constructs/cost-api-implementation.ts
+++ b/lib/constructs/cost-api-implementation.ts
@@ -79,9 +79,7 @@ export class CostApiImplementation extends Construct implements ICostApiImplemen
 
     // secrets permissions
     cspConfig.grantRead(this.costRequestFn);
-    props.idp?.addClient(new idp.IdentityProviderLambdaClient("CspWriteCost", this.costRequestFn), [
-      "atat/write-portfolio",
-    ]);
+    props.idp?.addClient(new idp.IdentityProviderLambdaClient("CspWriteCost", this.costRequestFn), ["atat/read-cost"]);
 
     this.path = props.apiParent.addResource("cost-jobs");
     this.methods = {} as Record<HttpMethod, Method>;

--- a/lib/constructs/cost-api-implementation.ts
+++ b/lib/constructs/cost-api-implementation.ts
@@ -79,7 +79,7 @@ export class CostApiImplementation extends Construct implements ICostApiImplemen
 
     // secrets permissions
     cspConfig.grantRead(this.costRequestFn);
-    props.idp?.addClient(new idp.IdentityProviderLambdaClient("CspWriteCost", this.costRequestFn), ["atat/read-cost"]);
+    props.idp?.addClient(new idp.IdentityProviderLambdaClient("CspReadCost", this.costRequestFn), ["atat/read-cost"]);
 
     this.path = props.apiParent.addResource("cost-jobs");
     this.methods = {} as Record<HttpMethod, Method>;


### PR DESCRIPTION
Per the API spec, this is only permitted to read cost.
