### PR TITLE
Add support for Contracting Shop Fee on Igce Summary Page

### DIFF
--- a/document-generation/igce-document.ts
+++ b/document-generation/igce-document.ts
@@ -245,9 +245,19 @@ export async function generateIGCEDocument(
   const surgeCapabilities = summarySheet.getCell("A23");
   surgeCapabilities.value = payload.surgeCapabilities / 100;
 
-  // DITCO Fee
-  const ditcoFee = summarySheet.getCell("C26");
-  ditcoFee.value = { formula: `=K24 *.0225`, date1904: false };
+  // DITCO Fee / Contracting Shop Fee
+  const contractingShopName = summarySheet.getCell("B26");
+  const contractingShopFee = summarySheet.getCell("C26");
+  if (payload.contractingShop.name === "OTHER") {
+    if (payload.contractingShop.fee > 0) {
+      const fee = (payload.contractingShop.fee / 100).toFixed(2); // round to 2 decimal places
+      contractingShopName.value = "Contracting Office Fee";
+      contractingShopFee.value = { formula: `=K24 *${fee}`, date1904: false };
+    }
+  } else if (payload.contractingShop.name === "DITCO") {
+    contractingShopName.value = "DITCO Fee";
+    contractingShopFee.value = { formula: `=K24 *.0225`, date1904: false };
+  }
 
   // Grand Total With Fee
   const grandTotalWithFee = summarySheet.getCell("C27");

--- a/document-generation/utils/sampleTestData.ts
+++ b/document-generation/utils/sampleTestData.ts
@@ -1130,7 +1130,9 @@ export const sampleIgceRequest = {
       orderNumber: "O2206-097-097-184790",
       gtcNumber: "A2201-097-097-18092",
     },
-    contractingShop: "DITCO",
+    contractingShop: {
+      name: "DITCO",
+    },
     periodsEstimate: [
       {
         period: { periodUnit: "YEAR", periodUnitCount: "1", periodType: "BASE", optionOrder: "" },

--- a/models/document-generation.ts
+++ b/models/document-generation.ts
@@ -260,6 +260,10 @@ export enum IdiqClin {
   CLOUD_SUPPORT_2000 = "2000_CLOUD_SUPPORT",
   OTHER_3000 = "3000_OTHER",
 }
+export interface IContractingShop {
+  name: string;
+  fee: number;
+}
 
 export interface IFundingDocument {
   fundingType: FundingType;
@@ -294,7 +298,7 @@ export interface IndependentGovernmentCostEstimate {
   surgeCapabilities: number;
   periodsEstimate: IPeriodEstimate[];
   instructions: IGCEInstructions;
-  contractingShop: string;
+  contractingShop: IContractingShop;
 }
 
 export interface IFundingIncrement {

--- a/models/document-generation.ts
+++ b/models/document-generation.ts
@@ -611,7 +611,7 @@ const independentGovernmentCostEstimate = {
     surgeCapabilities: { type: "integer" },
     periodsEstimate,
     instructions,
-    contractingShop: { type: "string" },
+    contractingShop: { type: "object", properties: { name: { type: "string" }, fee: { type: "number" } } },
   },
   additionalProperties: false,
 };


### PR DESCRIPTION
# Overview
Added support for Contracting Shop on the Igce Summary Page.
## Changes to calculations
Ditco Fee Calculation: `=K24 *.0225`
(This is unchanged)

Contracting Shop Fee Calculation `const fee = (payload.contractingShop.fee / 100).toFixed(2); // round to 2 decimal places`
This uses the contracting shop fee, which exists on the Requirements Cost Estimates Table (how_est_dev_contracting_office_other_charges_fee).