### PR TITLE
AT-9007 - Fixed ditco fee returning undefined

### DIFF
--- a/document-generation/igce-document.ts
+++ b/document-generation/igce-document.ts
@@ -262,7 +262,12 @@ export async function generateIGCEDocument(
   const contractingShopFeePct = payload.contractingShop.fee * 0.01;
   if (contractingShopFeePct) {
     const contractingShopFeeCell = summarySheet.getCell("C27");
-    contractingShopFeeCell.value = { formula: `=(K24 + K25) * ${contractingShopFeePct}`, date1904: false };
+    if (payload.contractingShop.name !== "DITCO") {
+      contractingShopFeeCell.value = { formula: `=(K24 + K25) * ${contractingShopFeePct}`, date1904: false };
+    }
+    if (payload.contractingShop.name === "DITCO") {
+      contractingShopFeeCell.value = { formula: `=K24 * ${contractingShopFeePct}`, date1904: false };
+    }
   }
 
   // Contracting Office Name

--- a/document-generation/igce-document.ts
+++ b/document-generation/igce-document.ts
@@ -262,11 +262,10 @@ export async function generateIGCEDocument(
   const contractingShopFeePct = payload.contractingShop.fee * 0.01;
   if (contractingShopFeePct) {
     const contractingShopFeeCell = summarySheet.getCell("C27");
-    if (payload.contractingShop.name !== "DITCO") {
-      contractingShopFeeCell.value = { formula: `=(K24 + K25) * ${contractingShopFeePct}`, date1904: false };
-    }
     if (payload.contractingShop.name === "DITCO") {
       contractingShopFeeCell.value = { formula: `=K24 * ${contractingShopFeePct}`, date1904: false };
+    } else {
+      contractingShopFeeCell.value = { formula: `=(K24 + K25) * ${contractingShopFeePct}`, date1904: false };
     }
   }
 


### PR DESCRIPTION
With recent change, DITCO user will have empty object for row 25 (External agency ordering fee)

Thus, formula `=(K24 + K25) * ${contractingShopFeePct}` will retrun underifned since K25 is null. 
![image](https://github.com/dod-ccpo/atat-web-api/assets/107569948/187300e9-9733-4bb0-abef-2b01b00e368f)


Use the If statement to properly display the contracting office fee
![image](https://github.com/dod-ccpo/atat-web-api/assets/107569948/fd7c67a1-d5a0-4786-a8f8-512c0635857a)
