### PR TITLE
adding cfn template for guardduty findings notifications - AT9526

### DIFF
--- a/cfn-templates/guardduty-cw-event-notification.yaml
+++ b/cfn-templates/guardduty-cw-event-notification.yaml
@@ -1,0 +1,61 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  Creates a EventBridge rule for GuardDuty to send an SNS notification with GuardDuty findings.
+
+Resources:
+  rEventRule:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: "Detect-GuardDuty-Finding"
+      Description: "A CloudWatch Event Rule that triggers on Amazon GuardDuty findings. The Event Rule can be used to trigger an SNS notification"
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Ref: "rSnsTopicEventRule"
+          Id: "target-sns1"
+      EventPattern:
+        detail-type:
+          - "GuardDuty Finding"
+        source:
+          - "aws.guardduty"
+  rSnsTopicEventRule:
+    Type: "AWS::SNS::Topic"
+    Properties:
+      Subscription:
+        - Endpoint: "disa.meade.hacc.list.hc2-atat-dev-notifications@mail.mil" #distro email used for dev environment
+          Protocol: "email"
+      TopicName: "GuardDuty-Event-Rule-Action"
+  rSnsTopicPolicyEventRule:
+    Type: "AWS::SNS::TopicPolicy"
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Sid: "GuardDuty-Event-Rule-Action-Topic"
+            Effect: "Allow"
+            Principal:
+              AWS: "*"
+            Action:
+              - "SNS:GetTopicAttributes"
+              - "SNS:SetTopicAttributes"
+              - "SNS:Subscribe"
+              - "SNS:ListSubscriptionsByTopic"
+              - "SNS:Publish"
+              - "SNS:Receive"
+            Resource:
+              Ref: "rSnsTopicEventRule"
+            Condition:
+              StringEquals:
+                AWS:SourceOwner:
+                  Ref: "AWS::AccountId"
+          - Sid: "TrustCWEToPublishEventsToTopic"
+            Effect: "Allow"
+            Principal:
+              Service: "events.amazonaws.com"
+            Action: "sns:Publish"
+            Resource:
+              Ref: "rSnsTopicEventRule"
+      Topics:
+        - Ref: "rSnsTopicEventRule"
+


### PR DESCRIPTION
cfn has been successfully deployed to the _dev_ transit account.