### PR TITLE
Change Eval Plan validation model to allow 'null' for property 'sourceSelection'

### DIFF
--- a/models/document-generation.ts
+++ b/models/document-generation.ts
@@ -710,9 +710,11 @@ export const evalPlan = {
         SourceSelection.TECH_PROPOSAL,
         SourceSelection.SET_LUMP_SUM,
         SourceSelection.EQUAL_SET_LUMP_SUM,
+        null,
       ],
     },
     method: {
+      type: "string",
       enum: [EvalPlanMethod.BEST_USE, EvalPlanMethod.LOWEST_RISK, EvalPlanMethod.BVTO, EvalPlanMethod.LPTA, null],
     },
     standardSpecifications: {


### PR DESCRIPTION
The Eval Plan model is extended by that for Eval Memo.  This may resolve validation errors during docgen when there is no `sourceSelection` value.  Property `method` already contains this null option and it doesn't seem to cause the same validation error.

Ticket: AT-9120