### PR TITLE
Update IAM: Give QA Read-only access to CloudWatch logs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -159,21 +159,21 @@
         "filename": "cfn-templates/sso-permission-sets.cf.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 257
+        "line_number": 258
       },
       {
         "type": "Secret Keyword",
         "filename": "cfn-templates/sso-permission-sets.cf.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 258
+        "line_number": 259
       },
       {
         "type": "Secret Keyword",
         "filename": "cfn-templates/sso-permission-sets.cf.yaml",
         "hashed_secret": "1ca44c212ca11001056046dee0d18206eac14bcb",
         "is_verified": false,
-        "line_number": 259
+        "line_number": 260
       }
     ],
     "idp/client.test.ts": [
@@ -211,5 +211,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-14T22:35:23Z"
+  "generated_at": "2023-04-05T20:53:33Z"
 }

--- a/cfn-templates/sso-permission-sets.cf.yaml
+++ b/cfn-templates/sso-permission-sets.cf.yaml
@@ -208,6 +208,7 @@ Resources:
         Access for members of Test and QA teams supporting ATAT.
       ManagedPolicies:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/job-function/ViewOnlyAccess"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/CloudWatchLogsReadOnlyAccess"
       InlinePolicy:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
Change will allow testing to see logs