### PR TITLE
Add support for IGCE to document generation lambda

### DIFF
--- a/document-generation/generate-document.test.ts
+++ b/document-generation/generate-document.test.ts
@@ -1,10 +1,10 @@
 import fs from "fs";
 import { Context } from "aws-lambda";
-import { requestContext } from "../api/util/common-test-fixtures";
-import { handler } from "./generate-document";
-import { sampleDowRequest } from "./handlebarUtils/sampleTestData";
-import { SuccessBase64Response, ValidationErrorResponse } from "../utils/response";
 import { DocumentType } from "../models/document-generation";
+import { ErrorStatusCode, OtherErrorResponse, SuccessBase64Response, ValidationErrorResponse } from "../utils/response";
+import { handler } from "./generate-document";
+import { requestContext } from "../api/util/common-test-fixtures";
+import { sampleDowRequest } from "./handlebarUtils/sampleTestData";
 
 const validRequest = {
   body: JSON.stringify(sampleDowRequest),
@@ -77,5 +77,25 @@ describe("Invalid requests for generate-document handler", () => {
     // THEN / ASSERT
     expect(response).toBeInstanceOf(ValidationErrorResponse);
     expect(responseBody.message).toBe("Request failed validation");
+  });
+});
+
+describe("Temporary Not Implemented generate-document handler", () => {
+  it("should return 501 response", async () => {
+    // GIVEN / ARRANGE
+    const igceRequest = {
+      ...validRequest,
+      body: JSON.stringify({
+        documentType: "INDEPENDENT_GOVERNMENT_COST_ESTIMATE",
+        templatePayload: "",
+      }),
+    };
+
+    // WHEN / ACT
+    const response = await handler(igceRequest, {} as Context);
+
+    // THEN / ASSERT
+    expect(response).toBeInstanceOf(OtherErrorResponse);
+    expect(response.statusCode).toBe(ErrorStatusCode.NOT_IMPLEMENTED);
   });
 });

--- a/document-generation/generate-document.test.ts
+++ b/document-generation/generate-document.test.ts
@@ -4,7 +4,7 @@ import { DocumentType } from "../models/document-generation";
 import { ErrorStatusCode, OtherErrorResponse, SuccessBase64Response, ValidationErrorResponse } from "../utils/response";
 import { handler } from "./generate-document";
 import { requestContext } from "../api/util/common-test-fixtures";
-import { sampleDowRequest } from "./handlebarUtils/sampleTestData";
+import { sampleDowRequest, sampleIgceRequest } from "./handlebarUtils/sampleTestData";
 
 const validRequest = {
   body: JSON.stringify(sampleDowRequest),
@@ -83,11 +83,8 @@ describe("Invalid requests for generate-document handler", () => {
 describe("Temporary Not Implemented generate-document handler", () => {
   it("should return 501 response", async () => {
     // GIVEN / ARRANGE
-    const igceRequest = {
-      body: {
-        documentType: "INDEPENDENT_GOVERNMENT_COST_ESTIMATE",
-        templatePayload: {},
-      },
+    const validIgceRequest = {
+      body: JSON.stringify(sampleIgceRequest),
       headers: {
         "Content-Type": "application/json",
       },
@@ -95,7 +92,7 @@ describe("Temporary Not Implemented generate-document handler", () => {
     } as any;
 
     // WHEN / ACT
-    const response = await handler(igceRequest, {} as Context);
+    const response = await handler(validIgceRequest, {} as Context);
 
     // THEN / ASSERT
     expect(response).toBeInstanceOf(OtherErrorResponse);

--- a/document-generation/generate-document.test.ts
+++ b/document-generation/generate-document.test.ts
@@ -94,7 +94,6 @@ describe("Temporary Not Implemented generate-document handler", () => {
       requestContext,
     } as any;
 
-    console.log("=======================> " + JSON.stringify(igceRequest));
     // WHEN / ACT
     const response = await handler(igceRequest, {} as Context);
 

--- a/document-generation/generate-document.test.ts
+++ b/document-generation/generate-document.test.ts
@@ -84,13 +84,17 @@ describe("Temporary Not Implemented generate-document handler", () => {
   it("should return 501 response", async () => {
     // GIVEN / ARRANGE
     const igceRequest = {
-      ...validRequest,
-      body: JSON.stringify({
+      body: {
         documentType: "INDEPENDENT_GOVERNMENT_COST_ESTIMATE",
-        templatePayload: "",
-      }),
-    };
+        templatePayload: {},
+      },
+      headers: {
+        "Content-Type": "application/json",
+      },
+      requestContext,
+    } as any;
 
+    console.log("=======================> " + JSON.stringify(igceRequest));
     // WHEN / ACT
     const response = await handler(igceRequest, {} as Context);
 

--- a/document-generation/generate-document.ts
+++ b/document-generation/generate-document.ts
@@ -8,7 +8,6 @@ import { logger } from "../utils/logging";
 import { tracer } from "../utils/tracing";
 import {
   ApiBase64SuccessResponse,
-  ErrorStatusCode,
   OtherErrorResponse,
   SuccessStatusCode,
   ValidationErrorResponse,

--- a/document-generation/handlebarUtils/sampleTestData.ts
+++ b/document-generation/handlebarUtils/sampleTestData.ts
@@ -248,3 +248,55 @@ export const sampleDowRequest = {
     },
   },
 };
+
+export const sampleIgceRequest = {
+  documentType: "INDEPENDENT_GOVERNMENT_COST_ESTIMATE",
+  templatePayload: {
+    funding_document: {
+      funding_type: "FS_FORM",
+      gtc_number: "1234",
+      order_number: "1234",
+      mipr_number: "1234",
+    },
+    surge_capabilities: 5,
+    periods_estimate: [
+      {
+        period: {
+          period_unit: "YEAR",
+          period_unit_count: "1",
+          period_type: "BASE",
+          option_order: null,
+        },
+        period_line_items: [
+          {
+            clin: "0001",
+            idiq_clin: "1000_CLOUD",
+            dow_task_number: "4.2.1.1",
+            service_offering: "Compute",
+            item_description_or_config_summary: "description of item",
+            monthly_price: "500",
+            months_in_period: 12,
+          },
+          {
+            clin: "0002",
+            idiq_clin: "2000_CLOUD_SUPPORT",
+            dow_task_number: "4.2.1.2",
+            service_offering: "Applications",
+            item_description_or_config_summary: "description of item",
+            monthly_price: "500",
+            months_in_period: 12,
+          },
+          {
+            clin: "0003",
+            idiq_clin: "3000_OTHER",
+            dow_task_number: "4.2.1.3",
+            service_offering: "Database",
+            item_description_or_config_summary: "description of item",
+            monthly_price: "500",
+            months_in_period: 12,
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/models/document-generation.ts
+++ b/models/document-generation.ts
@@ -421,7 +421,7 @@ const descriptionOfWork = {
 export const generateDocumentSchema = {
   type: "object",
   properties: {
-    documentType: { enum: [DocumentType.DESCRIPTION_OF_WORK] },
+    documentType: { enum: [DocumentType.DESCRIPTION_OF_WORK, DocumentType.INDEPENDENT_GOVERNMENT_COST_ESTIMATE] },
     templatePayload: descriptionOfWork,
   },
 };

--- a/models/document-generation.ts
+++ b/models/document-generation.ts
@@ -8,6 +8,7 @@ export enum AwardType {
 
 export enum DocumentType {
   DESCRIPTION_OF_WORK = "DESCRIPTION_OF_WORK",
+  INDEPENDENT_GOVERNMENT_COST_ESTIMATE = "INDEPENDENT_GOVERNMENT_COST_ESTIMATE",
 }
 
 export enum PeriodType {

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -17,3 +17,8 @@ export const REQUEST_BODY_INVALID = new OtherErrorResponse(
   "A valid request body must be provided",
   ErrorStatusCode.BAD_REQUEST
 );
+
+/**
+ * To be used in the interim until a feature has been implemented.
+ */
+export const NOT_IMPLEMENTED = new OtherErrorResponse("Not implemented", ErrorStatusCode.NOT_IMPLEMENTED);


### PR DESCRIPTION
Currently the document generation lambda supports generating the _Description of Work_ document as `PDF` with handlebars + puppeteer.  This PR allows the lambda to recognize the _IGCE_ document type and lays groundwork for the generation of an `XLSX` file (see #1105) with [ExcelJS](https://www.npmjs.com/package/exceljs).

- Requests for `IGCE` should return an HTTP 501
- Requests for `Description of Work` should continue to work as expected

Inspecting incoming document type in `baseHandler` and delegating to respective functions for generating PDF or XLSX.  Left PDF generation largely unchanged with the exception of relocating the handling of unrecognized document type (to switch default).

Added a new unit test checking for HTTP 501.  Added sample IGCE request data to use in new unit test to satisfy the middy validator middleware.

Ticket: AT-7758