### PR TITLE
Remove version reporting for CDK commands

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -1,5 +1,6 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/atat-web-api.ts",
+  "versionReporting": false,
   "watch": {
     "include": [
       "**"


### PR DESCRIPTION
This makes templates more readable and removes dead code that never
executes in GovCloud anyway (the conditions never evaluate to true).
