### PR TITLE
Add ELB Access Logs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -173,7 +173,7 @@
         "filename": "lib/atat-web-api-stack.ts",
         "hashed_secret": "e2c872ec4dc5d6d2ca8f1f22852b4670d039470a",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 163
       }
     ],
     "lib/constructs/api-user.test.ts": [
@@ -186,5 +186,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-30T04:06:09Z"
+  "generated_at": "2022-12-17T00:06:44Z"
 }

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -14,6 +14,7 @@ export function createApp(props?: cdk.AppProps): cdk.App {
   const vpcCidrParam = AtatContextValue.VPC_CIDR.resolve(app);
   const apiDomainParam = AtatContextValue.API_DOMAIN_NAME.resolve(app);
   const apiCertParam = AtatContextValue.API_CERTIFICATE_ARN.resolve(app);
+  const deployRegion = AtatContextValue.DEPLOY_REGION.resolve(app);
 
   if (!utils.isString(environmentParam)) {
     const err = `An EnvironmentId must be provided (use the ${AtatContextValue.ENVIRONMENT_ID} context key)`;
@@ -60,6 +61,9 @@ export function createApp(props?: cdk.AppProps): cdk.App {
       environmentName,
       isSandbox,
       apiDomain: apiCertOptions,
+      env: {
+        region: deployRegion,
+      },
     });
     cdk.Aspects.of(app).add(new RemovalPolicySetter({ globalRemovalPolicy: cdk.RemovalPolicy.DESTROY }));
     cdk.Aspects.of(app).add(new GovCloudCompatibilityAspect());
@@ -90,6 +94,9 @@ export function createApp(props?: cdk.AppProps): cdk.App {
       // Set the notification email address, unless we're building the account where
       // sandbox environments live because our inboxes would never recover.
       notificationEmail: environmentName === "Sandbox" ? undefined : AtatContextValue.NOTIFICATION_EMAIL.resolve(app),
+      env: {
+        region: deployRegion,
+      },
     });
   }
   return app;

--- a/lib/atat-monitoring-stack.ts
+++ b/lib/atat-monitoring-stack.ts
@@ -35,6 +35,11 @@ export class AtatMonitoringStack extends cdk.Stack {
           // our secrets.
           enabled: false,
         },
+        ec2: {
+          // We do not use any of the support EC2 resources in our stacks, and this results
+          // in odd synthesis warnings.
+          enabled: false,
+        },
       })
     );
   }

--- a/lib/atat-net-stack.ts
+++ b/lib/atat-net-stack.ts
@@ -37,7 +37,7 @@ export class AtatNetStack extends cdk.Stack {
     this.templateOptions.description = "Creates the necessary networking infrastructure for the ATAT application";
 
     const vpc = new ec2.Vpc(this, "AtatVpc", {
-      cidr: props.vpcCidr,
+      ipAddresses: props.vpcCidr ? ec2.IpAddresses.cidr(props.vpcCidr) : undefined,
       maxAzs: 2,
       subnetConfiguration: [
         {

--- a/lib/atat-pipeline-stack.ts
+++ b/lib/atat-pipeline-stack.ts
@@ -86,6 +86,10 @@ export class AtatPipelineStack extends cdk.Stack {
         environmentName: props.environmentName,
         notificationEmail: props.notificationEmail,
         apiDomain: props.apiDomain,
+        env: {
+          region: this.region,
+          account: this.account,
+        },
       })
     );
   }

--- a/lib/context-values.ts
+++ b/lib/context-values.ts
@@ -110,6 +110,15 @@ export class AtatContextValue {
     "config/csp/integration"
   );
 
+  /**
+   * The region where the stack will be deployed to.
+   *
+   * The resulting stack will only work in this region. Orginally, this was added to support
+   * ELB log delivery; however, once added other parts of the code base may adapt to this no
+   * longer being an unresolved value.
+   */
+  public static readonly DEPLOY_REGION = new AtatContextValue("atat:DeployRegion", "us-gov-west-1");
+
   // This eslint-disable is required as it picks up on the constructor shorthand as a
   // "useless" constructor which is not a correct determination.
   // eslint-disable-next-line no-useless-constructor


### PR DESCRIPTION
These logs will be helpful from a troubleshooting perspective as well as
required for compliance and security reasons. Enabling them requires
specifying the region on the stack. This is really unfortunate because
it means that our template isn't 100% portable anymore (as in, an
already-built template can no longer be run in any region; though, we
can still build a template that works in any region). The change is a
bit unfortunate as it requires _all_ synthesis to take place with the
`AWS_PROFILE` environment variable set where it points to the desired
target account/region.
