### PR TITLE
Support building permission sets without permissions boundary

### DIFF
--- a/cfn-templates/sso-permission-sets.cf.yaml
+++ b/cfn-templates/sso-permission-sets.cf.yaml
@@ -10,9 +10,12 @@ Parameters:
   CentralAccountRolePermissionsBoundary:
     Description: >-
       The name of the permissions boundary in the ATAT central account that must be
-      applied to roles. This must be the role NAME not the role ARN.
+      applied to roles. This must be the role NAME not the role ARN. If your account
+      does not require a permissions boundary, use the value "!".
     Type: String
-    Default: "GovCloudAdminRoleBoundary"
+
+Conditions:
+  HasPermissionsBoundary: !Equals [!Ref CentralAccountRolePermissionsBoundary, "!"]
 
 Resources:
   # Only Administrators and Auditors should have access to the the Central account. There
@@ -29,9 +32,11 @@ Resources:
       ManagedPolicies:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AdministratorAccess"
       SessionDuration: PT1H
-      PermissionsBoundary:
-        CustomerManagedPolicyReference:
-          Name: !Ref CentralAccountRolePermissionsBoundary
+      PermissionsBoundary: !If
+        - HasPermissionsBoundary
+        - CustomerManagedPolicyReference:
+            Name: !Ref CentralAccountRolePermissionsBoundary
+        - !Ref AWS::NoValue
   CentralAccountAuditorAccess:
     Type: AWS::SSO::PermissionSet
     Properties:
@@ -46,9 +51,11 @@ Resources:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AWSSSOReadOnly"
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AWSSSODirectoryReadOnly"
       SessionDuration: PT1H
-      PermissionsBoundary:
-        CustomerManagedPolicyReference:
-          Name: !Ref CentralAccountRolePermissionsBoundary
+      PermissionsBoundary: !If
+        - HasPermissionsBoundary
+        - CustomerManagedPolicyReference:
+            Name: !Ref CentralAccountRolePermissionsBoundary
+        - !Ref AWS::NoValue
 
   AtatAdministratorAccess:
     Type: AWS::SSO::PermissionSet


### PR DESCRIPTION
Not all AWS accounts will necessarily have a permissions boundary. We
need to support building our permission sets in such an environment. We
can do this by conditionally providing that attribute.

To avoid awkward issues with potential default values etc, we use the
value "!" as the "policy name" that causes us to ignore applying the
permissions set. We use "!" because it is not valid in a policy name and
because passing the empty string is awkward in the CloudFormation
console and CLI.

This also turns `CentralAccountRolePermissionsBoundary` into a required
parameter instead of an optional parameter with a default value; this is
likely the better long-term decision anyway.
