### PR TITLE
Fix GitHub PAT issue and refactor context keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,5 +75,10 @@ And then once you've confirmed that they do, deploy:
 cdk deploy -c atat:EnvironmentId=<ENVIRONMENT_ID> -c atat:Sandbox=true
 ```
 
-The deployed pipeline will be self-mutating so further manual deployments should be rarely (if ever) be
-needed.
+The deployed pipeline will be self-mutating so futher manual deployments should be rarely needed.
+The primary situations needing manual deployment are:
+ - When the GitHub PAT is rotated (using the `atat:ForceGitHubTokenVersion` context)
+ - When changes that require additional command line arguments to `cdk synth` in the self-mutate
+   step are made
+ - When it is necessary to change the branch being watched without a corresponding push to the
+   current target branch (for example, to switch from watching `main` to watching `develop`)

--- a/bin/app.test.ts
+++ b/bin/app.test.ts
@@ -27,7 +27,7 @@ describe("Validation tests", () => {
           "atat:VpcCidr": validCidr,
         },
       });
-    }).toThrow("A VpcCidr must NOT be provided for Sandbox environments.");
+    }).toThrow("atat:VpcCidr must NOT be provided for Sandbox environments.");
   });
 
   it("should have ViprCidr if not Sandbox", async () => {

--- a/docs/manual-steps.md
+++ b/docs/manual-steps.md
@@ -38,6 +38,13 @@ partitions where CodeStar integration is not possible.
 The Secret Name/Path/ARN is configured in the `atat:GitHubPatName` context
 setting. The default Secret Name is `auth/github/pat`.
 
+When the GitHub PAT is updated in AWS Secrets Manager, the Version ID must be
+obtained (this can be done with the `ListSecretVersionIds` API). Then, a
+manual deployment of the pipeline stack must be performed in _each_ environment,
+passing the `atat:ForceGitHubTokenVersion` context value set to the version ID.
+This will ensure that CloudFormation resolves the new version of the secret and
+updates all necessary resources appropriately.
+
 ### Cloud Service Provider Integration Configuration
 
 The configuration values for integrating with Cloud Service Providers is stored

--- a/lib/atat-pipeline-stack.ts
+++ b/lib/atat-pipeline-stack.ts
@@ -68,7 +68,9 @@ export class AtatPipelineStack extends cdk.Stack {
     const pipeline = new pipelines.CodePipeline(this, "Pipeline", {
       synth: new pipelines.ShellStep("Synth", {
         input: pipelines.CodePipelineSource.gitHub(props.repository, props.branch, {
-          authentication: cdk.SecretValue.secretsManager(props.githubPatName),
+          authentication: cdk.SecretValue.secretsManager(props.githubPatName, {
+            versionId: this.node.tryGetContext("atat:ForceGitHubTokenVersion"),
+          }),
         }),
         commands: ["npm ci", "npm run build", "npm run -- cdk synth " + synthParams.join(" ")],
       }),

--- a/lib/constructs/cost-api-implementation.ts
+++ b/lib/constructs/cost-api-implementation.ts
@@ -11,6 +11,7 @@ import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import * as idp from "../constructs/identity-provider";
 import * as secrets from "aws-cdk-lib/aws-secretsmanager";
 import { NodejsFunctionProps } from "aws-cdk-lib/aws-lambda-nodejs";
+import { AtatContextValue } from "../context-values";
 
 export interface ICostApiImplementation extends IApiRoute {
   readonly costRequestQueue: FifoQueue;
@@ -38,7 +39,7 @@ export class CostApiImplementation extends Construct implements ICostApiImplemen
     const cspConfig = secrets.Secret.fromSecretNameV2(
       this,
       "CspConfiguration",
-      this.node.tryGetContext("atat:CspConfigurationName")
+      AtatContextValue.CSP_CONFIGURATION_NAME.resolve(this)
     );
 
     // Cost Queues

--- a/lib/constructs/provisioning-sfn-workflow.ts
+++ b/lib/constructs/provisioning-sfn-workflow.ts
@@ -14,6 +14,7 @@ import { IdentityProviderLambdaClient, IIdentityProvider } from "./identity-prov
 import { mapTasks, TasksMap } from "./sfn-lambda-invoke-task";
 import { FifoQueue } from "./sqs";
 import { LoggingStandardStateMachine } from "./state-machine";
+import { AtatContextValue } from "../context-values";
 
 /**
  * Successful condition check
@@ -66,7 +67,7 @@ export class ProvisioningWorkflow extends Construct implements IProvisioningWork
     const cspConfig = secrets.Secret.fromSecretNameV2(
       this,
       "CspConfiguration",
-      this.node.tryGetContext("atat:CspConfigurationName")
+      AtatContextValue.CSP_CONFIGURATION_NAME.resolve(this)
     );
     const cspWritePortfolioFn = new lambdaNodeJs.NodejsFunction(scope, "CspWritePortfolioFn", {
       entry: "api/provision/csp-write-portfolio.ts",

--- a/lib/context-values.ts
+++ b/lib/context-values.ts
@@ -1,0 +1,144 @@
+import { IConstruct } from "constructs";
+
+/**
+ * Defined context values that configure or alter the behavior of the HOTH API.
+ *
+ * These values are set as CDK Context values, either using the `cdk.json` or
+ * `cdk.context.json` files or using the `-c/--context` CLI argument. Names are
+ * generally prefixed with `atat:` and may have a reasonable default value specified.
+ */
+export class AtatContextValue {
+  /**
+   * Use a specific version of the Secrets Manager Secret that stores the GitHub PAT.
+   *
+   * When specified, the given version will be used. When not specified, the default behavior
+   * of the CDK/CloudFormation will be used (which is to resolve the latest version).
+   */
+  public static readonly FORCE_GITHUB_TOKEN_VERSION = new AtatContextValue("atat:ForceGitHubTokenVersion", undefined);
+
+  /**
+   * The name of the AWS Secrets Manager Secret where the GitHub PAT for CodePipeline is
+   * stored.
+   *
+   * This is used for CodePipeline to access the GitHub repository. The PAT must be stored
+   * in AWS Secrets Manager for safety and it must hav the `repo` and `admin:repo_hooks`
+   * permissions associated with it.
+   */
+  public static readonly GITHUB_PAT_NAME = new AtatContextValue("atat:GitHubPatName", "auth/github/pat");
+
+  /**
+   * The GitHub repository that stores the ATAT/HOTH API infrastructure and application code.
+   */
+  public static readonly VERSION_CONTROL_REPO = new AtatContextValue(
+    "atat:VersionControlRepo",
+    "dod-ccpo/atat-web-api"
+  );
+
+  /**
+   * The branch of the GitHub repository to track for changes.
+   *
+   * This value can, theoretically, be anything under `refs/heads/`
+   */
+  public static readonly VERSION_CONTROL_BRANCH = new AtatContextValue("atat:VersionControlBranch", "develop");
+
+  /**
+   * The name/ID of this environment of ATAT.
+   *
+   * This is used as part of the environment's name in the CloudFormation stack as well as
+   * in descriptions and names of various resources.
+   *
+   * Note that "Sandbox" is a special name; it indicates the "container" environment where
+   * developer sandbox environments are created (and is not, itself, a developer sandbox
+   * environment).
+   */
+  public static readonly ENVIRONMENT_ID = new AtatContextValue("atat:EnvironmentId", undefined);
+
+  /**
+   * The CIDR to use for the environment's VPC.
+   *
+   * This should be one of the supported values by the AWS VPC service, generally the
+   * RFC 1918 addresses. It must be large enough to store all necesary interfaces and
+   * must be unique across all environments.
+   */
+  public static readonly VPC_CIDR = new AtatContextValue("atat:VpcCidr", undefined);
+
+  /**
+   * The custom domain name to use for the created API Gateway API.
+   *
+   * This must be a valid Subject or SAN on the provided ACM certificate.
+   */
+  public static readonly API_DOMAIN_NAME = new AtatContextValue("atat:ApiDomainName", undefined);
+
+  /**
+   * The ARN of the certificate in ACM to use for the created API.
+   *
+   * The certificate must be stored in ACM, not IAM. Additionally, the certificate must have
+   * the domain name specified in `atat:ApiDomainName` as a valid name for the certificate.
+   */
+  public static readonly API_CERTIFICATE_ARN = new AtatContextValue("atat:ApiCertificateArn", undefined);
+
+  /**
+   * Whether this is a developer's sandbox environment.
+   *
+   * The ATAT infrastructure deployment has a concept of Developer Sandbox environments, which
+   * are not attached to a VPC and allow direct internet access for testing and development
+   * activities.
+   *
+   * ONLY PROVIDE THIS VALUE IF SETTING IT TO `"true"`. For safety, allow this value to remain
+   * `undefined` when the intended behavior is for it to be false (as undefined is inherently
+   * falsey).
+   */
+  public static readonly SANDBOX_ENVIRONMENT = new AtatContextValue("atat:Sandbox", undefined);
+
+  /**
+   * The email address to send monitoring notifications to.
+   *
+   * When initially specifed or updated, this email address will receive an SNS subscription
+   * confirmation email which must be acknowledged. This email address must be the address
+   * specified/approved by the ISSO to receive operational notifications for the system.
+   *
+   * This value is ignored when `atat:EnvironmentId` is set to `"Sandbox"`.
+   */
+  public static readonly NOTIFICATION_EMAIL = new AtatContextValue("atat:NotificationEmail", undefined);
+
+  /**
+   * The name of the Secrets Manager Secret that holds the configuration for integrating with
+   * Cloud Service Providers ATAT API implementations.
+   */
+  public static readonly CSP_CONFIGURATION_NAME = new AtatContextValue(
+    "atat:CspConfigurationName",
+    "config/csp/integration"
+  );
+
+  // This eslint-disable is required as it picks up on the constructor shorthand as a
+  // "useless" constructor which is not a correct determination.
+  // eslint-disable-next-line no-useless-constructor
+  private constructor(public readonly name: string, public readonly defaultValue: any | undefined) {}
+
+  /**
+   * Resolve the value of the context within a given scope.
+   *
+   * This delegates to the CDK's builtin context resolution mechanism and falls back to the
+   * default value (if any).
+   */
+  resolve(scope: IConstruct): any | undefined {
+    const value = scope.node.tryGetContext(this.name);
+    return value ?? this.defaultValue;
+  }
+
+  /**
+   * Create a CDK app CLI argument that passes the given value for this context value.
+   *
+   * @param value The value to pass on the CLI
+   */
+  toCliArgument(value: string | undefined): string {
+    if (value === undefined) {
+      return "";
+    }
+    return `-c ${this.name}='${value}'`;
+  }
+
+  toString() {
+    return this.name;
+  }
+}


### PR DESCRIPTION
This PR makes two primary modifications. First, an override context
value is added to make it easier to override the version of the GitHub
PAT secret that CloudFormation resolves to force it to pick up a new
version. Because this is handled with yet another wonky context key,
the way we handle context keys generally is also improved to be more
maintainable and understandable in the future.

### Fixing the GitHub PAT resolution

In some scenarios, the PAT needs to be rotated; however, CloudFormation
will not automatically pick up that there's a new version. This is
because CloudFormation will only re-resolve the secret when either the
version changes or a property of the resource changes. I tried to do
this with Tags but that didn't seem to be sufficient.

Instead, what we do is conditionally pass a specific version ID to
resolve when the `atat:ForceGitHubTokenVersion` context value is
provided. When not provided, this will be `undefined` and the default
value will be used (`AWSCURRENT`). Otherwise, the given value will be
used.

This means that we need to _manually_ run a single CDK deploy in each
environment after rotating the GitHub PAT. CloudFormation will update
the pipeline and the pipeline will then automatically update itself to
not specify a particular version. This parameter should be provided
manually on the CLI and not via `cdk.json` (nor via `cdk.context.json`)
to allow it to just be specified for the one execution.

### Contextualizing context

This extracts all currently used context values into a shared enum-like
class that will allow for easier and more consistent resolution of
context values as well as, most excitingly, clear documentation for each
of the used context values.

Each of the given context values is extracted to an instance of the
`AtatContextValue` class and exposed as a static variable of the class;
the class has a private constructor and all attributes are readonly to
limit runtime modifications. The static properties are documented to
describe the intended behavior and usage of the context key and how the
value will be used. A helper is provider to allow automatically
resolving within a given scope in the CDK app as well the ability to
fallback to the default value (if one exists). A helper is also created
to support converting the values to CLI arguments (helpful in the
pipeline).

The test change is just a verbiage modification for Sandbox
environments; otherwise, this does not have any significant changes on
the output of the application, either via CLI or synthesized output.
