### PR TITLE
AT-9120 -Able to eval memo with empty eval plan

### DIFF
--- a/document-generation/eval-memo-document.test.ts
+++ b/document-generation/eval-memo-document.test.ts
@@ -19,6 +19,18 @@ describe("Test Eval Memo document generation", () => {
     process.env.TEMPLATE_FOLDER = oldEnv;
   });
 
+  it("can generate a Eval memo with a null sourceSelection without throwing an error", async () => {
+    payload.sourceSelection = null;
+    const base64 = await generateEvalMemoDocument(docxTemplate, payload);
+    expect(base64).toBeInstanceOf(ApiBase64SuccessResponse);
+  });
+
+  it("can generate a Eval memo with a null eval plan method without throwing an error", async () => {
+    payload.method = null;
+    const base64 = await generateEvalMemoDocument(docxTemplate, payload);
+    expect(base64).toBeInstanceOf(ApiBase64SuccessResponse);
+  });
+
   it("can generate a Eval Memo without throwing an error", async () => {
     const base64 = await generateEvalMemoDocument(docxTemplate, payload);
     expect(base64).toBeInstanceOf(ApiBase64SuccessResponse);

--- a/models/document-generation.ts
+++ b/models/document-generation.ts
@@ -343,8 +343,8 @@ export interface IncrementalFundingPlan {
 
 export interface EvaluationPlan {
   taskOrderTitle: string;
-  sourceSelection: SourceSelection;
-  method: EvalPlanMethod;
+  sourceSelection: SourceSelection | null;
+  method: EvalPlanMethod | null;
   standardSpecifications: string[];
   customSpecifications: string[];
   standardDifferentiators: string[];


### PR DESCRIPTION
In EvaluationPlan Inteface
added " | null" to support the package with exception to the fair opportunity. Since when the package is exception to fair opportunity, both sourceSelection: SourceSelection and method return null. 
Also added unit tests these changes