### PR TITLE
Add support for Evaluation Memo to HOTH API

### DIFF
--- a/document-generation/dow-document.test.ts
+++ b/document-generation/dow-document.test.ts
@@ -7,6 +7,7 @@ import { IDescriptionOfWork } from "../models/document-generation/description-of
 import { doGenerate, generateDowDocument } from "./dow-document";
 
 describe("Test DoW document generation", () => {
+  jest.setTimeout(15000);
   const oldEnv = process.env.TEMPLATE_FOLDER;
   const payload = sampleDowRequest.templatePayload as IDescriptionOfWork;
   let docxTemplate: Buffer;

--- a/document-generation/eval-memo-document.test.ts
+++ b/document-generation/eval-memo-document.test.ts
@@ -4,10 +4,11 @@ import { sampleEvalMemo } from "./utils/sampleTestData";
 import { ApiBase64SuccessResponse } from "../utils/response";
 import fs from "fs";
 import { doGenerate, generateEvalMemoDocument } from "./eval-memo-document";
+import { IEvaluationMemo } from "../models/document-generation/evaluation-memo";
 
 describe("Test Eval Memo document generation", () => {
   const oldEnv = process.env.TEMPLATE_FOLDER;
-  const payload = sampleEvalMemo.templatePayload;
+  const payload = sampleEvalMemo.templatePayload as IEvaluationMemo;
   let docxTemplate: Buffer;
 
   beforeAll(() => {
@@ -22,7 +23,7 @@ describe("Test Eval Memo document generation", () => {
     const base64 = await generateEvalMemoDocument(docxTemplate, payload);
     expect(base64).toBeInstanceOf(ApiBase64SuccessResponse);
   });
-
+  
   it.skip("unskip me to generate a local file for manual review", async () => {
     const docBuffer = await doGenerate(docxTemplate, payload);
     await fs.writeFileSync("evalmemo.docx", docBuffer);

--- a/document-generation/eval-memo-document.test.ts
+++ b/document-generation/eval-memo-document.test.ts
@@ -23,7 +23,7 @@ describe("Test Eval Memo document generation", () => {
     const base64 = await generateEvalMemoDocument(docxTemplate, payload);
     expect(base64).toBeInstanceOf(ApiBase64SuccessResponse);
   });
-  
+
   it.skip("unskip me to generate a local file for manual review", async () => {
     const docBuffer = await doGenerate(docxTemplate, payload);
     await fs.writeFileSync("evalmemo.docx", docBuffer);

--- a/document-generation/eval-memo-document.test.ts
+++ b/document-generation/eval-memo-document.test.ts
@@ -1,6 +1,6 @@
 import { getDocxTemplate } from "./utils/utils";
 import { DocumentType } from "../models/document-generation";
-import { sampleEvalMemo } from "./utils/sampleTestData";
+import { sampleEvalMemoRequest } from "./utils/sampleTestData";
 import { ApiBase64SuccessResponse } from "../utils/response";
 import fs from "fs";
 import { doGenerate, generateEvalMemoDocument } from "./eval-memo-document";
@@ -8,7 +8,7 @@ import { IEvaluationMemo } from "../models/document-generation/evaluation-memo";
 
 describe("Test Eval Memo document generation", () => {
   const oldEnv = process.env.TEMPLATE_FOLDER;
-  const payload = sampleEvalMemo.templatePayload as IEvaluationMemo;
+  const payload = sampleEvalMemoRequest.templatePayload as IEvaluationMemo;
   let docxTemplate: Buffer;
 
   beforeAll(() => {

--- a/document-generation/eval-memo-document.ts
+++ b/document-generation/eval-memo-document.ts
@@ -1,8 +1,9 @@
 import { logger } from "../utils/logging";
 import createReport from "docx-templates";
 import { ApiBase64SuccessResponse, SuccessStatusCode } from "../utils/response";
+import { IEvaluationMemo } from "../models/document-generation/evaluation-memo";
 
-export async function doGenerate(template: Buffer, payload: any): Promise<Buffer> {
+export async function doGenerate(template: Buffer, payload: IEvaluationMemo): Promise<Buffer> {
   return Buffer.from(
     await createReport({
       template,
@@ -14,7 +15,10 @@ export async function doGenerate(template: Buffer, payload: any): Promise<Buffer
   );
 }
 
-export async function generateEvalMemoDocument(template: Buffer, payload: any): Promise<ApiBase64SuccessResponse> {
+export async function generateEvalMemoDocument(
+  template: Buffer,
+  payload: IEvaluationMemo
+): Promise<ApiBase64SuccessResponse> {
   const report = await doGenerate(template, payload);
   logger.info("Eval Memo document generated.");
 

--- a/document-generation/eval-memo-document.ts
+++ b/document-generation/eval-memo-document.ts
@@ -24,7 +24,7 @@ export async function generateEvalMemoDocument(
 
   const headers = {
     "Content-Type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "Content-Disposition": `attachment; filename=EvalMemo.docx`,
+    "Content-Disposition": `attachment; filename=EvaluationMemo.docx`,
   };
 
   return new ApiBase64SuccessResponse(report.toString("base64"), SuccessStatusCode.OK, headers);

--- a/document-generation/generate-document.test.ts
+++ b/document-generation/generate-document.test.ts
@@ -58,7 +58,7 @@ const docHeaders = {
   },
 };
 
-jest.setTimeout(15000); // default of 5000 was too short
+jest.setTimeout(15000);
 // mocking the functions that generate the documents
 jest.mock("./chromium", () => {
   return {

--- a/document-generation/generate-document.test.ts
+++ b/document-generation/generate-document.test.ts
@@ -16,6 +16,7 @@ import {
   sampleRequirementsChecklistRequest,
   sampleJustificationAndApproval,
   sampleMarketResearchReport,
+  sampleEvalMemo,
 } from "./utils/sampleTestData";
 
 const validRequest = {
@@ -50,6 +51,10 @@ const docHeaders = {
   mrr: {
     "Content-Type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     "Content-Disposition": `attachment; filename=MarketResearchReport.docx`,
+  },
+  evalMemo: {
+    "Content-Type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "Content-Disposition": `attachment; filename=EvalMemo.docx`,
   },
 };
 
@@ -96,7 +101,7 @@ jest.mock("./requirements-checklist-document", () => {
     }),
   };
 });
-jest.mock("./justification-and-approval-document.ts", () => {
+jest.mock("./justification-and-approval-document", () => {
   return {
     generateJustificationAndApprovalDocument: jest.fn().mockImplementation(() => {
       const buffer = Buffer.from("generateJustificationAndApprovalDocument");
@@ -104,11 +109,19 @@ jest.mock("./justification-and-approval-document.ts", () => {
     }),
   };
 });
-jest.mock("./mrr-document.ts", () => {
+jest.mock("./mrr-document", () => {
   return {
     generateMarketResearchReportDocument: jest.fn().mockImplementation(() => {
       const buffer = Buffer.from("generateMarketResearchReportDocument");
       return new ApiBase64SuccessResponse(buffer.toString("base64"), SuccessStatusCode.OK, docHeaders.mrr);
+    }),
+  };
+});
+jest.mock("./eval-memo-document", () => {
+  return {
+    generateEvalMemoDocument: jest.fn().mockImplementation(() => {
+      const buffer = Buffer.from("generateEvalMemoDocument");
+      return new ApiBase64SuccessResponse(buffer.toString("base64"), SuccessStatusCode.OK, docHeaders.evalMemo);
     }),
   };
 });
@@ -169,7 +182,6 @@ describe("Successful generate-document handler", () => {
 
     // WHEN / ACT
     const response = await handler(request, {} as Context);
-    console.log("RESPONSE: ", JSON.stringify(response));
     // THEN / ASSERT
     expect(response).toBeInstanceOf(SuccessBase64Response);
     expect(response.headers).toEqual(docHeaders.requirementsChecklist);
@@ -186,7 +198,6 @@ describe("Successful generate-document handler", () => {
 
     // WHEN / ACT
     const response = await handler(request, {} as Context);
-    console.log("RESPONSE: ", JSON.stringify(response));
     // THEN / ASSERT
     expect(response).toBeInstanceOf(SuccessBase64Response);
     expect(response.headers).toEqual(docHeaders.janda);
@@ -203,10 +214,25 @@ describe("Successful generate-document handler", () => {
 
     // WHEN / ACT
     const response = await handler(request, {} as Context);
-    console.log("RESPONSE: ", JSON.stringify(response));
     // THEN / ASSERT
     expect(response).toBeInstanceOf(SuccessBase64Response);
     expect(response.headers).toEqual(docHeaders.mrr);
+  });
+
+  it("should return successful Eval Memo document response", async () => {
+    // GIVEN / ARRANGE
+    const request = {
+      ...validRequest,
+      body: JSON.stringify({
+        ...sampleEvalMemo,
+      }),
+    };
+
+    // WHEN / ACT
+    const response = await handler(request, {} as Context);
+    // THEN / ASSERT
+    expect(response).toBeInstanceOf(SuccessBase64Response);
+    expect(response.headers).toEqual(docHeaders.evalMemo);
   });
 });
 
@@ -218,6 +244,7 @@ describe("Invalid requests for generate-document handler", () => {
     sampleRequirementsChecklistRequest.templatePayload,
     sampleJustificationAndApproval.templatePayload,
     sampleMarketResearchReport.templatePayload,
+    sampleEvalMemo.templatePayload,
   ])("should return validation error when invalid document type", async (payload) => {
     // GIVEN / ARRANGE
     const invalidRequest = {
@@ -242,6 +269,7 @@ describe("Invalid requests for generate-document handler", () => {
     DocumentType.REQUIREMENTS_CHECKLIST,
     DocumentType.JUSTIFICATION_AND_APPROVAL,
     DocumentType.MARKET_RESEARCH_REPORT,
+    DocumentType.EVALUATION_MEMO,
   ])("should return validation error when payload not an object", async (documentType) => {
     // GIVEN / ARRANGE
     const invalidRequest = {
@@ -282,6 +310,10 @@ describe("Invalid requests for generate-document handler", () => {
     {
       documentType: DocumentType.MARKET_RESEARCH_REPORT,
       templatePayload: { ...sampleMarketResearchReport.templatePayload, spurious: "prop" },
+    },
+    {
+      documentType: DocumentType.EVALUATION_MEMO,
+      templatePayload: { ...sampleEvalMemo.templatePayload, garbage: "prop" },
     },
   ])("should return validation error when payload has additional properties", async (requestBody) => {
     // GIVEN / ARRANGE

--- a/document-generation/generate-document.test.ts
+++ b/document-generation/generate-document.test.ts
@@ -54,7 +54,7 @@ const docHeaders = {
   },
   evalMemo: {
     "Content-Type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "Content-Disposition": `attachment; filename=EvalMemo.docx`,
+    "Content-Disposition": `attachment; filename=EvaluationMemo.docx`,
   },
 };
 

--- a/document-generation/generate-document.test.ts
+++ b/document-generation/generate-document.test.ts
@@ -14,9 +14,9 @@ import {
   sampleIfpRequest,
   sampleIgceRequest,
   sampleRequirementsChecklistRequest,
-  sampleJustificationAndApproval,
-  sampleMarketResearchReport,
-  sampleEvalMemo,
+  sampleJustificationAndApprovalRequest,
+  sampleMarketResearchReportRequest,
+  sampleEvalMemoRequest,
 } from "./utils/sampleTestData";
 
 const validRequest = {
@@ -192,7 +192,7 @@ describe("Successful generate-document handler", () => {
     const request = {
       ...validRequest,
       body: JSON.stringify({
-        ...sampleJustificationAndApproval,
+        ...sampleJustificationAndApprovalRequest,
       }),
     };
 
@@ -208,7 +208,7 @@ describe("Successful generate-document handler", () => {
     const request = {
       ...validRequest,
       body: JSON.stringify({
-        ...sampleMarketResearchReport,
+        ...sampleMarketResearchReportRequest,
       }),
     };
 
@@ -224,7 +224,7 @@ describe("Successful generate-document handler", () => {
     const request = {
       ...validRequest,
       body: JSON.stringify({
-        ...sampleEvalMemo,
+        ...sampleEvalMemoRequest,
       }),
     };
 
@@ -242,9 +242,9 @@ describe("Invalid requests for generate-document handler", () => {
     sampleIgceRequest.templatePayload,
     sampleIfpRequest.templatePayload,
     sampleRequirementsChecklistRequest.templatePayload,
-    sampleJustificationAndApproval.templatePayload,
-    sampleMarketResearchReport.templatePayload,
-    sampleEvalMemo.templatePayload,
+    sampleJustificationAndApprovalRequest.templatePayload,
+    sampleMarketResearchReportRequest.templatePayload,
+    sampleEvalMemoRequest.templatePayload,
   ])("should return validation error when invalid document type", async (payload) => {
     // GIVEN / ARRANGE
     const invalidRequest = {
@@ -305,15 +305,15 @@ describe("Invalid requests for generate-document handler", () => {
     },
     {
       documentType: DocumentType.JUSTIFICATION_AND_APPROVAL,
-      templatePayload: { ...sampleJustificationAndApproval.templatePayload, notreal: "prop" },
+      templatePayload: { ...sampleJustificationAndApprovalRequest.templatePayload, notreal: "prop" },
     },
     {
       documentType: DocumentType.MARKET_RESEARCH_REPORT,
-      templatePayload: { ...sampleMarketResearchReport.templatePayload, spurious: "prop" },
+      templatePayload: { ...sampleMarketResearchReportRequest.templatePayload, spurious: "prop" },
     },
     {
       documentType: DocumentType.EVALUATION_MEMO,
-      templatePayload: { ...sampleEvalMemo.templatePayload, garbage: "prop" },
+      templatePayload: { ...sampleEvalMemoRequest.templatePayload, garbage: "prop" },
     },
   ])("should return validation error when payload has additional properties", async (requestBody) => {
     // GIVEN / ARRANGE

--- a/document-generation/generate-document.ts
+++ b/document-generation/generate-document.ts
@@ -56,6 +56,7 @@ async function baseHandler(event: RequestEvent<GenerateDocumentRequest>): Promis
     case DocumentType.REQUIREMENTS_CHECKLIST:
     case DocumentType.JUSTIFICATION_AND_APPROVAL:
     case DocumentType.MARKET_RESEARCH_REPORT:
+    case DocumentType.EVALUATION_MEMO:
       return generateDocxDocument(event);
     default:
       return new ValidationErrorResponse(`Invalid document type: "${documentType}"`, {

--- a/document-generation/generate-document.ts
+++ b/document-generation/generate-document.ts
@@ -40,6 +40,8 @@ import { generateMarketResearchReportDocument } from "./mrr-document";
 
 import { IJustificationAndApproval } from "../models/document-generation/justification-and-approval";
 import { IMarketResearchReport } from "../models/document-generation/market-research-report";
+import { IEvaluationMemo } from "../models/document-generation/evaluation-memo";
+import { generateEvalMemoDocument } from "./eval-memo-document";
 
 async function baseHandler(event: RequestEvent<GenerateDocumentRequest>): Promise<ApiBase64SuccessResponse> {
   const { documentType } = event.body;
@@ -102,6 +104,8 @@ async function generateDocxDocument(event: RequestEvent<GenerateDocumentRequest>
       return generateDowDocument(docxTemplate, templatePayload as IDescriptionOfWork);
     case DocumentType.INCREMENTAL_FUNDING_PLAN:
       return generateIFPDocument(docxTemplate, templatePayload as IncrementalFundingPlan);
+    case DocumentType.EVALUATION_MEMO:
+      return generateEvalMemoDocument(docxTemplate, templatePayload as IEvaluationMemo);
     case DocumentType.EVALUATION_PLAN:
       return generateEvalPlanDocument(docxTemplate, templatePayload as EvaluationPlan);
     case DocumentType.REQUIREMENTS_CHECKLIST:

--- a/document-generation/igce-document.test.ts
+++ b/document-generation/igce-document.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
 });
 
 describe("Generate an IGCE binary document - happy path", () => {
-  jest.setTimeout(10000); // these tests take longer on some clients
+  jest.setTimeout(15000);
   const sampleIgceRequestWithGTCNumber = sampleIgceRequest.templatePayload as IndependentGovernmentCostEstimate;
   const sampleIgceRequestWithMIPRNumber = {
     ...sampleIgceRequest.templatePayload,

--- a/document-generation/justification-and-approval-document.test.ts
+++ b/document-generation/justification-and-approval-document.test.ts
@@ -1,14 +1,14 @@
 import { doGenerate, generateJustificationAndApprovalDocument } from "./justification-and-approval-document";
 import { getDocxTemplate } from "./utils/utils";
 import { DocumentType } from "../models/document-generation";
-import { sampleJustificationAndApproval } from "./utils/sampleTestData";
+import { sampleJustificationAndApprovalRequest } from "./utils/sampleTestData";
 import { IJustificationAndApproval } from "../models/document-generation/justification-and-approval";
 import { ApiBase64SuccessResponse } from "../utils/response";
 import fs from "fs";
 
 describe("Test J&A document generation", () => {
   const oldEnv = process.env.TEMPLATE_FOLDER;
-  const payload = sampleJustificationAndApproval.templatePayload as IJustificationAndApproval;
+  const payload = sampleJustificationAndApprovalRequest.templatePayload as IJustificationAndApproval;
   let docxTemplate: Buffer;
 
   beforeAll(() => {

--- a/document-generation/mrr-document.test.ts
+++ b/document-generation/mrr-document.test.ts
@@ -1,14 +1,14 @@
 import { doGenerate, generateMarketResearchReportDocument } from "./mrr-document";
 import { getDocxTemplate } from "./utils/utils";
 import { DocumentType } from "../models/document-generation";
-import { sampleMarketResearchReport } from "./utils/sampleTestData";
+import { sampleMarketResearchReportRequest } from "./utils/sampleTestData";
 import { IMarketResearchReport } from "../models/document-generation/market-research-report";
 import { ApiBase64SuccessResponse } from "../utils/response";
 import fs from "fs";
 
 describe("Test MRR document generation", () => {
   const oldEnv = process.env.TEMPLATE_FOLDER;
-  const payload = sampleMarketResearchReport.templatePayload as IMarketResearchReport;
+  const payload = sampleMarketResearchReportRequest.templatePayload as IMarketResearchReport;
   let docxTemplate: Buffer;
 
   beforeAll(() => {

--- a/document-generation/utils/sampleTestData.ts
+++ b/document-generation/utils/sampleTestData.ts
@@ -1549,7 +1549,7 @@ export const sampleRequirementsChecklistRequest = {
   },
 };
 
-export const sampleJustificationAndApproval = {
+export const sampleJustificationAndApprovalRequest = {
   documentType: "JUSTIFICATION_AND_APPROVAL",
   templatePayload: {
     purchaseRequestNumber: "O2208-097-097-697046, O2208-097-097-697046",
@@ -1649,7 +1649,7 @@ export const sampleJustificationAndApproval = {
   },
 };
 
-export const sampleMarketResearchReport = {
+export const sampleMarketResearchReportRequest = {
   documentType: "MARKET_RESEARCH_REPORT",
   templatePayload: {
     researchers: [
@@ -1763,7 +1763,7 @@ export const sampleMarketResearchReport = {
   },
 };
 
-export const sampleEvalMemo = {
+export const sampleEvalMemoRequest = {
   documentType: "EVALUATION_MEMO",
   templatePayload: {
     title: "my title",

--- a/models/document-generation.ts
+++ b/models/document-generation.ts
@@ -739,7 +739,54 @@ export const evalPlan = {
   additionalProperties: false,
 };
 
-// J&A
+export const evalMemo = {
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    estimatedValueFormatted: { type: "string" },
+    exceptionToFairOpportunity: { type: "string" },
+    proposedVendor: { type: "string" },
+    // Eval Plan below
+    taskOrderTitle: { type: "string" },
+    sourceSelection: {
+      type: "string",
+      enum: [
+        SourceSelection.NO_TECH_PROPOSAL,
+        SourceSelection.TECH_PROPOSAL,
+        SourceSelection.SET_LUMP_SUM,
+        SourceSelection.EQUAL_SET_LUMP_SUM,
+      ],
+    },
+    method: {
+      enum: [EvalPlanMethod.BEST_USE, EvalPlanMethod.LOWEST_RISK, EvalPlanMethod.BVTO, EvalPlanMethod.LPTA, null],
+    },
+    standardSpecifications: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+    customSpecifications: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+    standardDifferentiators: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+    customDifferentiators: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+  },
+  additionalProperties: false,
+};
 
 export const fairOpportunity = {
   type: "object",
@@ -796,7 +843,6 @@ export const justificationAndApproval = {
   additionalProperties: false,
 };
 
-// MRR
 export const marketResearchReport = {
   type: "object",
   properties: {
@@ -830,6 +876,7 @@ export const generateDocumentSchema = {
         DocumentType.REQUIREMENTS_CHECKLIST,
         DocumentType.JUSTIFICATION_AND_APPROVAL,
         DocumentType.MARKET_RESEARCH_REPORT,
+        DocumentType.EVALUATION_MEMO,
       ],
     },
     templatePayload: {
@@ -838,6 +885,7 @@ export const generateDocumentSchema = {
         independentGovernmentCostEstimate,
         incrementalFundingPlan,
         evalPlan,
+        evalMemo,
         requirementsCheckList,
         justificationAndApproval,
         marketResearchReport,

--- a/models/document-generation.ts
+++ b/models/document-generation.ts
@@ -746,44 +746,7 @@ export const evalMemo = {
     estimatedValueFormatted: { type: "string" },
     exceptionToFairOpportunity: { type: "string" },
     proposedVendor: { type: "string" },
-    // Eval Plan below
-    taskOrderTitle: { type: "string" },
-    sourceSelection: {
-      type: "string",
-      enum: [
-        SourceSelection.NO_TECH_PROPOSAL,
-        SourceSelection.TECH_PROPOSAL,
-        SourceSelection.SET_LUMP_SUM,
-        SourceSelection.EQUAL_SET_LUMP_SUM,
-      ],
-    },
-    method: {
-      enum: [EvalPlanMethod.BEST_USE, EvalPlanMethod.LOWEST_RISK, EvalPlanMethod.BVTO, EvalPlanMethod.LPTA, null],
-    },
-    standardSpecifications: {
-      type: "array",
-      items: {
-        type: "string",
-      },
-    },
-    customSpecifications: {
-      type: "array",
-      items: {
-        type: "string",
-      },
-    },
-    standardDifferentiators: {
-      type: "array",
-      items: {
-        type: "string",
-      },
-    },
-    customDifferentiators: {
-      type: "array",
-      items: {
-        type: "string",
-      },
-    },
+    ...evalPlan.properties,
   },
   additionalProperties: false,
 };

--- a/models/document-generation/evaluation-memo.ts
+++ b/models/document-generation/evaluation-memo.ts
@@ -1,0 +1,16 @@
+import { EvalPlanMethod, SourceSelection } from "../document-generation";
+
+export interface IEvaluationMemo {
+  title: string;
+  estimatedValueFormatted: string;
+  exceptionToFairOpportunity?: string | null; // 16.505(b)(2)(i)([A|B|C])
+  proposedVendor: string;
+  // Eval Plan below
+  taskOrderTitle: string;
+  sourceSelection: SourceSelection;
+  method: EvalPlanMethod;
+  standardSpecifications: string[];
+  customSpecifications: string[];
+  standardDifferentiators: string[];
+  customDifferentiators: string[];
+}

--- a/models/document-generation/evaluation-memo.ts
+++ b/models/document-generation/evaluation-memo.ts
@@ -1,16 +1,8 @@
-import { EvalPlanMethod, SourceSelection } from "../document-generation";
+import { EvalPlanMethod, EvaluationPlan, SourceSelection } from "../document-generation";
 
-export interface IEvaluationMemo {
+export interface IEvaluationMemo extends EvaluationPlan {
   title: string;
   estimatedValueFormatted: string;
   exceptionToFairOpportunity?: string | null; // 16.505(b)(2)(i)([A|B|C])
   proposedVendor: string;
-  // Eval Plan below
-  taskOrderTitle: string;
-  sourceSelection: SourceSelection;
-  method: EvalPlanMethod;
-  standardSpecifications: string[];
-  customSpecifications: string[];
-  standardDifferentiators: string[];
-  customDifferentiators: string[];
 }


### PR DESCRIPTION
- Adds and makes use of interface `IEvaluationMemo`
- Adds document type and payload for Eval Memo to `generateDocumentSchema` and `generateDocxDocument` other places
- Adds `evalMemo` to models in `document-generation.ts`
- Adds jest mock response for `generateEvalMemoDocument`
- Sets jest timeout to 15000ms for DoW because timeouts were encountered for that document; used same amount elsewhere for consistency
- Renamed some recently created exports in `sampleTestData.ts` for consistency; we'd ignored an established convention for that last couple documents

Ticket: AT-9121