### PR TITLE
Add workaround for issues with stack updates

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -33,7 +33,7 @@
 
     "atat:CspConfigurationName": "config/csp/integration",
     "atat:GitHubPatName": "auth/github/pat",
-    "atat:VersionControlBranch": "feature/workaround-cdk-bug-cognito-client-secret",
+    "atat:VersionControlBranch": "develop",
     "atat:VersionControlRepo": "dod-ccpo/atat-web-api",
     "atat:NotificationEmail": "atat-dev+infrastructure-notif@ccpo.mil"
   }

--- a/cdk.json
+++ b/cdk.json
@@ -33,7 +33,7 @@
 
     "atat:CspConfigurationName": "config/csp/integration",
     "atat:GitHubPatName": "auth/github/pat",
-    "atat:VersionControlBranch": "develop",
+    "atat:VersionControlBranch": "feature/workaround-cdk-bug-cognito-client-secret",
     "atat:VersionControlRepo": "dod-ccpo/atat-web-api",
     "atat:NotificationEmail": "atat-dev+infrastructure-notif@ccpo.mil"
   }

--- a/lib/constructs/identity-provider.ts
+++ b/lib/constructs/identity-provider.ts
@@ -130,6 +130,7 @@ export class CognitoIdentityProviderClient extends Construct {
             UserPoolId: props.userPool.userPoolId,
             ClientId: this.userPoolClient.userPoolClientId,
           },
+          physicalResourceId: cr.PhysicalResourceId.of(this.userPoolClient.userPoolClientId),
         },
         onUpdate: {
           service: "CognitoIdentityServiceProvider",
@@ -138,6 +139,7 @@ export class CognitoIdentityProviderClient extends Construct {
             UserPoolId: props.userPool.userPoolId,
             ClientId: this.userPoolClient.userPoolClientId,
           },
+          physicalResourceId: cr.PhysicalResourceId.of(this.userPoolClient.userPoolClientId),
         },
         policy: cr.AwsCustomResourcePolicy.fromSdkCalls({ resources: [props.userPool.userPoolArn] }),
       }).getResponseField("UserPoolClient.ClientSecret")


### PR DESCRIPTION
It looks like the CDK may have introduced an issue with stack updates to
the `DescribeCognitoUserPoolClient`. There is a possible unmerged patch
upstream. To unblock updates, this adds a temporary workaround
(reimplemented the custom resource internally) until the fix (or an
alternative) is merged.
