### PR TITLE
Add package script `test-watch` for jest watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test-watch": "npm run test -- --watch",
     "test": "jest",
+    "test-watch": "npm run test -- --watch",
     "cdk": "cdk",
     "lint": "eslint --ext .js,.ts,.json -c ./.eslintrc.json .",
     "lint:fix": "npm run lint -- --fix"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
+    "test-watch": "npm run test -- --watch",
     "test": "jest",
     "cdk": "cdk",
     "lint": "eslint --ext .js,.ts,.json -c ./.eslintrc.json .",


### PR DESCRIPTION
- Adds script `test-watch` that starts jest in watch mode - Helpful when writing unit tests and tweaking implementation