### PR TITLE
Remove GT&C number from IFP document

### DIFF
--- a/document-generation/ifp-document.test.ts
+++ b/document-generation/ifp-document.test.ts
@@ -7,7 +7,7 @@ import { ApiBase64SuccessResponse, ErrorStatusCode, OtherErrorResponse } from ".
 import { generateIFPDocument } from "./ifp-document";
 
 describe("Generate an IFP binary document - happy path", () => {
-  const sampleIfpRequestWithGTCNumber = sampleIfpRequest.templatePayload as IncrementalFundingPlan;
+  const sampleIfpRequestWithOrderNumber = sampleIfpRequest.templatePayload as IncrementalFundingPlan;
   const sampleIfpRequestWithMIPRNumber = {
     ...sampleIfpRequest.templatePayload,
     fundingDocument: fundingDocumentWithMiprNumber,
@@ -19,7 +19,7 @@ describe("Generate an IFP binary document - happy path", () => {
     },
   } as IncrementalFundingPlan;
 
-  it.each([sampleIfpRequestWithGTCNumber, sampleIfpRequestWithMIPRNumber, sampleIfpRequestWithNoType])(
+  it.each([sampleIfpRequestWithOrderNumber, sampleIfpRequestWithMIPRNumber, sampleIfpRequestWithNoType])(
     "should return an ApiBase64Response",
     async (ifpPayload) => {
       // GIVEN

--- a/document-generation/utils/sampleTestData.ts
+++ b/document-generation/utils/sampleTestData.ts
@@ -330,7 +330,7 @@ export const sampleIfpRequest = {
     estimatedTaskOrderValue: 125000.55,
     initialAmount: 50000.55,
     remainingAmount: 75000,
-    fundingDocument: { fundingType: "FS_FORM", gtcNumber: "234234", orderNumber: "O-23434-34234" },
+    fundingDocument: { fundingType: "FS_FORM", orderNumber: "O-23434-34234" },
     fundingIncrements: [
       { amount: 25000, description: "2nd QTR FY23", order: 1 },
       { amount: 50000, description: "3rd QTR FY23", order: 2 },

--- a/document-generation/utils/utils.test.ts
+++ b/document-generation/utils/utils.test.ts
@@ -121,15 +121,13 @@ describe("getFundingDocInfo", () => {
     expect(fundingDocInfo).toEqual(`MIPR #: ${fundingDocument.miprNumber}`);
   });
   it("should return GT&C and Order number when FS_FORM document type", async () => {
-    const gtcNumber = "29348403";
     const orderNumber = "O-03049-2034-48403";
     const fundingDocument = {
       fundingType: FundingType.FS_FORM,
-      gtcNumber,
       orderNumber,
     } as IFundingDocument;
     const fundingDocInfo = getFundingDocInfo(fundingDocument);
-    expect(fundingDocInfo).toEqual(`GT&C #: ${gtcNumber} and Order #: ${orderNumber}`);
+    expect(fundingDocInfo).toEqual(`Order #: ${orderNumber}`);
   });
   it.each(["", null, undefined, {}])("should return an empty string when invalid inputs", async (type) => {
     const fundingDocument = {

--- a/document-generation/utils/utils.ts
+++ b/document-generation/utils/utils.ts
@@ -63,7 +63,7 @@ export const getFundingDocInfo = (fundingDoc: IFundingDocument): string => {
   if (fundingDoc.fundingType === FundingType.MIPR) {
     return `MIPR #: ${fundingDoc.miprNumber}`;
   }
-  return `GT&C #: ${fundingDoc.gtcNumber} and Order #: ${fundingDoc.orderNumber}`;
+  return `Order #: ${fundingDoc.orderNumber}`;
 };
 
 interface PDFTemplateFiles {


### PR DESCRIPTION
Remove GTC number. Only the Order number is needed for IFP document.
