### PR TITLE
Increase SFN Task timeout

### DIFF
--- a/lib/constructs/api-sfn-function.ts
+++ b/lib/constructs/api-sfn-function.ts
@@ -62,7 +62,7 @@ export class ApiSfnFunction extends Construct {
       entry: props.handlerPath,
       runtime: lambda.Runtime.NODEJS_16_X,
       memorySize: 256,
-      timeout: Duration.seconds(5),
+      timeout: Duration.minutes(5),
       vpc: props.vpc,
       ...props.functionPropsOverride,
       tracing: lambda.Tracing.ACTIVE,

--- a/lib/constructs/sfn-lambda-invoke-task.ts
+++ b/lib/constructs/sfn-lambda-invoke-task.ts
@@ -21,7 +21,7 @@ export function mapTasks(scope: Construct, tasks: Array<TaskProps>): TasksMap {
     (mappedTasks, task) => ({
       ...mappedTasks,
       [task.id]: new sfnTasks.LambdaInvoke(scope, task.id, {
-        timeout: Duration.seconds(20),
+        timeout: Duration.minutes(6),
         ...task.props,
       }),
     }),


### PR DESCRIPTION
- Update tasks default timeout in the SFN to 6 minutes. This value
was selected since the longest lambda timeout in the SFN is 5
minutes and this ensures that the lambda timeout before the SFN.

- Update api-sfn-function to provide a lambda default of 5 minutes
rather than 5 seconds.
