### PR TITLE
Increase State Machine timeout

### DIFF
--- a/lib/constructs/provisioning-sfn-workflow.ts
+++ b/lib/constructs/provisioning-sfn-workflow.ts
@@ -108,7 +108,7 @@ export class ProvisioningWorkflow extends Construct implements IProvisioningWork
       method: HttpMethod.GET,
       handlerPath: "api/provision/consume-provisioning-job.ts",
       functionPropsOverride: {
-        timeout: cdk.Duration.seconds(20),
+        timeout: cdk.Duration.minutes(1),
         environment: {
           PROVISIONING_QUEUE_URL: this.provisioningJobsQueue.queueUrl,
         },

--- a/lib/constructs/state-machine.ts
+++ b/lib/constructs/state-machine.ts
@@ -14,14 +14,14 @@ export interface StateMachineProps extends sfn.StateMachineProps {
 /**
  * Creates a State Machine in AWS Step Functions service
  * - uses a Standard State Machine Type (default)
- * - 180 seconds timeout (default)
+ * - 10 minutes timeout (default)
  */
 export class LoggingStandardStateMachine extends sfn.StateMachine {
   constructor(scope: Construct, id: string, props: StateMachineProps) {
     const { logGroup, ...otherProps } = props;
     super(scope, id, {
       // defaults that can be overridden
-      timeout: Duration.seconds(10),
+      timeout: Duration.minutes(10),
       stateMachineType: sfn.StateMachineType.STANDARD,
       // configuration passed in
       ...otherProps,


### PR DESCRIPTION
Increase state machine timeout from 10 seconds to 10 minutes.
Currently timing out when making a request to external CSP.

Additionally, increase `consume-provisioning-job` lambda timeout from 20 seconds to 1 minute.
