### PR TITLE
Update `result-fn` state inputs

### DIFF
--- a/api/provision/async-provisioning-check.test.ts
+++ b/api/provision/async-provisioning-check.test.ts
@@ -5,6 +5,8 @@ import { sqsClient } from "../../utils/aws-sdk/sqs";
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { ProvisioningStatusType } from "../client";
 import { generateMockMessageResponses, generateTestSQSEvent } from "../util/common-test-fixtures";
+import * as client from "../client";
+import * as types from "../client/types";
 import * as atatClientHelper from "../../utils/atat-client";
 
 // Mocks
@@ -133,6 +135,67 @@ describe("Async Provisioning Checker - Success", () => {
     // THEN
     expect(commandCalls.length).toEqual(0); // only one request, still in progress
     expect(response.batchItemFailures.length).toEqual(1);
+  });
+  it("Use atat-client (mocking) to make request to a real CSP - FAILED", async () => {
+    const cspMock = {
+      name: "CSP_Mock",
+      uri: "https://realCsp.example.com/v1/",
+    };
+    const failedMessage = {
+      code: 400,
+      content: {
+        response: {
+          location: cspMock.uri,
+          status: {
+            status: ProvisioningStatusType.FAILED,
+            provisioningJobId: "",
+            portfolioId: "",
+          },
+          $metadata: {
+            status: 400,
+            request: {
+              targetCsp: { name: cspMock.name },
+            },
+            response: {},
+          },
+        },
+        request: {
+          location: cspMock.uri,
+        },
+      },
+      targetCsp: { name: cspMock.name },
+    };
+
+    // GIVEN
+    const messages = [failedMessage];
+    const queueEvent = generateTestSQSEvent(messages);
+    const mockResponse = generateMockMessageResponses(messages);
+    sqsMock.on(SendMessageCommand).resolves(mockResponse);
+    jest
+      .spyOn(client.AtatClient.prototype, "getProvisioningStatus")
+      .mockImplementation((): Promise<types.GetProvisioningStatusResponse> => {
+        return Promise.resolve({
+          status: {
+            provisioningJobId: "",
+            portfolioId: "",
+            status: ProvisioningStatusType.FAILED,
+          },
+          location: cspMock.uri,
+          $metadata: failedMessage.content.response.$metadata,
+        });
+      });
+    mockedMakeClient.mockResolvedValue(new client.AtatClient("SAMPLE", { uri: "http://fake.example.com" }));
+
+    // WHEN
+    await handler(queueEvent, {} as Context);
+    const commandCalls = sqsMock.commandCalls(SendMessageCommand);
+    const firstSentMessage: any = commandCalls[0].firstArg.input;
+
+    // THEN
+    expect(commandCalls).toBeTruthy();
+    expect(commandCalls.length).toEqual(1);
+    expect(JSON.parse(firstSentMessage.MessageBody)).toEqual(messages[0]);
+    expect(firstSentMessage.MessageGroupId).toEqual(MESSAGE_GROUP_ID);
   });
   it("no records to process", async () => {
     // GIVEN

--- a/api/provision/async-provisioning-check.ts
+++ b/api/provision/async-provisioning-check.ts
@@ -75,7 +75,7 @@ async function makeRequest(
 async function baseHandler(event: SQSEvent): Promise<SQSBatchResponse> {
   // The item IDs for records that are still in the IN_PROGRESS or NOT_STARTED state
   const stillInProgress: string[] = [];
-  // Items that have moved to the COMPELTE or FAILED state
+  // Items that have moved to the COMPLETE or FAILED state
   const moveToReady: ProvisionCspResponse[] = [];
   if (!event?.Records?.length) {
     logger.info("There are no records in this request.");

--- a/api/provision/async-provisioning-check.ts
+++ b/api/provision/async-provisioning-check.ts
@@ -82,11 +82,10 @@ async function baseHandler(event: SQSEvent): Promise<SQSBatchResponse> {
   }
   for (const record of event.Records) {
     const request = JSON.parse(record.body) as ProvisionCspResponse;
-    let cspName = "";
-    if (request.targetCsp) {
-      cspName = request.targetCsp.name;
+    if (!request.targetCsp) {
+      throw new Error(`No target CSP provided for Async request`);
     }
-    const client = await makeClient(cspName);
+    const client = await makeClient(request.targetCsp.name);
     const provisioningStatus = await makeRequest(client, request);
     if (provisioningStatus) {
       moveToReady.push(provisioningStatus);

--- a/api/provision/csp-write-portfolio.ts
+++ b/api/provision/csp-write-portfolio.ts
@@ -85,7 +85,7 @@ async function makeRequest(client: IAtatClient, request: ProvisionRequest): Prom
       return transformSynchronousResponse(response, creationRequest);
     }
 
-    logger.info("Should not reach here at the current moment because of mocking.");
+    logger.info("Making an actual CSP request w/ atat-client - CspWritePortfolio");
     const cspResponse = await client.addPortfolio(creationRequest);
     if (cspResponse.$metadata.status === 202) {
       const asyncResponse = cspResponse as atatApiTypes.AddPortfolioResponseAsync;

--- a/api/util/csp-request.ts
+++ b/api/util/csp-request.ts
@@ -1,3 +1,4 @@
+import { CloudServiceProvider } from "../../models/cloud-service-providers";
 import { logger } from "../../utils/logging";
 import { ProvisioningStatusType } from "../client";
 export interface CspResponse<Req, Resp> {
@@ -6,6 +7,7 @@ export interface CspResponse<Req, Resp> {
     request: Req;
     response: Resp;
   };
+  targetCsp?: CloudServiceProvider;
 }
 
 // This is merely a stop gap to provide mock responses

--- a/models/provisioning-jobs.ts
+++ b/models/provisioning-jobs.ts
@@ -134,6 +134,12 @@ export const provisionResponseSchema = {
       },
       required: ["request", "response"],
     },
+    targetCsp: {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+    },
   },
   required: ["code", "content"],
   additionalProperties: false,

--- a/utils/middleware/error-handling-middleware.ts
+++ b/utils/middleware/error-handling-middleware.ts
@@ -34,6 +34,7 @@ export const errorHandlingMiddleware = (): middy.MiddlewareObj<MiddlewareInputs,
 
     switch (errorMessage) {
       case "CSP portfolio ID required.":
+      case "No target CSP provided for Async request":
         request.response = new ValidationErrorResponse("Request failed validation", {
           issue: errorMessage,
           name: error.name,


### PR DESCRIPTION
This addresses the error caused by the `targetCsp` not being available
in the `async-provisioning-check` fn to create an `atat-client` which more
than likely happened due to refactoring the `ProvisioningRequest` schema 
in https://github.com/dod-ccpo/atat-web-api/pull/1185/commits/819fdb86636796bcc0bb63532793cfe133bdaf3d#top .

As a result the `targetCsp` from the original SFN input is not available 
in messages sent to the async provisioning queue. An update to the SFN workflow 
now passes the `targetCsp` into the `result-fn` state input, which allows
the `async-provisioning-check` fn to create an `atat-client` when messages
are polled and and the `atat-client` makes a request to the target CSP.

The `targetCsp` is made optional because some functions already have
access to the `targetCsp` for provisioning and costs jobs and is
not necessarily required.
