### PR TITLE
Add a custom resource to remove all rules from the VPC default SG

### DIFF
--- a/lib/constructs/vpc-default-sg-rule-remove.ts
+++ b/lib/constructs/vpc-default-sg-rule-remove.ts
@@ -1,0 +1,80 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as nodejs from "aws-cdk-lib/aws-lambda-nodejs";
+import * as cr from "aws-cdk-lib/custom-resources";
+import { Construct } from "constructs";
+
+export interface VpcDefaultSecurityGroupRuleRemoverProps {
+  /**
+   * The VPC that should have is default SG rules removed, as well as where
+   * the backing custom resource should be deployed.
+   */
+  // This has to accept the concrete class because we need the VPC and
+  // attributes only available on the concrete class.
+  readonly vpc: ec2.Vpc;
+}
+
+/**
+ * A Construct for removing all rules from a given VPC's default Security Group.
+ *
+ * This may be necessary in some environments to meet compliance requirements. All the
+ * rules on the VPC's default Security Group will be deleted (Ingress and Egress). Therefore,
+ * any ENI in this Security Group will not be able to send or receive traffic unless granted
+ * by another Security Group.
+ *
+ * Constructs that add rules to the VPC's default Security Group should depend on this if
+ * those rules should be kept; otherwise, this should depend on any constructs that create
+ * rules on the default Security Group that should be deleted.
+ *
+ * This is implemented as a custom resource in a VPC. It will need network access to make
+ * EC2 and S3 API calls, as well as possibly CloudFormation.
+ */
+export class VpcDefaultSecurityGroupRuleRemover extends Construct {
+  constructor(scope: Construct, id: string, props: VpcDefaultSecurityGroupRuleRemoverProps) {
+    super(scope, id);
+
+    const handler = new nodejs.NodejsFunction(this, "VpcSgRuleRemovalHandler", {
+      runtime: lambda.Runtime.NODEJS_16_X,
+      entry: "lib/custom-resources/delete-default-sg-rules.ts",
+      handler: "onEvent",
+      vpc: props.vpc,
+      initialPolicy: [
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ["ec2:DescribeSecurityGroupRules"],
+          // Describe has to be allowed on all VPCs in order to perform the filter
+          resources: ["*"],
+        }),
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ["ec2:RevokeSecurityGroupIngress", "ec2:RevokeSecurityGroupEgress"],
+          // Only allow changing rules on the default security group
+          resources: [
+            cdk.Stack.of(this).formatArn({
+              service: "ec2",
+              resource: "security-group",
+              resourceName: props.vpc.vpcDefaultSecurityGroup,
+              arnFormat: cdk.ArnFormat.SLASH_RESOURCE_NAME,
+            }),
+          ],
+        }),
+      ],
+      tracing: lambda.Tracing.ACTIVE,
+    });
+    const vpcEndpointIpProvider = new cr.Provider(this, "VpcSgRuleRemovalProvider", {
+      onEventHandler: handler,
+      vpc: props.vpc,
+    });
+    const customResource = new cdk.CustomResource(this, "VpcSgRuleRemoval", {
+      serviceToken: vpcEndpointIpProvider.serviceToken,
+      properties: {
+        // Do not pass any other Security Group here. The underlying handler will
+        // actually happily delete rules from any Security Group and this construct
+        // is the only thing that safely applies this to only the default Security Group.
+        DefaultSecurityGroupId: props.vpc.vpcDefaultSecurityGroup,
+      },
+    });
+  }
+}

--- a/lib/custom-resources/delete-default-sg-rules.ts
+++ b/lib/custom-resources/delete-default-sg-rules.ts
@@ -1,0 +1,88 @@
+import { EC2, SecurityGroupRule } from "@aws-sdk/client-ec2";
+import type { OnEventRequest, OnEventResponse } from "aws-cdk-lib/custom-resources/lib/provider-framework/types";
+
+const ec2 = new EC2({ useFipsEndpoint: true });
+
+/**
+ * Handle CloudFormation Custom Resource events using the CDK Custom Resource Provider Framework.
+ *
+ * This will delete all Security Group Rules (Ingress and Egress) on the given Security
+ * Group. This is done by querying the list of rules and then performing the delete because
+ * there is no atomic operation for this.
+ *
+ * This _does not_ restore rules on a "Delete" or "Update" event. Any rules deleted during
+ * a "Create" event are deleted forever unless manually recreated.
+ */
+export async function onEvent(event: OnEventRequest): Promise<OnEventResponse> {
+  // There is no data to provide on a Delete operation and no resources were
+  // actually created so there's nothing for us to actually destroy. The associated
+  // VPC is likely about to be deleted. We _could_ try and add the rules back but
+  // that is a lot of complexity.
+  if (event.RequestType === "Delete") {
+    return {};
+  }
+  // Yikes hopefully this never happens! This means someone updated the ResourceProperties
+  // passed to this custom resource... which means we now apply to a new VPC. We should
+  // properly remove the rules but, as we did in Delete, we're going to ignore the old
+  // VPC and hope that it's just being deleted.
+  if (event.RequestType === "Update") {
+    console.log("Applying remediation to a new VPC without restoring the old one");
+  }
+
+  const groupId = event.ResourceProperties.DefaultSecurityGroupId;
+  if (!groupId) {
+    throw new Error("DefaultSecurityGroupId property is required");
+  }
+  const securityGroupRules = await getExistingSecurityGroupRules(groupId);
+  await deleteAllIngressRules(groupId, securityGroupRules);
+  await deleteAllEgressRules(groupId, securityGroupRules);
+
+  return {
+    PhysicalResourceId: groupId,
+    Data: {
+      DeletedRules: securityGroupRules,
+    },
+  };
+}
+
+async function getExistingSecurityGroupRules(groupId: string): Promise<SecurityGroupRule[]> {
+  const result = await ec2.describeSecurityGroupRules({
+    Filters: [{ Name: "group-id", Values: [groupId] }],
+  });
+  if (result.SecurityGroupRules === undefined) {
+    throw new Error(`Unable to find SG with ID: ${groupId}`);
+  }
+  return result.SecurityGroupRules;
+}
+
+async function deleteSgRuleHelper(groupId: string, rules: SecurityGroupRule[], ruleType: "Egress" | "Ingress") {
+  const ids = rules
+    .filter((rule) => (ruleType === "Egress" ? !!rule.IsEgress : !rule.IsEgress))
+    .map((rule) => rule.SecurityGroupRuleId)
+    .filter((id): id is string => !!id);
+  if (!ids.length) {
+    console.log(`There are no Security Group ${ruleType} rules to delete`);
+    return [];
+  }
+
+  const command = {
+    GroupId: groupId,
+    SecurityGroupRuleIds: ids,
+  };
+
+  console.log(`Removing Security Group ${ruleType} rules: %j`, command);
+  switch (ruleType) {
+    case "Egress":
+      return ec2.revokeSecurityGroupEgress(command);
+    case "Ingress":
+      return ec2.revokeSecurityGroupIngress(command);
+  }
+}
+
+async function deleteAllIngressRules(groupId: string, rules: SecurityGroupRule[]) {
+  return deleteSgRuleHelper(groupId, rules, "Ingress");
+}
+
+async function deleteAllEgressRules(groupId: string, rules: SecurityGroupRule[]) {
+  return deleteSgRuleHelper(groupId, rules, "Egress");
+}


### PR DESCRIPTION
AWS' Best Practices for the CIS Benchmarks and for Foundational Best Practices recommend not having any rules that allow traffic in the Default Security Group for a VPC. This SG by default allows traffic within the SG and all egress traffic. We **do not** place any resources in the Security Group. Nonetheless, for some reason we are required to comply with the CIS rules 4.3 and 5.3 as well as EC2.2.

CloudFormation (and therefore the CDK) do not provide a native way to delete resources as part of resource definitions. So we have to write a custom resource to handle the deletions. This is a gross abuse of Custom Resources and perhaps a hook triggered on `AWS::EC2::VPC` creation would be better, but with this setup we can directly pass the attributes of the VPC to the custom resource to handle the rule deletion.

This deletes all rules from the passed security group with no regard for the content of the rule. REALLY DEFINITELY make sure you're passing in the default security group and don't get wild and start passing in other security groups. There is no obvious way to detect if a Security Group is the default so the best check would be description-based which is pretty weak. So instead, this just doesn't check.

At the same time some VPC endpoints are added that make this custom resource's job a little easier and they also check some other compliance boxes.

Tests are not written because this is a bunch of complicated API calls and custom resources that are not easily tested. We can improve testing of these resources at a later time.