### PR TITLE
Update puppeteer to v19.6.0

### DIFF
--- a/document-generation/chromium.ts
+++ b/document-generation/chromium.ts
@@ -9,7 +9,7 @@ export async function generateDocument(document: string): Promise<Buffer | undef
     browser = await launch({
       args: chromium.args,
       defaultViewport: chromium.defaultViewport,
-      executablePath: await chromium.executablePath,
+      executablePath: await chromium.executablePath(),
       headless: chromium.headless,
       ignoreHTTPSErrors: true,
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@middy/http-json-body-parser": "^3.6.2",
         "@middy/input-output-logger": "^3.6.2",
         "@middy/validator": "^3.6.2",
-        "@sparticuz/chromium": "^109.0.6",
+        "@sparticuz/chromium": "^110.0.0",
         "aws-cdk-lib": "2.61.1",
         "axios": "^1.2.4",
         "axios-mock-adapter": "^1.21.2",
@@ -37,7 +37,7 @@
         "juice": "^8.1.0",
         "lodash": "^4.17.21",
         "middy-middleware-json-error-handler": "^3.0.0",
-        "puppeteer-core": "^19.4.0",
+        "puppeteer-core": "^19.6.0",
         "source-map-support": "^0.5.21",
         "xss": "^1.0.14"
       },
@@ -3521,9 +3521,9 @@
       "dev": true
     },
     "node_modules/@sparticuz/chromium": {
-      "version": "109.0.6",
-      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-109.0.6.tgz",
-      "integrity": "sha512-9hTE03DXnrWTiGNpfjLfmGhIfmiVAerSPinDb+x5bBdM4KF4PMM1NZ0A+V7WKazoA+CasSX/osHK8K0MuO6uqg==",
+      "version": "110.0.0",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-110.0.0.tgz",
+      "integrity": "sha512-b4lVUnG+waiMzm/O5wO1RCnr/DV9Xn1Om4NujHsM0oy12KdQ7gfB/JyRDCYhlASrpyLYMA6F01t8/r+rLqIjkg==",
       "dependencies": {
         "tar-fs": "^2.1.1"
       },
@@ -13451,9 +13451,9 @@
       "dev": true
     },
     "@sparticuz/chromium": {
-      "version": "109.0.6",
-      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-109.0.6.tgz",
-      "integrity": "sha512-9hTE03DXnrWTiGNpfjLfmGhIfmiVAerSPinDb+x5bBdM4KF4PMM1NZ0A+V7WKazoA+CasSX/osHK8K0MuO6uqg==",
+      "version": "110.0.0",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-110.0.0.tgz",
+      "integrity": "sha512-b4lVUnG+waiMzm/O5wO1RCnr/DV9Xn1Om4NujHsM0oy12KdQ7gfB/JyRDCYhlASrpyLYMA6F01t8/r+rLqIjkg==",
       "requires": {
         "tar-fs": "^2.1.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@middy/http-json-body-parser": "^3.6.2",
         "@middy/input-output-logger": "^3.6.2",
         "@middy/validator": "^3.6.2",
-        "@sparticuz/chromium": "^108.0.1",
+        "@sparticuz/chromium": "^109.0.6",
         "aws-cdk-lib": "2.61.1",
         "axios": "^1.2.4",
         "axios-mock-adapter": "^1.21.2",
@@ -37,7 +37,7 @@
         "juice": "^8.1.0",
         "lodash": "^4.17.21",
         "middy-middleware-json-error-handler": "^3.0.0",
-        "puppeteer-core": "^19.2.2",
+        "puppeteer-core": "^19.4.0",
         "source-map-support": "^0.5.21",
         "xss": "^1.0.14"
       },
@@ -3521,14 +3521,14 @@
       "dev": true
     },
     "node_modules/@sparticuz/chromium": {
-      "version": "108.0.3",
-      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-108.0.3.tgz",
-      "integrity": "sha512-vMOWoGKb/zQZ83FoB8GUAx5LzofaeCp0qCSQDkuugx89/CFmgRlUBO3x1Kk/4jwVXeM055UaYvhboaohPpH9zA==",
+      "version": "109.0.6",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-109.0.6.tgz",
+      "integrity": "sha512-9hTE03DXnrWTiGNpfjLfmGhIfmiVAerSPinDb+x5bBdM4KF4PMM1NZ0A+V7WKazoA+CasSX/osHK8K0MuO6uqg==",
       "dependencies": {
         "tar-fs": "^2.1.1"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.18.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -13451,9 +13451,9 @@
       "dev": true
     },
     "@sparticuz/chromium": {
-      "version": "108.0.3",
-      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-108.0.3.tgz",
-      "integrity": "sha512-vMOWoGKb/zQZ83FoB8GUAx5LzofaeCp0qCSQDkuugx89/CFmgRlUBO3x1Kk/4jwVXeM055UaYvhboaohPpH9zA==",
+      "version": "109.0.6",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-109.0.6.tgz",
+      "integrity": "sha512-9hTE03DXnrWTiGNpfjLfmGhIfmiVAerSPinDb+x5bBdM4KF4PMM1NZ0A+V7WKazoA+CasSX/osHK8K0MuO6uqg==",
       "requires": {
         "tar-fs": "^2.1.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "juice": "^8.1.0",
         "lodash": "^4.17.21",
         "middy-middleware-json-error-handler": "^3.0.0",
-        "puppeteer-core": "^19.6.0",
+        "puppeteer-core": "^19.6.2",
         "source-map-support": "^0.5.21",
         "xss": "^1.0.14"
       },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@middy/http-json-body-parser": "^3.6.2",
     "@middy/input-output-logger": "^3.6.2",
     "@middy/validator": "^3.6.2",
-    "@sparticuz/chromium": "^108.0.1",
+    "@sparticuz/chromium": "^109.0.6",
     "aws-cdk-lib": "2.61.1",
     "axios": "^1.2.4",
     "axios-mock-adapter": "^1.21.2",
@@ -74,7 +74,7 @@
     "juice": "^8.1.0",
     "lodash": "^4.17.21",
     "middy-middleware-json-error-handler": "^3.0.0",
-    "puppeteer-core": "^19.2.2",
+    "puppeteer-core": "^19.4.0",
     "source-map-support": "^0.5.21",
     "xss": "^1.0.14"
   }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "juice": "^8.1.0",
     "lodash": "^4.17.21",
     "middy-middleware-json-error-handler": "^3.0.0",
-    "puppeteer-core": "^19.6.0",
+    "puppeteer-core": "^19.6.2",
     "source-map-support": "^0.5.21",
     "xss": "^1.0.14"
   }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@middy/http-json-body-parser": "^3.6.2",
     "@middy/input-output-logger": "^3.6.2",
     "@middy/validator": "^3.6.2",
-    "@sparticuz/chromium": "^109.0.6",
+    "@sparticuz/chromium": "^110.0.0",
     "aws-cdk-lib": "2.61.1",
     "axios": "^1.2.4",
     "axios-mock-adapter": "^1.21.2",
@@ -74,7 +74,7 @@
     "juice": "^8.1.0",
     "lodash": "^4.17.21",
     "middy-middleware-json-error-handler": "^3.0.0",
-    "puppeteer-core": "^19.4.0",
+    "puppeteer-core": "^19.6.0",
     "source-map-support": "^0.5.21",
     "xss": "^1.0.14"
   }


### PR DESCRIPTION
Update `puppeteer-core@19.6.0` and `@sparticuz/chromium@110`.
Document generation for PDFs is no longer being used at the moment, 
so we might want to consider if the puppeteer dependencies can be removed.