### PR TITLE
Update async provisioning check fn mocking logic

### DIFF
--- a/api/provision/async-provisioning-check.ts
+++ b/api/provision/async-provisioning-check.ts
@@ -35,7 +35,7 @@ async function makeRequest(
     location: origResponse.location,
   };
   const mockCspNames = ["CSP_B", "CSP_C", "CSP_F"];
-  if (mockCspNames.includes(origResponse.$metadata.request.targetCsp.name)) {
+  if (request.targetCsp && mockCspNames.includes(request.targetCsp.name)) {
     const cspMockResponse = mockCspClientResponse(origResponse.$metadata.request);
     const mockResponse = {
       code: request.code,


### PR DESCRIPTION
Fix bug that accounts for a mock message being sent to `async provisioning check` fn.
Appears similar to the last bug due to the `name property on undefined` but this is 
happens inside the `makeRequest()` when mocking CSPs.