### PR TITLE
Update Provisioning schema and models

### DIFF
--- a/api/cost/cost-request-fn.test.ts
+++ b/api/cost/cost-request-fn.test.ts
@@ -45,7 +45,7 @@ describe("Cost Request Fn - Success", () => {
       {
         ...validCostRequest,
         requestId: "7w1er266-4a04-47ec-a3c9-6775f2a82d28",
-        targetCsp: constructCspTarget("CSP_A", "NETWORK_1"),
+        targetCsp: constructCspTarget("CSP_A"),
       },
     ];
     const queueEvent = generateTestSQSEvent(validMessages);
@@ -92,7 +92,7 @@ describe("Cost Request Fn - Errors", () => {
     const invalidCostRequest: CostRequest = {
       ...validCostRequest,
       portfolioId: "",
-      targetCsp: constructCspTarget("CSP_B", "Network_2"),
+      targetCsp: constructCspTarget("CSP_B"),
     };
     const errorMessages = [invalidCostRequest];
     const queueEvent = generateTestSQSEvent(errorMessages);

--- a/api/provision/async-provisioning-check.test.ts
+++ b/api/provision/async-provisioning-check.test.ts
@@ -21,12 +21,12 @@ describe("Async Provisioning Checker - Success", () => {
   it("poll messages from AsyncProvisioningQueue and send completed jobs to ProvisioningQueue", async () => {
     const cspB = {
       name: "CSP_B",
-      uri: "https://cspB.example.com",
+      uri: "https://cspB.example.com/v1/",
       network: "NETWORK_1",
     };
     const cspC = {
       name: "CSP_C",
-      uri: "https://cspC.example.com",
+      uri: "https://cspC.example.com/v1/",
       network: "NETWORK_2",
     };
 

--- a/api/provision/csp-write-portfolio.test.ts
+++ b/api/provision/csp-write-portfolio.test.ts
@@ -68,7 +68,7 @@ describe("Successful invocation of mock CSP function", () => {
       content: {
         request: createdRequest,
         response: {
-          location: request.targetCsp.uri,
+          location: "https://cspB.example.com/v1/",
           status: {
             status: ProvisioningStatusType.COMPLETE,
             portfolioId: request.portfolioId,
@@ -149,7 +149,7 @@ describe("Failed invocation operations", () => {
       code: 400,
       content: {
         response: {
-          location: request.targetCsp.uri,
+          location: "https://cspC.example.com/v1/",
           status: {
             status: ProvisioningStatusType.FAILED,
             portfolioId: request.portfolioId,
@@ -196,7 +196,7 @@ describe("Failed invocation operations", () => {
       code: 202,
       content: {
         response: {
-          location: request.targetCsp.uri,
+          location: "https://cspF.example.com/v1/",
           status: {
             status: ProvisioningStatusType.IN_PROGRESS,
             portfolioId: request.portfolioId,
@@ -219,7 +219,7 @@ describe("Failed invocation operations", () => {
       csp: "response",
     };
     mockedGetToken.mockResolvedValueOnce({ access_token: "FakeToken", expires_in: 0, token_type: "Bearer" });
-    mockedConfig.mockResolvedValueOnce({ uri: cspA.uri });
+    mockedConfig.mockResolvedValueOnce({ uri: "https://cspA.example.com/v1/" });
     // mockedAxios.post.mockResolvedValueOnce({
     //   data: expectedResponse,
     //   status: 400,
@@ -281,7 +281,6 @@ export function constructProvisionRequestForCsp(csp: string): ProvisionRequest {
   const body = {
     ...provisioningBodyWithPayload,
     targetCsp: {
-      ...cspA,
       name: csp,
     },
   };

--- a/api/util/common-test-fixtures.ts
+++ b/api/util/common-test-fixtures.ts
@@ -28,15 +28,11 @@ export const operators = [
 ];
 export const cspA = {
   name: "CSP_A",
-  uri: "https://cspa.example.com/api/atat",
-  network: "NETWORK_1",
 };
 
-export function constructCspTarget(csp: string, network: string) {
+export function constructCspTarget(csp: string) {
   return {
     name: csp,
-    uri: `https://${csp.toLocaleLowerCase()}.example/com/api/atat`,
-    network,
   };
 }
 

--- a/api/util/csp-request.ts
+++ b/api/util/csp-request.ts
@@ -27,7 +27,7 @@ export function mockCspClientResponse(request: any) {
       return response;
     case "CSP_B":
       response = {
-        location: request.targetCsp.uri,
+        location: "https://cspB.example.com/v1/",
         status: {
           status: ProvisioningStatusType.COMPLETE,
           portfolioId: request.portfolioId,
@@ -42,7 +42,7 @@ export function mockCspClientResponse(request: any) {
       return response;
     case "CSP_C":
       response = {
-        location: request.targetCsp.uri,
+        location: "https://cspC.example.com/v1/",
         status: {
           status: ProvisioningStatusType.FAILED,
           portfolioId: request.portfolioId,
@@ -77,7 +77,7 @@ export function mockCspClientResponse(request: any) {
       return response;
     case "CSP_F":
       response = {
-        location: request.targetCsp.uri,
+        location: "https://cspF.example.com/v1/",
         status: {
           status: ProvisioningStatusType.IN_PROGRESS,
           portfolioId: request.portfolioId,

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -194,7 +194,6 @@ components:
       required:
         - job_id
         - user_id
-        - portfolio_id
         - operation_type
         - target_csp
         - payload

--- a/models/provisioning-jobs.ts
+++ b/models/provisioning-jobs.ts
@@ -49,7 +49,7 @@ export type ProvisionCspResponse =
 export interface ProvisionRequest {
   jobId: string;
   userId: string;
-  portfolioId: string;
+  portfolioId?: string;
   operationType: ProvisionRequestType;
   targetCsp: CloudServiceProvider;
   payload: NewPortfolioPayload | FundingSourcePayload | OperatorPayload;
@@ -116,7 +116,7 @@ export const provisionRequestSchema = {
       minProperties: 1,
     },
   },
-  required: ["jobId", "userId", "portfolioId", "operationType", "targetCsp", "payload"],
+  required: ["jobId", "userId", "operationType", "targetCsp", "payload"],
   additionalProperties: false,
 };
 


### PR DESCRIPTION
Make `portfolioId` optional in the `ProvisioningRequest` for the provisioning schemas and models.
Update `cspMockResponse` to hardcode `location`.
- Removed `uri` and `network` in unit test
- Update unit tests