### PR TITLE
Refactor SFN task inputs

### DIFF
--- a/api/provision/async-provisioning-check.test.ts
+++ b/api/provision/async-provisioning-check.test.ts
@@ -9,6 +9,7 @@ import * as client from "../client";
 import * as types from "../client/types";
 import * as atatClientHelper from "../../utils/atat-client";
 import { ErrorStatusCode, ValidationErrorResponse } from "../../utils/response";
+import { constructProvisionRequestForCsp } from "./csp-write-portfolio.test";
 
 // Mocks
 jest.mock("../../utils/atat-client");
@@ -54,7 +55,7 @@ describe("Async Provisioning Checker - Success", () => {
             location: cspB.uri,
           },
         },
-        targetCsp: cspB,
+        initialSnowRequest: constructProvisionRequestForCsp("CSP_B"),
       },
       {
         code: 400,
@@ -75,7 +76,7 @@ describe("Async Provisioning Checker - Success", () => {
             location: cspC.uri,
           },
         },
-        targetCsp: cspC,
+        initialSnowRequest: constructProvisionRequestForCsp("CSP_C"),
       },
     ];
     const queueEvent = generateTestSQSEvent(messages);
@@ -125,7 +126,7 @@ describe("Async Provisioning Checker - Success", () => {
             location: cspF.uri,
           },
         },
-        targetCsp: cspF,
+        initialSnowRequest: constructProvisionRequestForCsp("CSP_F"),
       },
     ];
     const queueEvent = generateTestSQSEvent(messages);
@@ -167,7 +168,7 @@ describe("Async Provisioning Checker - Success", () => {
           location: cspMock.uri,
         },
       },
-      targetCsp: { name: cspMock.name },
+      initialSnowRequest: constructProvisionRequestForCsp("CSP_Mock"),
     };
 
     // GIVEN
@@ -216,7 +217,7 @@ describe("Async Provisioning Checker - Success", () => {
 });
 
 describe("Async Provisioning Checker - Errors", () => {
-  it("No target CSP provided", async () => {
+  it("No initial SNOW request provided", async () => {
     // GIVEN
     const messages = [
       {
@@ -225,7 +226,7 @@ describe("Async Provisioning Checker - Errors", () => {
           response: {},
           request: {},
         },
-        // targetCsp: {},
+        // initialSnowRequest: {},
       },
     ];
     const queueEvent = generateTestSQSEvent(messages);

--- a/api/provision/async-provisioning-check.ts
+++ b/api/provision/async-provisioning-check.ts
@@ -35,7 +35,7 @@ async function makeRequest(
     location: origResponse.location,
   };
   const mockCspNames = ["CSP_B", "CSP_C", "CSP_F"];
-  if (request.targetCsp && mockCspNames.includes(request.targetCsp.name)) {
+  if (request.initialSnowRequest && mockCspNames.includes(request.initialSnowRequest.targetCsp.name)) {
     const cspMockResponse = mockCspClientResponse(origResponse.$metadata.request);
     const mockResponse = {
       code: request.code,
@@ -43,7 +43,7 @@ async function makeRequest(
         request: requestBody,
         response: cspMockResponse,
       },
-      targetCsp: request.targetCsp,
+      initialSnowRequest: request.initialSnowRequest,
     };
     if (
       cspMockResponse.status.status === ProvisioningStatusType.COMPLETE ||
@@ -66,7 +66,7 @@ async function makeRequest(
         request: requestBody,
         response: cspResponse,
       },
-      targetCsp: request.targetCsp,
+      initialSnowRequest: request.initialSnowRequest,
     };
   }
   return undefined;
@@ -82,10 +82,10 @@ async function baseHandler(event: SQSEvent): Promise<SQSBatchResponse> {
   }
   for (const record of event.Records) {
     const request = JSON.parse(record.body) as ProvisionCspResponse;
-    if (!request.targetCsp) {
-      throw new Error(`No target CSP provided for Async request`);
+    if (!request.initialSnowRequest) {
+      throw new Error("No initial ServiceNow Request provided for Async request");
     }
-    const client = await makeClient(request.targetCsp.name);
+    const client = await makeClient(request.initialSnowRequest.targetCsp.name);
     const provisioningStatus = await makeRequest(client, request);
     if (provisioningStatus) {
       moveToReady.push(provisioningStatus);

--- a/api/provision/start-provisioning-job.ts
+++ b/api/provision/start-provisioning-job.ts
@@ -34,7 +34,7 @@ export async function baseHandler(event: RequestEvent<ProvisionRequest>): Promis
       ...event.body,
     };
     await sfnClient.startExecution({
-      input: JSON.stringify(sfnInput),
+      input: JSON.stringify({ initialSnowRequest: sfnInput }),
       stateMachineArn: SFN_ARN,
     });
 

--- a/api/util/csp-request.ts
+++ b/api/util/csp-request.ts
@@ -1,4 +1,4 @@
-import { CloudServiceProvider } from "../../models/cloud-service-providers";
+import { ProvisionRequest } from "../../models/provisioning-jobs";
 import { logger } from "../../utils/logging";
 import { ProvisioningStatusType } from "../client";
 export interface CspResponse<Req, Resp> {
@@ -7,7 +7,7 @@ export interface CspResponse<Req, Resp> {
     request: Req;
     response: Resp;
   };
-  targetCsp?: CloudServiceProvider;
+  initialSnowRequest?: ProvisionRequest;
 }
 
 // This is merely a stop gap to provide mock responses

--- a/lib/constructs/provisioning-sfn-workflow.ts
+++ b/lib/constructs/provisioning-sfn-workflow.ts
@@ -125,7 +125,7 @@ export class ProvisioningWorkflow extends Construct implements IProvisioningWork
         id: "InvokeCspApi",
         props: {
           lambdaFunction: cspWritePortfolioFn,
-          inputPath: "$",
+          inputPath: "$.initialSnowRequest",
           resultSelector: {
             code: sfn.JsonPath.objectAt("$.Payload.code"),
             content: sfn.JsonPath.objectAt("$.Payload.content"),
@@ -141,7 +141,7 @@ export class ProvisioningWorkflow extends Construct implements IProvisioningWork
           payload: sfn.TaskInput.fromObject({
             code: sfn.JsonPath.objectAt("$.cspResponse.code"),
             content: sfn.JsonPath.objectAt("$.cspResponse.content"),
-            targetCsp: sfn.JsonPath.objectAt("$.targetCsp"),
+            initialSnowRequest: sfn.JsonPath.objectAt("$.initialSnowRequest"),
           }),
           resultPath: "$.enqueueResultResponse",
           outputPath: "$",

--- a/models/provisioning-jobs.ts
+++ b/models/provisioning-jobs.ts
@@ -134,12 +134,7 @@ export const provisionResponseSchema = {
       },
       required: ["request", "response"],
     },
-    targetCsp: {
-      type: "object",
-      properties: {
-        name: { type: "string" },
-      },
-    },
+    initialSnowRequest: provisionRequestSchema,
   },
   required: ["code", "content"],
   additionalProperties: false,

--- a/utils/middleware/error-handling-middleware.ts
+++ b/utils/middleware/error-handling-middleware.ts
@@ -34,7 +34,7 @@ export const errorHandlingMiddleware = (): middy.MiddlewareObj<MiddlewareInputs,
 
     switch (errorMessage) {
       case "CSP portfolio ID required.":
-      case "No target CSP provided for Async request":
+      case "No initial ServiceNow Request provided for Async request":
         request.response = new ValidationErrorResponse("Request failed validation", {
           issue: errorMessage,
           name: error.name,


### PR DESCRIPTION
Create an `initialSnowRequest` property and pass along to the async provisioning queue.
All initial properties from the SNOW request are available for use such as `targetCsp` and
the `jobId`.
- Refactor SFN initial input
- Update the `async-provisioning-check` fn
