### PR TITLE
FIX: Don't alter contracting office fee used in IGCE docgen

### DIFF
--- a/document-generation/igce-document.ts
+++ b/document-generation/igce-document.ts
@@ -242,17 +242,20 @@ export async function generateIGCEDocument(
   summaryFundingDocCell.value = fundingDocumentNumber;
 
   // Surge Capabilities
+  const surgeFeePct = payload.surgeCapabilities * 0.01;
   const surgeCapabilities = summarySheet.getCell("A23");
-  surgeCapabilities.value = payload.surgeCapabilities / 100;
+  surgeCapabilities.value = surgeFeePct;
 
   // Contracting Office Fee
-  const contractingShopName = summarySheet.getCell("B26");
-  const contractingShopFee = summarySheet.getCell("C26");
-  const feePercentageFraction = (payload.contractingShop.fee / 100).toFixed(2); // round to 2 decimal places
-  contractingShopName.value = payload.contractingShop.name === "DITCO" ? "DITCO Fee" : "Contracting Office Fee";
-  if (payload.contractingShop.fee > 0) {
-    contractingShopFee.value = { formula: `=K24 * ${feePercentageFraction}`, date1904: false };
+  const contractingShopFeePct = payload.contractingShop.fee * 0.01;
+  if (contractingShopFeePct) {
+    const contractingShopFee = summarySheet.getCell("C26");
+    contractingShopFee.value = { formula: `=K24 * ${contractingShopFeePct}`, date1904: false };
   }
+
+  // Contracting Office Name
+  const contractingShopName = summarySheet.getCell("B26");
+  contractingShopName.value = payload.contractingShop.name === "DITCO" ? "DITCO Fee" : "Contracting Office Fee";
 
   // Grand Total With Fee
   const grandTotalWithFee = summarySheet.getCell("C27");

--- a/document-generation/igce-document.ts
+++ b/document-generation/igce-document.ts
@@ -243,23 +243,23 @@ export async function generateIGCEDocument(
 
   // Surge Capabilities
   const surgeFeePct = payload.surgeCapabilities * 0.01;
-  const surgeCapabilities = summarySheet.getCell("A23");
-  surgeCapabilities.value = surgeFeePct;
+  const surgeCapabilitiesCell = summarySheet.getCell("A23");
+  surgeCapabilitiesCell.value = surgeFeePct;
 
   // Contracting Office Fee
   const contractingShopFeePct = payload.contractingShop.fee * 0.01;
   if (contractingShopFeePct) {
-    const contractingShopFee = summarySheet.getCell("C26");
-    contractingShopFee.value = { formula: `=K24 * ${contractingShopFeePct}`, date1904: false };
+    const contractingShopFeeCell = summarySheet.getCell("C26");
+    contractingShopFeeCell.value = { formula: `=K24 * ${contractingShopFeePct}`, date1904: false };
   }
 
   // Contracting Office Name
-  const contractingShopName = summarySheet.getCell("B26");
-  contractingShopName.value = payload.contractingShop.name === "DITCO" ? "DITCO Fee" : "Contracting Office Fee";
+  const contractingShopNameCell = summarySheet.getCell("B26");
+  contractingShopNameCell.value = payload.contractingShop.name === "DITCO" ? "DITCO Fee" : "Contracting Office Fee";
 
   // Grand Total With Fee
-  const grandTotalWithFee = summarySheet.getCell("C27");
-  grandTotalWithFee.value = { formula: `=C26 + K24`, date1904: false };
+  const grandTotalWithFeeCell = summarySheet.getCell("C27");
+  grandTotalWithFeeCell.value = { formula: `=C26 + K24`, date1904: false };
 
   // Set Instruction Sheet Cells
   const instructionSheet = workbook.getWorksheet("INSTRUCTIONS-MUST COMPLETE");
@@ -267,8 +267,8 @@ export async function generateIGCEDocument(
   estimateMadeCell.value = payload.instructions.estimateDescription;
   const infoToolsCell = instructionSheet.getCell("B12");
   infoToolsCell.value = payload.instructions.toolsUsed;
-  const previousEstimate = instructionSheet.getCell("B13");
-  previousEstimate.value = payload.instructions.previousEstimateComparison;
+  const previousEstimateCell = instructionSheet.getCell("B13");
+  previousEstimateCell.value = payload.instructions.previousEstimateComparison;
 
   const buffer = (await workbook.xlsx.writeBuffer()) as Buffer;
   logger.info("IGCE document generated");


### PR DESCRIPTION
Fixes a latent bug that was made worse by #1614.  That PR spread the bug to DITCO calculations in addition to impacting non-DITCO calculations.

- Removes altering of contracting office fee to two fixed digits; had been negatively impacting fee calculation
  - use of `Number.toFixed()` returns a string which was then placed directly in formula of the generated XLSX file
  - for example: a fee of `3.55%` would be translated to decimal `0.0355`, then process by `Number.toFixed()` resulting in `0.03` which was then used in the fee calculation; incorrectly using `3%` rather than `3.55%`
- Changes fee percentage calculations for similarity with corresponding calculations in https://github.com/dod-ccpo/atat-snow/pull/360/
- Renames variables containing exceljs.Cell objects for clarity
