### PR TITLE
AT-8895: HOTH API: Encode path parameters in CSP requests and update version number header to remove "v"

### DIFF
--- a/api/client/client.test.ts
+++ b/api/client/client.test.ts
@@ -158,6 +158,17 @@ describe("addEnvironment", () => {
     expect(mock.history.post[0].url).toEqual(`/portfolios/${portfolioId}/environments`);
     expect(result.environment).toEqual(environment);
   });
+  it("should encode URL", async () => {
+    const needsEncoding = "this:needs/to;be encoded,";
+    const encoded = encodeURIComponent(needsEncoding).toString();
+    const urlWithEncoding = `${TEST_CSP_ENDPOINT}/portfolios/${encoded}/environments`;
+    mock.onPost(urlWithEncoding).reply(200, environment, { "Content-Type": "application/json" });
+    await client.addEnvironment({
+      portfolioId: needsEncoding,
+      environment,
+    });
+    expect(mock.history.post[0].url).toEqual(`/portfolios/${encoded}/environments`);
+  });
   it("should handle a successful 202 response", async () => {
     mock.onPost(url).reply(202, mockProvisioningStatus, { "Content-Type": "application/json", location });
     const result = (await client.addEnvironment({

--- a/api/provision/csp-create-environment.test.ts
+++ b/api/provision/csp-create-environment.test.ts
@@ -9,6 +9,7 @@ import {
   CSP_A,
   CSP_A_TEST_ENDPOINT,
   CSP_B,
+  CSP_B_STATUS_ENDPOINT,
   CSP_B_TEST_ENDPOINT,
   TEST_ENVIRONMENT_ID,
 } from "../util/common-test-fixtures";
@@ -102,9 +103,9 @@ describe("Add Environment Tests", () => {
           provisionDeadline: deadline.toISOString(),
         },
         response: {
-          location: CSP_B_TEST_ENDPOINT,
+          location: CSP_B_STATUS_ENDPOINT,
           status: {
-            status: ProvisioningStatusType.SUCCESS,
+            status: ProvisioningStatusType.IN_PROGRESS,
             portfolioId: addEnvironmentProvisionJob.portfolioId,
             provisioningJobId: addEnvironmentProvisionJob.jobId,
           },

--- a/api/util/common-test-fixtures.ts
+++ b/api/util/common-test-fixtures.ts
@@ -14,7 +14,8 @@ export const TEST_PORTFOLIO_ID = "b02e77d1-234d-4e3d-bc85-b57ca5a93952";
 export const TEST_ENVIRONMENT_ID = "1a302680-6127-4bc1-be43-735703bdecb1";
 export const TEST_PROVISIONING_JOB_ID = "81b31a89-e3e5-46ee-acfe-75436bd14577";
 export const CSP_A_TEST_ENDPOINT = `https://CSP_A.example.com`;
-export const CSP_B_TEST_ENDPOINT = "https://CSP_B.com/atat/api";
+export const CSP_B_TEST_ENDPOINT = "https://CSP_B.example.com";
+export const CSP_B_STATUS_ENDPOINT = `${CSP_B_TEST_ENDPOINT}/provisioning/${TEST_PROVISIONING_JOB_ID}/status`;
 export const CSP_A = "CSP_A";
 export const CSP_B = "CSP_B";
 


### PR DESCRIPTION
- Fixed version number header
- Updated client.ts to encode path parameters (not entire URL or path portion)