### PR TITLE
Add enable call in addition to reset for EBS encryption

### DIFF
--- a/manual-steps/stig-remediation.ts
+++ b/manual-steps/stig-remediation.ts
@@ -54,8 +54,13 @@ function setIamPasswordPolicy() {
  * There shouldn't be any EBS volumes but if one happens to exist, it will
  * be encrypted using the default `aws/ebs` KMS key.
  */
-function setDefaultEbsEncryption() {
-  ec2.resetEbsDefaultKmsKeyId({});
+async function setDefaultEbsEncryption() {
+  // First reset to using the default KMS key ID
+  await ec2.resetEbsDefaultKmsKeyId({});
+  const enableResult = await ec2.enableEbsEncryptionByDefault({});
+  if (!enableResult.EbsEncryptionByDefault) {
+    throw new Error("EBS Encryption by Default is not enabled");
+  }
 }
 
 blockS3PublicAccess();


### PR DESCRIPTION
The call to actually enable the feature was missing, we only reset the
key. Now we reset the key to the default and then we enable the setting.
This ensures that the key is one that's available prior to enabling
during bootstrapping.
