### PR TITLE
Feature/vpcflowlogs creation update

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -33,7 +33,7 @@
 
     "atat:CspConfigurationName": "config/csp/integration",
     "atat:GitHubPatName": "auth/github/pat",
-    "atat:VersionControlBranch": "develop",
+    "atat:VersionControlBranch": "feature/vpcflowlogs-creation-update",
     "atat:VersionControlRepo": "dod-ccpo/atat-web-api",
     "atat:NotificationEmail": "atat-dev+infrastructure-notif@ccpo.mil"
   }

--- a/cdk.json
+++ b/cdk.json
@@ -33,7 +33,7 @@
 
     "atat:CspConfigurationName": "config/csp/integration",
     "atat:GitHubPatName": "auth/github/pat",
-    "atat:VersionControlBranch": "feature/vpcflowlogs-creation-update",
+    "atat:VersionControlBranch": "develop",
     "atat:VersionControlRepo": "dod-ccpo/atat-web-api",
     "atat:NotificationEmail": "atat-dev+infrastructure-notif@ccpo.mil"
   }

--- a/lib/atat-net-stack.ts
+++ b/lib/atat-net-stack.ts
@@ -57,11 +57,6 @@ export class AtatNetStack extends cdk.Stack {
       })
     );
 
-    const cwLogs = new logs.LogGroup(this, "LogGroup", {
-      logGroupName: "vpc-cssp-cwl-logs",
-      retention: logs.RetentionDays.INFINITE,
-    });
-
     // Capture all VPC flow logs and send to CloudWatch Logs with indefinite retention.
     // Flow log format made to meet C5ISR log format requirement
     /* eslint-disable no-template-curly-in-string */
@@ -89,7 +84,11 @@ export class AtatNetStack extends cdk.Stack {
         ec2.LogFormat.custom("${log-status}"),
         /* eslint-enable no-template-curly-in-string */
       ],
-      destination: ec2.FlowLogDestination.toCloudWatchLogs(cwLogs),
+      destination: ec2.FlowLogDestination.toCloudWatchLogs(
+        new logs.LogGroup(this, "vpc-cssp-cwl-logs", {
+          retention: logs.RetentionDays.INFINITE,
+        })
+      ),
     });
 
     // const dnsLogsGroup = new logs.LogGroup(this, "VpcDnsQueryLogs", {


### PR DESCRIPTION
had to change how the cloudwatch log group was created so deployments dont fail saying a resource already exists. 