### PR TITLE
Update provisioning schema and HOTH spec

### DIFF
--- a/api/provision/start-provisioning-job.test.ts
+++ b/api/provision/start-provisioning-job.test.ts
@@ -54,7 +54,14 @@ describe("Successful provisioning operations", () => {
         ...provisioningBodyNoPayload,
         operationType: ProvisionRequestType.ADD_OPERATORS,
         payload: {
-          operators: [...operators, "root.admin@mail.mil"],
+          operators: [
+            ...operators,
+            {
+              email: "root.admin@mail.mil",
+              dodId: "9999999999",
+              needsReset: false,
+            },
+          ],
         },
       }),
       headers: {

--- a/api/util/common-test-fixtures.ts
+++ b/api/util/common-test-fixtures.ts
@@ -14,7 +14,18 @@ export const fundingSources = [
   },
 ];
 
-export const operators = ["admin1@mail.mil", "superAdmin@mail.mil"];
+export const operators = [
+  {
+    email: "admin1@mail.mil",
+    dodId: "1122334455",
+    needsReset: false,
+  },
+  {
+    email: "superAdmin@mail.mil",
+    dodId: "1234567890",
+    needsReset: false,
+  },
+];
 export const cspA = {
   name: "CSP_A",
   uri: "https://cspa.example.com/api/atat",

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -272,11 +272,10 @@ components:
           items:
             $ref: "#/components/schemas/FundingSource"
         operators:
+          description: Array of operator objects
           type: array
-          description: Array of operator email addresses
           items:
-            type: string
-            example: "user@mail.mil"
+            $ref: "#/components/schemas/Operator"
         csp_id:
           type: string
           readOnly: true
@@ -299,11 +298,21 @@ components:
         - operators
       properties:
         operators:
+          description: Array of operator objects
           type: array
-          description: Array of operator email addresses
           items:
-            type: string
-            example: "user@mail.mil"
+            $ref: "#/components/schemas/Operator"
+    Operator:
+      description: Operator data for provisioning resources in a CSP
+      type: object
+      properties:
+        email:
+          type: string
+          example: "user@mail.mil"
+        dod_id:
+          type: string
+        needs_reset:
+          type: boolean
     FundingSource:
       type: object
       description: >-

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -305,6 +305,9 @@ components:
     Operator:
       description: Operator data for provisioning resources in a CSP
       type: object
+      required:
+        - email
+        - dod_id
       properties:
         email:
           type: string
@@ -313,6 +316,7 @@ components:
           type: string
         needs_reset:
           type: boolean
+          default: false
     FundingSource:
       type: object
       description: >-

--- a/models/provisioning-jobs.ts
+++ b/models/provisioning-jobs.ts
@@ -15,10 +15,16 @@ export interface FundingSource {
   popEndDate: string;
 }
 
+export interface Operator {
+  email: string;
+  dodId: string;
+  needsReset: boolean;
+}
+
 export interface NewPortfolioPayload {
   name: string;
   fundingSources: Array<FundingSource>;
-  operators: Array<string>;
+  operators: Array<Operator>;
 }
 
 export interface FundingSourcePayload {
@@ -26,7 +32,7 @@ export interface FundingSourcePayload {
 }
 
 export interface OperatorPayload {
-  operators: Array<string>;
+  operators: Array<Operator>;
 }
 
 export interface CspInvocation {
@@ -87,7 +93,17 @@ export const provisionRequestSchema = {
             required: ["taskOrderNumber", "clin", "popStartDate", "popEndDate"],
           },
         },
-        operators: { type: "array", items: { type: "string" } },
+        operators: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              email: { type: "string" },
+              dodId: { type: "string" },
+              needsReset: { type: "boolean" },
+            },
+          },
+        },
       },
       additionalProperties: false,
       minProperties: 1,

--- a/models/provisioning-jobs.ts
+++ b/models/provisioning-jobs.ts
@@ -97,10 +97,11 @@ export const provisionRequestSchema = {
           type: "array",
           items: {
             type: "object",
+            required: ["email", "dodId"],
             properties: {
               email: { type: "string" },
               dodId: { type: "string" },
-              needsReset: { type: "boolean" },
+              needsReset: { type: "boolean", default: false },
             },
           },
         },


### PR DESCRIPTION
Update provisioning schema and HOTH specification to account for the changes in operators 
used for provisioning jobs, which aligns with the ATAT spec  version `0.3.0`. 
- Update provisioning job model and HOTH spec
- Update tests to reflect operator changes

Ticket: AT-7804