### PR TITLE
Feature/cw event kms access

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -33,7 +33,7 @@
 
     "atat:CspConfigurationName": "config/csp/integration",
     "atat:GitHubPatName": "auth/github/pat",
-    "atat:VersionControlBranch": "develop",
+    "atat:VersionControlBranch": "feature/cw-event-kms-access",
     "atat:VersionControlRepo": "dod-ccpo/atat-web-api",
     "atat:NotificationEmail": "atat-dev+infrastructure-notif@ccpo.mil"
   }

--- a/cdk.json
+++ b/cdk.json
@@ -33,7 +33,7 @@
 
     "atat:CspConfigurationName": "config/csp/integration",
     "atat:GitHubPatName": "auth/github/pat",
-    "atat:VersionControlBranch": "feature/cw-event-kms-access",
+    "atat:VersionControlBranch": "develop",
     "atat:VersionControlRepo": "dod-ccpo/atat-web-api",
     "atat:NotificationEmail": "atat-dev+infrastructure-notif@ccpo.mil"
   }

--- a/lib/atat-shared-data-stack.ts
+++ b/lib/atat-shared-data-stack.ts
@@ -1,6 +1,7 @@
 import * as cdk from "aws-cdk-lib";
 import * as kms from "aws-cdk-lib/aws-kms";
 import * as logs from "aws-cdk-lib/aws-logs";
+import * as iam from "aws-cdk-lib/aws-iam";
 import { RetentionDays } from "aws-cdk-lib/aws-logs";
 import { NagSuppressions } from "cdk-nag";
 import { Construct } from "constructs";

--- a/lib/atat-shared-data-stack.ts
+++ b/lib/atat-shared-data-stack.ts
@@ -22,7 +22,7 @@ export class AtatSharedDataStack extends cdk.Stack {
 
     const svsprincipal = new iam.ServicePrincipal("events.amazonaws.com");
     key.grantDecrypt(svsprincipal);
-    key.grantAdmin(svsprincipal);
+    key.grant(svsprincipal, "kms:GenerateDataKey*");
 
     // Cloudwatch Log group for C5ISR
     const logGroup = new logs.LogGroup(this, "cssp-cwl-logs", {

--- a/lib/atat-shared-data-stack.ts
+++ b/lib/atat-shared-data-stack.ts
@@ -19,6 +19,10 @@ export class AtatSharedDataStack extends cdk.Stack {
     this.encryptionKeyAlias = key.addAlias("atat-default");
     this.encryptionKey = key;
 
+    const svsprincipal = new iam.ServicePrincipal("events.amazonaws.com");
+    key.grantDecrypt(svsprincipal);
+    key.grantAdmin(svsprincipal);
+
     // Cloudwatch Log group for C5ISR
     const logGroup = new logs.LogGroup(this, "cssp-cwl-logs", {
       //  logGroupName: `${environmentName.toLowerCase()}-cssp-cwl-logs`,


### PR DESCRIPTION
grants the Decrypt and GenerateDataKey capabilities for AWS CloudWatch events to trigger SNS topics. Currently SNS it encrypted with a KMs so the "events.amazonaws.com" needs access to that key. 
https://aws.amazon.com/premiumsupport/knowledge-center/sns-not-getting-eventbridge-notification/