### PR TITLE
Eval Memo improvements

### DIFF
--- a/document-generation/eval-memo-document.test.ts
+++ b/document-generation/eval-memo-document.test.ts
@@ -1,6 +1,6 @@
 import { getDocxTemplate } from "./utils/utils";
 import { DocumentType } from "../models/document-generation";
-import { sampleEvalMemoRequest } from "./utils/sampleTestData";
+import { sampleEvalMemoRequestWithException, sampleEvalMemoRequestWithoutException } from "./utils/sampleTestData";
 import { ApiBase64SuccessResponse } from "../utils/response";
 import fs from "fs";
 import { doGenerate, generateEvalMemoDocument } from "./eval-memo-document";
@@ -8,7 +8,8 @@ import { IEvaluationMemo } from "../models/document-generation/evaluation-memo";
 
 describe("Test Eval Memo document generation", () => {
   const oldEnv = process.env.TEMPLATE_FOLDER;
-  const payload = sampleEvalMemoRequest.templatePayload as IEvaluationMemo;
+  const payloadWithException = sampleEvalMemoRequestWithException.templatePayload as IEvaluationMemo;
+  const payloadWithoutException = sampleEvalMemoRequestWithoutException.templatePayload as IEvaluationMemo;
   let docxTemplate: Buffer;
 
   beforeAll(() => {
@@ -19,13 +20,23 @@ describe("Test Eval Memo document generation", () => {
     process.env.TEMPLATE_FOLDER = oldEnv;
   });
 
-  it("can generate a Eval Memo without throwing an error", async () => {
-    const base64 = await generateEvalMemoDocument(docxTemplate, payload);
+  it("can generate a Eval Memo w/ exception to fair opportunity without throwing an error", async () => {
+    const base64 = await generateEvalMemoDocument(docxTemplate, payloadWithException);
     expect(base64).toBeInstanceOf(ApiBase64SuccessResponse);
   });
 
-  it.skip("unskip me to generate a local file for manual review", async () => {
-    const docBuffer = await doGenerate(docxTemplate, payload);
-    await fs.writeFileSync("evalmemo.docx", docBuffer);
+  it("can generate a Eval Memo w/o exception to fair opportunity without throwing an error", async () => {
+    const base64 = await generateEvalMemoDocument(docxTemplate, payloadWithoutException);
+    expect(base64).toBeInstanceOf(ApiBase64SuccessResponse);
+  });
+
+  it.skip("unskip me to generate a local file for manual review - w/ exception to fair opportunity", async () => {
+    const docBuffer = await doGenerate(docxTemplate, payloadWithException);
+    await fs.writeFileSync("evalmemo-withException.docx", docBuffer);
+  });
+
+  it.skip("unskip me to generate a local file for manual review - w/o exception to fair opportunity", async () => {
+    const docBuffer = await doGenerate(docxTemplate, payloadWithoutException);
+    await fs.writeFileSync("evalmemo-withoutException.docx", docBuffer);
   });
 });

--- a/document-generation/generate-document.test.ts
+++ b/document-generation/generate-document.test.ts
@@ -16,7 +16,8 @@ import {
   sampleRequirementsChecklistRequest,
   sampleJustificationAndApprovalRequest,
   sampleMarketResearchReportRequest,
-  sampleEvalMemoRequest,
+  sampleEvalMemoRequestWithException,
+  sampleEvalMemoRequestWithoutException,
 } from "./utils/sampleTestData";
 
 const validRequest = {
@@ -219,12 +220,27 @@ describe("Successful generate-document handler", () => {
     expect(response.headers).toEqual(docHeaders.mrr);
   });
 
-  it("should return successful Eval Memo document response", async () => {
+  it("should return successful Eval Memo document response - w/ Exception to Fair Opportunity", async () => {
     // GIVEN / ARRANGE
     const request = {
       ...validRequest,
       body: JSON.stringify({
-        ...sampleEvalMemoRequest,
+        ...sampleEvalMemoRequestWithException,
+      }),
+    };
+
+    // WHEN / ACT
+    const response = await handler(request, {} as Context);
+    // THEN / ASSERT
+    expect(response).toBeInstanceOf(SuccessBase64Response);
+    expect(response.headers).toEqual(docHeaders.evalMemo);
+  });
+  it("should return successful Eval Memo document response - w/o Exception to Fair Opportunity", async () => {
+    // GIVEN / ARRANGE
+    const request = {
+      ...validRequest,
+      body: JSON.stringify({
+        ...sampleEvalMemoRequestWithoutException,
       }),
     };
 
@@ -244,7 +260,8 @@ describe("Invalid requests for generate-document handler", () => {
     sampleRequirementsChecklistRequest.templatePayload,
     sampleJustificationAndApprovalRequest.templatePayload,
     sampleMarketResearchReportRequest.templatePayload,
-    sampleEvalMemoRequest.templatePayload,
+    sampleEvalMemoRequestWithException.templatePayload,
+    sampleEvalMemoRequestWithoutException.templatePayload,
   ])("should return validation error when invalid document type", async (payload) => {
     // GIVEN / ARRANGE
     const invalidRequest = {
@@ -313,7 +330,11 @@ describe("Invalid requests for generate-document handler", () => {
     },
     {
       documentType: DocumentType.EVALUATION_MEMO,
-      templatePayload: { ...sampleEvalMemoRequest.templatePayload, garbage: "prop" },
+      templatePayload: { ...sampleEvalMemoRequestWithException.templatePayload, garbage: "prop" },
+    },
+    {
+      documentType: DocumentType.EVALUATION_MEMO,
+      templatePayload: { ...sampleEvalMemoRequestWithoutException.templatePayload, basura: "prop" },
     },
   ])("should return validation error when payload has additional properties", async (requestBody) => {
     // GIVEN / ARRANGE

--- a/document-generation/utils/sampleTestData.ts
+++ b/document-generation/utils/sampleTestData.ts
@@ -1807,14 +1807,31 @@ export const sampleMarketResearchReportRequest = {
   },
 };
 
-export const sampleEvalMemoRequest = {
+export const sampleEvalMemoRequestWithException = {
   documentType: "EVALUATION_MEMO",
   templatePayload: {
-    title: "my title",
+    title: "Eval Memo Test",
     estimatedValueFormatted: "$6,299,661.00",
-    exceptionToFairOpportunity: true,
+    exceptionToFairOpportunity: true,  // EP not generated, expect no EP record
     proposedVendor: "Google Support Services",
-    taskOrderTitle: "Eval Memo Test",
+    // EP properties below
+    taskOrderTitle: null,
+    sourceSelection: null,
+    method: null,
+    standardSpecifications: [],
+    customSpecifications: [],
+    standardDifferentiators: [],
+    customDifferentiators: [],
+  },
+};
+
+export const sampleEvalMemoRequestWithoutException = {
+  ...sampleEvalMemoRequestWithException,
+  templatePayload: {
+    ...sampleEvalMemoRequestWithException.templatePayload,
+    exceptionToFairOpportunity: false,  // EP generated, expect EP record
+    // EP properties below
+    taskOrderTitle: "Amazing Task Order",
     sourceSelection: "NO_TECH_PROPOSAL",
     method: "LPTA",
     standardSpecifications: ["standard spec 1", "standard spec 2", "standard spec 3"],

--- a/document-generation/utils/sampleTestData.ts
+++ b/document-generation/utils/sampleTestData.ts
@@ -1812,7 +1812,7 @@ export const sampleEvalMemoRequestWithException = {
   templatePayload: {
     title: "Eval Memo Test",
     estimatedValueFormatted: "$6,299,661.00",
-    exceptionToFairOpportunity: true,  // EP not generated, expect no EP record
+    exceptionToFairOpportunity: true, // EP not generated, expect no EP record
     proposedVendor: "Google Support Services",
     // EP properties below
     taskOrderTitle: null,
@@ -1829,7 +1829,7 @@ export const sampleEvalMemoRequestWithoutException = {
   ...sampleEvalMemoRequestWithException,
   templatePayload: {
     ...sampleEvalMemoRequestWithException.templatePayload,
-    exceptionToFairOpportunity: false,  // EP generated, expect EP record
+    exceptionToFairOpportunity: false, // EP generated, expect EP record
     // EP properties below
     taskOrderTitle: "Amazing Task Order",
     sourceSelection: "NO_TECH_PROPOSAL",

--- a/models/document-generation.ts
+++ b/models/document-generation.ts
@@ -714,7 +714,7 @@ export const evalPlan = {
       ],
     },
     method: {
-      enum: [EvalPlanMethod.BEST_USE, EvalPlanMethod.LOWEST_RISK, EvalPlanMethod.BVTO, EvalPlanMethod.LPTA, null,],
+      enum: [EvalPlanMethod.BEST_USE, EvalPlanMethod.LOWEST_RISK, EvalPlanMethod.BVTO, EvalPlanMethod.LPTA, null],
     },
     standardSpecifications: {
       type: "array",

--- a/models/document-generation.ts
+++ b/models/document-generation.ts
@@ -343,9 +343,10 @@ export interface IncrementalFundingPlan {
 }
 
 export interface EvaluationPlan {
-  taskOrderTitle: string;
-  sourceSelection: SourceSelection;
-  method: EvalPlanMethod;
+  // EP requires non-null values, but EM doesn't always require an EP
+  taskOrderTitle: string | null;
+  sourceSelection: SourceSelection | null;
+  method: EvalPlanMethod | null;
   standardSpecifications: string[];
   customSpecifications: string[];
   standardDifferentiators: string[];

--- a/models/document-generation.ts
+++ b/models/document-generation.ts
@@ -703,9 +703,8 @@ const incrementalFundingPlan = {
 export const evalPlan = {
   type: "object",
   properties: {
-    taskOrderTitle: { type: "string" },
+    taskOrderTitle: { type: "string", nullable: true },
     sourceSelection: {
-      type: "string",
       enum: [
         SourceSelection.NO_TECH_PROPOSAL,
         SourceSelection.TECH_PROPOSAL,
@@ -715,8 +714,7 @@ export const evalPlan = {
       ],
     },
     method: {
-      type: "string",
-      enum: [EvalPlanMethod.BEST_USE, EvalPlanMethod.LOWEST_RISK, EvalPlanMethod.BVTO, EvalPlanMethod.LPTA, null],
+      enum: [EvalPlanMethod.BEST_USE, EvalPlanMethod.LOWEST_RISK, EvalPlanMethod.BVTO, EvalPlanMethod.LPTA, null,],
     },
     standardSpecifications: {
       type: "array",
@@ -751,7 +749,7 @@ export const evalMemo = {
   properties: {
     title: { type: "string" },
     estimatedValueFormatted: { type: "string" },
-    exceptionToFairOpportunity: { type: "string" },
+    exceptionToFairOpportunity: { type: "boolean" },
     proposedVendor: { type: "string" },
     ...evalPlan.properties,
   },


### PR DESCRIPTION
- adds additional sample payloads and unit tests for Eval Memo (EM) using the two most common variations - with and without exception to fair opportunity.
  - The replaced singular sample payload had a (what I now understand to be) nonsensical combination with `exceptionToFairOpportunity`=_YES_ and values for both `sourceSelection` and `method` which come from Eval Plan (EP)
- adds unit tests for generate-document lambda for EM using the two new sample payloads
- corrects schema models for EP and EM that we pass to [middy](https://middy.js.org/) for validation during docgen
  - this change allowed both of the new unit tests for the generate-document lambda to pass
  - I believe this effectively isolated the validation errors we've seen in DSP Dev environment
  - I witnessed similar oneOf validation errors with index 4 before correcting
  - The then-failing test agrees with behavior that @palaparthi-ccpo has documented during testing, only failed when `exceptionToFairOpportunity`=_YES_ and we won't expect to have an EP record, thus all of those inherited properties will be null or empty array.  The middy validation must be configured to allow this for successful docgen.

### Expanded unit tests for EM document
Prior sample data was at odds with business rules.  These two configurations are more representative of expected combinations.  Had to loosen type model for EP to pass the test (due to model inheritance).

![image](https://github.com/dod-ccpo/atat-web-api/assets/77642966/c8e6c1ca-4b42-40be-91be-ebabb213ddb6)

The two latter tests generate these files.  To my eye these files contain the desired generated content.

![image](https://github.com/dod-ccpo/atat-web-api/assets/77642966/a025fdd5-6574-4a13-a596-8acbc2d22d69)

[evalmemo-withException.docx](https://github.com/dod-ccpo/atat-web-api/files/11962589/evalmemo-withException.docx)
[evalmemo-withoutException.docx](https://github.com/dod-ccpo/atat-web-api/files/11962590/evalmemo-withoutException.docx)

### Added unit test for generate-document lambda
When first added, one of these tests passed, and the other failed (the w/ Exception to Fair Opportunity flavor).  I corrected errors in the schema models we pass to middy for validation during docgen.  Now both tests pass.

![image](https://github.com/dod-ccpo/atat-web-api/assets/77642966/d2a103af-bc6e-49ad-873f-b602cf82a4a4)

Ticket: AT-9120