### PR TITLE
Change Eval Memo JSON payload property 'exceptionToFairOpportunity' to boolean

### DIFF
--- a/document-generation/utils/sampleTestData.ts
+++ b/document-generation/utils/sampleTestData.ts
@@ -1776,7 +1776,7 @@ export const sampleEvalMemoRequest = {
   templatePayload: {
     title: "my title",
     estimatedValueFormatted: "$6,299,661.00",
-    exceptionToFairOpportunity: null,
+    exceptionToFairOpportunity: true,
     proposedVendor: "Google Support Services",
     taskOrderTitle: "Eval Memo Test",
     sourceSelection: "NO_TECH_PROPOSAL",

--- a/hoth_api.yaml
+++ b/hoth_api.yaml
@@ -635,7 +635,7 @@ components:
             title:
               type: string
             exceptionToFairOpportunity:
-              type: string
+              type: boolean
             proposedVendor:
               type: string
             estimatedValueFormatted:

--- a/models/document-generation/evaluation-memo.ts
+++ b/models/document-generation/evaluation-memo.ts
@@ -1,8 +1,8 @@
-import { EvalPlanMethod, EvaluationPlan, SourceSelection } from "../document-generation";
+import { EvaluationPlan } from "../document-generation";
 
 export interface IEvaluationMemo extends EvaluationPlan {
   title: string;
   estimatedValueFormatted: string;
-  exceptionToFairOpportunity?: string | null; // 16.505(b)(2)(i)([A|B|C])
+  exceptionToFairOpportunity: boolean; // true for YES values, false for NO_NONE
   proposedVendor: string;
 }


### PR DESCRIPTION
This PR partially corrects a gap in expectations for property `exceptionToFairOpportunity` across the following PRs between @jeffsegal-ccpo and myself:
- https://github.com/dod-ccpo/atat-snow/pull/410
- https://github.com/dod-ccpo/atat-web-api/pull/1702 
- https://github.com/dod-ccpo/atat-web-api/pull/1710

The the remainder of the gap will be corrected in the Eval Plan script include in https://github.com/dod-ccpo/atat-snow/pull/413

Changes type of `exceptionToFairOpportunity` to boolean - _true_ for YES values (in column Fair Opportunity.exception_to_fair_opportunity), _false_ for NO_NONE and property is always included in JSON payload

### Document template requires no changes for the above
Eval Memo document template requires no changes as written. Tested docgen locally with true and false values with positive results.  Use in document is exclusively `IF exceptionToFairOpportunity` and `IF !exceptionToFairOpportunity`.

![image](https://github.com/dod-ccpo/atat-web-api/assets/77642966/00569b49-572e-4969-b0c7-3855fd7a5cc9)

Ticket: AT-9121

