### PR TITLE
HOTH API: Fix reference to AdministratorPayload

### DIFF
--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -250,7 +250,7 @@ components:
           oneOf:
             - $ref: "#/components/schemas/NewPortfolioPayload"
             - $ref: "#/components/schemas/NewEnvironmentPayload"
-            - $ref: "#/components/schemas/OperatorPayload"
+            - $ref: "#/components/schemas/AdministratorPayload"
     ProvisionResponse:
       description: Response from the CSP which will be set after a request has been processed
       type: object


### PR DESCRIPTION
- Fixes a reference that was missed when we renamed `OperatorPayload` to `AdministratorPayload` in the HOTH API