### PR TITLE
Update optionOrder page calculation to reflect optionOrder changes

### DIFF
--- a/document-generation/igce-document.ts
+++ b/document-generation/igce-document.ts
@@ -95,14 +95,14 @@ export async function generateIGCEDocument(
     if (periodType === PeriodType.BASE) {
       periodSheetName = "Base Period";
     } else {
-      periodSheetName = `Option Period ${optionOrder}`;
+      periodSheetName = `Option Period ${optionOrder - 1}`;
     }
 
     // Get the specific worksheet
     const periodSheet =
       periodType === PeriodType.BASE
         ? workbook.getWorksheet("Base Period")
-        : workbook.getWorksheet(`Option Period ${optionOrder}`);
+        : workbook.getWorksheet(`Option Period ${optionOrder - 1}`);
 
     // Set Period of Performance and Funding Document Number
     // Located at the top of each Period Sheet


### PR DESCRIPTION
`optionOrder` used to start on 1 for Option Period 1, but due to `optionOrder` starting on 1 for Base Period instead of null, Option Period 1 had an `optionOrder` of 2. 

This fixes that issue.

Test it on the dev PDI with `ACQ0000230`, you will see that Option Period 1 is an empty page, and all option periods are shifted over:
![image](https://user-images.githubusercontent.com/84199040/212426108-df677663-63aa-49fd-94f2-91d864d99e8e.png)

Test it on the At838423WebApi sandbox endpoint and you will see Option Period 1 is in its proper location:
![image](https://user-images.githubusercontent.com/84199040/212426535-4f7ed849-4765-4d74-a277-c796307bf5c6.png)
